### PR TITLE
Catalog & writer concurrency fixes

### DIFF
--- a/SQLParser/insertintostatement.go
+++ b/SQLParser/insertintostatement.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/alpacahq/marketstore/executor"
-	"github.com/alpacahq/marketstore/planner"
 	"github.com/alpacahq/marketstore/utils/io"
 )
 
@@ -106,10 +105,11 @@ func (is *InsertIntoStatement) Materialize() (outputColumnSeries *io.ColumnSerie
 	tgc := executor.ThisInstance.TXNPipe
 	catDir := executor.ThisInstance.CatalogDir
 	wal := executor.ThisInstance.WALFile
-	q := planner.NewQuery(catDir)
-	q.AddTargetKey(targetMK)
-	parsed, _ := q.Parse()
-	writer, err := executor.NewWriter(parsed, tgc, catDir)
+	tbi, err := catDir.GetLatestTimeBucketInfoFromKey(targetMK)
+	if err != nil {
+		return nil, err
+	}
+	writer, err := executor.NewWriter(tbi, tgc, catDir)
 	if err != nil {
 		return nil, err
 	}

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -1,7 +1,6 @@
 package catalog
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -50,6 +49,8 @@ func (dRoot *Directory) AddTimeBucket(tbk *io.TimeBucketKey, f *io.TimeBucketInf
 		Adds a (possibly) new data item to a rootpath. Takes an existing catalog directory and
 		adds the new data item to that data directory.
 	*/
+	dRoot.Lock()
+	defer dRoot.Unlock()
 	exists := func(path string) bool {
 		_, err := os.Stat(path)
 		if err == nil {
@@ -125,7 +126,6 @@ func (dRoot *Directory) AddTimeBucket(tbk *io.TimeBucketKey, f *io.TimeBucketInf
 	childNodePath := filepath.Join(dRoot.GetPath(), childNodeName)
 	childDirectory := NewDirectory(childNodePath)
 	dRoot.addSubdir(childDirectory, childNodeName)
-
 	return nil
 }
 
@@ -304,9 +304,17 @@ func (d *Directory) GetName() string {
 }
 
 func (d *Directory) GetPath() string {
-	d.RLock()
-	defer d.RUnlock()
 	return d.pathToItemName
+}
+
+func (d *Directory) GetSubDirectoryAndAddFile(fullFilePath string, year int16) (*io.TimeBucketInfo, error) {
+	d.Lock()
+	defer d.Unlock()
+	dirPath := path.Dir(fullFilePath)
+	if dir, ok := d.directMap[dirPath]; ok {
+		return dir.AddFile(year)
+	}
+	return nil, fmt.Errorf("Directory path %s not found in catalog", fullFilePath)
 }
 
 func (d *Directory) GetOwningSubDirectory(fullFilePath string) (subDir *Directory, err error) {
@@ -316,9 +324,8 @@ func (d *Directory) GetOwningSubDirectory(fullFilePath string) (subDir *Director
 	defer d.RUnlock()
 	if dir, ok := d.directMap[dirPath]; ok {
 		return dir, nil
-	} else {
-		return nil, fmt.Errorf("Directory path %s not found in catalog", fullFilePath)
 	}
+	return nil, fmt.Errorf("Directory path %s not found in catalog", fullFilePath)
 }
 
 func (d *Directory) GetListOfSubDirs() (subDirList []*Directory) {
@@ -504,8 +511,6 @@ func (d *Directory) pathToKey(fullPath string) (key string) {
 }
 func (d *Directory) addSubdir(subDir *Directory, subDirItemName string) {
 	subDir.itemName = subDirItemName
-	d.Lock()
-	defer d.Unlock()
 	d.catList = nil // Reset the category list
 	if d.subDirs == nil {
 		d.subDirs = make(DMap)
@@ -541,46 +546,6 @@ func (d *Directory) recurse(elem interface{}, levelFunc LevelFunc) {
 			pd.recurse(elem, levelFunc)
 		}
 	}
-}
-
-func (d *Directory) cloneDir(fileInfoTemplate *io.TimeBucketInfo, destItemName string) (err error) {
-	/*
-		Takes a fileinfo pointer, and creates a clone of the directory, with a new dir name
-		and adds it to the catalog. All of the remaining attributes of the fileinfo are
-		retained, except for the relative top level name.
-	*/
-	// make directory
-	destDirPath := path.Join(d.pathToItemName, destItemName)
-	srcKey := d.pathToKey(fileInfoTemplate.Path)
-	srcDirPath := path.Join(d.pathToItemName, strings.Split(srcKey, "/")[0])
-
-	// check validity of clone
-	destParts := strings.Split(destDirPath, "/")
-	srcParts := strings.Split(srcDirPath, "/")
-	if len(destParts) != len(srcParts) {
-		errStr := fmt.Sprintf("Invalid clone operation. Depth source the target - Source: %v Target: %v", srcDirPath, destDirPath)
-		return errors.New(errStr)
-	}
-
-	err = io.CopyDir(srcDirPath, destDirPath)
-	if err != nil {
-		return fmt.Errorf(io.GetCallerFileContext(0) + err.Error())
-	}
-
-	// Create the new file
-	relFilePath, err := filepath.Rel(srcDirPath, fileInfoTemplate.Path)
-	if err != nil {
-		return err
-	}
-	relFilePathDir := filepath.Dir(filepath.Join(destDirPath, relFilePath))
-	newFileInfo := fileInfoTemplate.GetDeepCopy()
-	newFileInfo.Path = path.Join(relFilePathDir, strconv.Itoa(int(newFileInfo.Year))+".bin")
-	if err = newTimeBucketInfoFromTemplate(newFileInfo); err != nil {
-		return err
-	}
-	newDir := NewDirectory(destDirPath)
-	d.addSubdir(newDir, destItemName)
-	return nil
 }
 
 func (d *Directory) load(rootPath string) error {

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -129,33 +129,6 @@ func (s *TestSuite) TestAddFile(c *C) {
 	// fmt.Println("New Latest Year:", latestFile.Year, latestFile.Path)
 }
 
-func (s *TestSuite) TestCloneDir(c *C) {
-	d := NewDirectory(s.Rootdir)
-	tf := utils.TimeframeFromString("1Min")
-	fp := path.Join(s.Rootdir, "EURUSD", "1Min", "OHLC")
-	dsv := io.NewDataShapeVector(
-		[]string{"Open", "High", "Low", "Close"},
-		[]io.EnumElementType{io.FLOAT32, io.FLOAT32, io.FLOAT32, io.FLOAT32},
-	)
-	tbinfo := io.NewTimeBucketInfo(*tf, fp, "Fake fileinfo", int16(2016), dsv, io.FIXED)
-	// Add a new item "GBPUSD" to the top level of the directory
-	err := d.cloneDir(tbinfo, "GBPUSD")
-	c.Assert(err, Equals, nil)
-	catList := d.GatherCategoriesAndItems()
-	// Construct the known new path to this subdirectory so that we can verify it is in the catalog
-
-	oldFilePath := path.Join(s.Rootdir, "EURUSD", "1Min", "OHLC", "2000.bin")
-	_, err = d.GetOwningSubDirectory(oldFilePath)
-	c.Assert(err == nil, Equals, true)
-
-	newFilePath := path.Join(s.Rootdir, "GBPUSD", "1Min", "OHLC", "2000.bin")
-	_, err = d.GetOwningSubDirectory(newFilePath)
-	c.Assert(err == nil, Equals, true)
-
-	_, ok := catList["Symbol"]["GBPUSD"]
-	c.Assert(ok, Equals, true)
-}
-
 func (s *TestSuite) TestAddAndRemoveDataItem(c *C) {
 	d := NewDirectory(s.Rootdir)
 	catKey := "Symbol/Timeframe/AttributeGroup"

--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -136,13 +136,10 @@ func createTickBucket(symbol string) {
 	/*
 		Write some data
 	*/
-	q := planner.NewQuery(dd)
-	q.AddRestriction("Symbol", "TEST")
-	q.AddRestriction("AttributeGroup", "TICK")
-	q.AddRestriction("Timeframe", "1Min")
-	q.SetStart(time.Date(2016, time.November, 1, 12, 0, 0, 0, time.UTC))
-	parsed, _ := q.Parse()
-	writer, _ := executor.NewWriter(parsed, tgc, dd)
+	w, err := executor.NewWriter(tbinfo, tgc, dd)
+	if err != nil {
+		panic(err)
+	}
 	row := struct {
 		Epoch    int64
 		Bid, Ask float32
@@ -152,7 +149,7 @@ func createTickBucket(symbol string) {
 		ts = ts.Add(time.Second)
 		row.Epoch = ts.Unix()
 		buffer, _ := io.Serialize([]byte{}, row)
-		writer.WriteRecords([]time.Time{ts}, buffer)
+		w.WriteRecords([]time.Time{ts}, buffer)
 	}
 	wf.RequestFlush()
 }

--- a/contrib/ondiskagg/aggtrigger/aggtrigger.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger.go
@@ -186,9 +186,14 @@ func (s *OnDiskAggTrigger) processFor(timeframe, keyPath string, headIndex, tail
 	outCs := aggregate(cs, targetTbk)
 	outCsm := io.NewColumnSeriesMap()
 	outCsm.AddColumnSeries(*targetTbk, outCs)
-
+	epoch := outCs.GetEpoch()
 	if err := executor.WriteCSM(outCsm, false); err != nil {
-		glog.Errorf("failed to write CSM: %v", err)
+		glog.Errorf(
+			"failed to write %v CSM from: %v to %v - Error: %v",
+			targetTbk.String(),
+			time.Unix(epoch[0], 0),
+			time.Unix(epoch[len(epoch)-1], 0),
+			err)
 	}
 }
 

--- a/executor/writer.go
+++ b/executor/writer.go
@@ -4,29 +4,22 @@ import (
 	"fmt"
 	stdio "io"
 	"os"
-	"sort"
+	"strings"
 	"time"
 
 	"github.com/alpacahq/marketstore/catalog"
-	"github.com/alpacahq/marketstore/planner"
 	"github.com/alpacahq/marketstore/utils/io"
 	. "github.com/alpacahq/marketstore/utils/io"
 	"github.com/golang/glog"
 )
 
 type Writer struct {
-	pr             planner.ParseResult
-	iop            *ioplan
-	BaseDirectory  *catalog.Directory
-	tgc            *TransactionPipe
-	FileInfoByYear map[int16]*TimeBucketInfo // One-one relationship for a writer between year and target file
-	KeyPathByYear  map[int16]string          // This key includes the year filename
+	root *catalog.Directory
+	tgc  *TransactionPipe
+	tbi  *io.TimeBucketInfo
 }
 
-func NewWriter(pr *planner.ParseResult, tgc *TransactionPipe, rootCatDir *catalog.Directory) (w *Writer, err error) {
-	if pr.IntervalsPerDay == 0 {
-		return nil, fmt.Errorf("No query results, cannot create writer")
-	}
+func NewWriter(tbi *io.TimeBucketInfo, tgc *TransactionPipe, rootCatDir *catalog.Directory) (*Writer, error) {
 	/*
 		A writer is produced that complies with the parsed query results, including a possible date
 		range restriction.  If there is a date range restriction, the write() routine should produce
@@ -34,54 +27,30 @@ func NewWriter(pr *planner.ParseResult, tgc *TransactionPipe, rootCatDir *catalo
 	*/
 	// Check to ensure there is a valid WALFile for this instance before writing
 	if ThisInstance.WALFile == nil {
-		err = fmt.Errorf("There is not an active WALFile for this instance, so cannot write.")
+		err := fmt.Errorf("there is not an active WALFile for this instance, so cannot write")
 		glog.Errorf("NewWriter: %v", err)
 		return nil, err
 	}
-	w = new(Writer)
-	SortedFiles := SortedFileList(pr.QualifiedFiles)
-	sort.Sort(SortedFiles)
-	w.pr = *pr
-	if pr.Range == nil {
-		pr.Range = planner.NewDateRange()
-	}
-	secondsPerInterval := 3600 * 24 / pr.IntervalsPerDay
-	if w.iop, err = NewIOPlan(SortedFiles, pr, secondsPerInterval); err != nil {
-		return nil, err
-	}
-
-	// Process the ioplan to determine if it has a single base directory target, required for a writer
-	baseDirectories := make(map[string]int, 0)
-	w.FileInfoByYear = make(map[int16]*TimeBucketInfo, 0)
-	w.KeyPathByYear = make(map[int16]string, 0)
-	for _, fp := range w.iop.FilePlan {
-		if w.BaseDirectory == nil {
-			if w.BaseDirectory, err = rootCatDir.GetOwningSubDirectory(fp.FullPath); err != nil {
-				glog.Errorf("NewWriter: %v", err)
-				return nil, err
-			}
-		}
-		baseDirectories[w.BaseDirectory.GetPath()] = 0
-		year := fp.GetFileYear()
-		if w.FileInfoByYear[year], err = w.BaseDirectory.PathToTimeBucketInfo(fp.FullPath); err != nil {
-			glog.Errorf("NewWriter: %v", err)
-			return nil, err
-		}
-		w.KeyPathByYear[year] = ThisInstance.WALFile.FullPathToWALKey(w.FileInfoByYear[year].Path)
-	}
-	if len(baseDirectories) != 1 {
-		return nil, SingleTargetRequiredForWriter("NewWriter")
-	}
-	w.tgc = tgc // TransactionPipe, will be used to implement all writes
-
-	return w, nil
+	return &Writer{
+		root: rootCatDir,
+		tgc:  tgc,
+		tbi:  tbi,
+	}, nil
 }
+
 func (w *Writer) AddNewYearFile(year int16) (err error) {
-	w.FileInfoByYear[year], err = w.BaseDirectory.AddFile(year)
+	dir, err := w.root.GetOwningSubDirectory(w.tbi.Path)
 	if err != nil {
 		return err
 	}
-	w.KeyPathByYear[year] = ThisInstance.WALFile.FullPathToWALKey(w.FileInfoByYear[year].Path)
+	newTbi, err := dir.AddFile(year)
+	if err != nil {
+		return err
+	}
+	w.tbi = newTbi
+
+	// w.FileInfoByYear[fInfo.Year] = fInfo
+	// w.KeyPathByYear[year] = ThisInstance.WALFile.FullPathToWALKey(w.FileInfoByYear[year].Path)
 	return nil
 }
 
@@ -100,16 +69,15 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte) {
 			Incoming data records ALWAYS have the 8-byte Epoch column first
 		*/
 		record = record[8:] // Chop off the Epoch column
-		if w.iop.RecordType == VARIABLE {
+		if w.tbi.GetRecordType() == VARIABLE {
 			/*
 				Trim the Epoch column off and replace it with ticks since bucket time
 			*/
 			outBuf = append(buf, record...)
 			outBuf = AppendIntervalTicks(outBuf, t, index, intervalsPerDay)
 			return outBuf
-		} else {
-			return record
 		}
+		return record
 	}
 
 	for i := 0; i < numRows; i++ {
@@ -117,18 +85,20 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte) {
 		record := data[pos : pos+rowLen]
 		t := ts[i]
 		year := int16(t.Year())
-		if _, ok := w.FileInfoByYear[year]; !ok {
-			w.AddNewYearFile(year)
+		if year != w.tbi.Year {
+			if err := w.AddNewYearFile(year); err != nil {
+				panic(err)
+			}
 		}
-		intervalsPerDay := w.FileInfoByYear[year].GetIntervals()
-		offset := TimeToOffset(t, intervalsPerDay, w.FileInfoByYear[year].GetRecordLength())
+		intervalsPerDay := w.tbi.GetIntervals()
+		offset := TimeToOffset(t, intervalsPerDay, w.tbi.GetRecordLength())
 		index := TimeToIndex(t, intervalsPerDay)
 
 		if i == 0 {
 			prevIndex = index
 			cc = &WriteCommand{
-				RecordType: w.iop.RecordType,
-				WALKeyPath: w.KeyPathByYear[year],
+				RecordType: w.tbi.GetRecordType(),
+				WALKeyPath: ThisInstance.WALFile.FullPathToWALKey(w.tbi.Path),
 				Offset:     offset,
 				Index:      index,
 				Data:       nil}
@@ -149,8 +119,8 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte) {
 			prevIndex = index
 			outBuf = formatRecord([]byte{}, record, t, index, intervalsPerDay)
 			cc = &WriteCommand{
-				RecordType: w.iop.RecordType,
-				WALKeyPath: w.KeyPathByYear[year],
+				RecordType: w.tbi.GetRecordType(),
+				WALKeyPath: ThisInstance.WALFile.FullPathToWALKey(w.tbi.Path),
 				Offset:     offset,
 				Index:      index,
 				Data:       outBuf}
@@ -276,10 +246,9 @@ func WriteCSM(csm io.ColumnSeriesMap, isVariableLength bool) (err error) {
 			/*
 				Verify there is an available TimeBucket for the destination
 			*/
-			err = cDir.AddTimeBucket(&tbk, tbi)
-			if err != nil {
+			if err := cDir.AddTimeBucket(&tbk, tbi); err != nil {
 				// If File Exists error, ignore it, otherwise return the error
-				if _, ok := err.(catalog.FileAlreadyExists); !ok {
+				if !strings.Contains(err.Error(), "Can not overwrite file") && !strings.Contains(err.Error(), "file exists") {
 					return err
 				}
 			}
@@ -288,20 +257,14 @@ func WriteCSM(csm io.ColumnSeriesMap, isVariableLength bool) (err error) {
 		/*
 			Create a writer for this TimeBucket
 		*/
-		q := planner.NewQuery(cDir)
-		q.AddTargetKey(&tbk)
-		pr, err := q.Parse()
-		if err != nil {
-			return err
-		}
-		wr, err := NewWriter(pr, ThisInstance.TXNPipe, cDir)
+		w, err := NewWriter(tbi, ThisInstance.TXNPipe, cDir)
 		if err != nil {
 			return err
 		}
 		rs := cs.ToRowSeries(tbk)
 		rowdata := rs.GetData()
 		times := rs.GetTime()
-		wr.WriteRecords(times, rowdata)
+		w.WriteRecords(times, rowdata)
 	}
 	wal := ThisInstance.WALFile
 	wal.RequestFlush()

--- a/executor/writer.go
+++ b/executor/writer.go
@@ -39,6 +39,8 @@ func NewWriter(tbi *io.TimeBucketInfo, tgc *TransactionPipe, rootCatDir *catalog
 }
 
 func (w *Writer) AddNewYearFile(year int16) (err error) {
+	w.root.RLock()
+	defer w.root.RUnlock()
 	dir, err := w.root.GetOwningSubDirectory(w.tbi.Path)
 	if err != nil {
 		return err

--- a/executor/writer.go
+++ b/executor/writer.go
@@ -39,20 +39,11 @@ func NewWriter(tbi *io.TimeBucketInfo, tgc *TransactionPipe, rootCatDir *catalog
 }
 
 func (w *Writer) AddNewYearFile(year int16) (err error) {
-	w.root.RLock()
-	defer w.root.RUnlock()
-	dir, err := w.root.GetOwningSubDirectory(w.tbi.Path)
-	if err != nil {
-		return err
-	}
-	newTbi, err := dir.AddFile(year)
+	newTbi, err := w.root.GetSubDirectoryAndAddFile(w.tbi.Path, year)
 	if err != nil {
 		return err
 	}
 	w.tbi = newTbi
-
-	// w.FileInfoByYear[fInfo.Year] = fInfo
-	// w.KeyPathByYear[year] = ThisInstance.WALFile.FullPathToWALKey(w.FileInfoByYear[year].Path)
 	return nil
 }
 

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -236,7 +236,7 @@ func (q *query) Parse() (pr *ParseResult, err error) {
 	// Check to see that the categories in the query are present in the DB directory
 	CatList := q.DataDir.GatherCategoriesFromCache()
 	for key := range q.Restriction.GetRestrictionMap() {
-		if _, ok := CatList[key]; !ok {
+		if _, ok := CatList.Load(key); !ok {
 			return nil, errors.New(fmt.Sprintf("Category: %s not in catalog\n", key))
 		}
 	}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -236,7 +236,7 @@ func (q *query) Parse() (pr *ParseResult, err error) {
 	// Check to see that the categories in the query are present in the DB directory
 	CatList := q.DataDir.GatherCategoriesFromCache()
 	for key := range q.Restriction.GetRestrictionMap() {
-		if _, ok := CatList.Load(key); !ok {
+		if _, ok := CatList[key]; !ok {
 			return nil, errors.New(fmt.Sprintf("Category: %s not in catalog\n", key))
 		}
 	}


### PR DESCRIPTION
NewWriter now only requires a TimeBucketInfo to write to disk. This, along with the concurrency refactor of the catalog have resolved the write concurrency issue exposed by the combination of batch writes during backfill and the on-disk aggregation plugin.