### PR TITLE
WrittenIndexes channel

### DIFF
--- a/cmd/marketstore/marketstore.go
+++ b/cmd/marketstore/marketstore.go
@@ -79,6 +79,7 @@ func main() {
 func shutdown() {
 	executor.ThisInstance.ShutdownPending = true
 	executor.ThisInstance.WALWg.Wait()
+	executor.FinishAndWait()
 	Log(INFO, "Exiting...")
 	os.Exit(0)
 }

--- a/executor/writtenIndexes.go
+++ b/executor/writtenIndexes.go
@@ -2,44 +2,71 @@ package executor
 
 import (
 	"runtime/debug"
+	"sync"
 
 	"github.com/golang/glog"
+
+	"github.com/alpacahq/marketstore/plugins/trigger"
 )
 
-// WrittenIndexes collects row indexes of files being modified
-// for triggers to act on changes.
-type WrittenIndexes struct {
-	// key of the map is string relative path of the modified file
-	indexesMap map[string][]int64
+var once sync.Once
+var c chan writtenIndexes
+var done chan struct{}
+var m map[string][]int64
+
+type writtenIndexes struct {
+	key     string
+	indexes []int64
 }
 
-// NewWrittenIndexes creates a new WrittenIndexes.
-func NewWrittenIndexes() *WrittenIndexes {
-	return &WrittenIndexes{
-		indexesMap: map[string][]int64{},
+func setup() {
+	c = make(chan writtenIndexes, WriteChannelCommandDepth)
+	done = make(chan struct{})
+	go run()
+}
+
+// AddWrittenIndex collects the index value from the serialized buffer.
+func addWrittenIndex(keyPath string, index int64) {
+	once.Do(setup)
+	if m == nil {
+		m = make(map[string][]int64)
+	}
+	m[keyPath] = append(m[keyPath], index)
+}
+
+// DispatchWrittenIndexes iterates over the registered triggers and fire the event
+// if the file path matches the condition.  This is meant to be
+// run in a separate goroutine and recovers from panics in the triggers.
+func dispatchWrittenIndexes() {
+	for key, indexes := range m {
+		c <- writtenIndexes{key: key, indexes: indexes}
+	}
+	m = nil // for GC
+}
+
+func run() {
+	defer func() { done <- struct{}{} }()
+	for wi := range c {
+		for _, tmatcher := range ThisInstance.TriggerMatchers {
+			if tmatcher.Match(wi.key) {
+				fire(tmatcher.Trigger, wi.key, wi.indexes)
+			}
+		}
 	}
 }
 
-// Add collects the index value from the serialized buffer.
-func (wo *WrittenIndexes) Add(keyPath string, buffer offsetIndexBuffer) {
-	index := buffer.Index()
-	wo.indexesMap[keyPath] = append(wo.indexesMap[keyPath], index)
-}
-
-// Dispatch iterates over the registered triggers and fire the event
-// if the file path matches the condition.  This is meant to be
-// run in a separate goroutine and recovers from panics in the triggers.
-func (wo *WrittenIndexes) Dispatch() {
+func fire(trig trigger.Trigger, key string, indexes []int64) {
 	defer func() {
 		if r := recover(); r != nil {
 			glog.Errorf("recovering from %v\n%s", r, string(debug.Stack()))
 		}
 	}()
-	for keyPath, indexes := range wo.indexesMap {
-		for _, tmatcher := range ThisInstance.TriggerMatchers {
-			if tmatcher.Match(keyPath) {
-				tmatcher.Trigger.Fire(keyPath, indexes)
-			}
-		}
-	}
+	trig.Fire(key, indexes)
+}
+
+// FinishAndWait closes the writtenIndexes channel, and waits
+// for the remaining triggers to fire, returning
+func FinishAndWait() {
+	close(c)
+	<-done
 }


### PR DESCRIPTION
To avoid losing trigger writes on system exit, we will buffer them to a channel, and flush them before exiting.