### PR TITLE
Optimize serialization for writes

### DIFF
--- a/utils/io/serializer.go
+++ b/utils/io/serializer.go
@@ -10,6 +10,12 @@ func Serialize(buffer []byte, datum interface{}) ([]byte, error) {
 	if buffer == nil {
 		buffer = make([]byte, 0)
 	}
+	// skip reflection & recurision if it's a byte slice
+	if b, ok := datum.([]byte); ok {
+		return append(buffer, b...), nil
+	}
+
+	// use reflection
 	value := ValueOf(datum)
 	var err error
 	switch value.Kind() {


### PR DESCRIPTION
Since all writes are converted to []byte before being serialized, simply appending the byte slice to the buffer rather than recursing should improve things.