### PR TITLE
Fix (most) race conditions in TimeBucketInfo using sync.Once

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -224,8 +224,7 @@ func (d *Directory) PathToTimeBucketInfo(path string) (*io.TimeBucketInfo, error
 		if d.datafile != nil {
 			for _, dfile := range d.datafile {
 				if dfile.Path == path {
-					fi := *dfile
-					tbinfo = &fi
+					tbinfo = dfile.GetDeepCopy()
 					return
 				}
 			}

--- a/cmd/tools/integritycheck/integritycheck.go
+++ b/cmd/tools/integritycheck/integritycheck.go
@@ -264,8 +264,7 @@ func processChunk(myChunk int, offset int64, buffer []byte, fp *os.File, filenam
 
 func fixKnownHeaderProblems(buffer []byte, filePath string) {
 	header := (*io.Header)(unsafe.Pointer(&buffer[0]))
-	tbinfo := new(io.TimeBucketInfo)
-	tbinfo.Load(header, filePath)
+	tbinfo := io.NewTimeBucketInfoFromHeader(header, filePath)
 
 	/*
 		Check for OHLC with elementTypes = {1,1,1,1}

--- a/executor/scanner.go
+++ b/executor/scanner.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/alpacahq/marketstore/executor/readhint"
 	"github.com/alpacahq/marketstore/planner"
-	"github.com/alpacahq/marketstore/utils"
 	. "github.com/alpacahq/marketstore/utils/io"
 	. "github.com/alpacahq/marketstore/utils/log"
 )


### PR DESCRIPTION
The previous flag check wasn't safe for concurrency.  I tried
sync.Mutex, but didn't work due to the Go's memory model and ended up
with sync.Once solution.  There are still a few places where it updates
fields when reading it, which is not a very good idea anyway, but leave
it for now since they are minor use cases at the moment.