### PR TITLE
Slait plugin, alignment & WAL flush fixes

### DIFF
--- a/executor/cache.go
+++ b/executor/cache.go
@@ -21,29 +21,32 @@ type WriteCommand struct {
 	Data          []byte
 }
 
-/*
-	TransactionPipe stores the contents of the current pending Transaction Group and writes it to WAL when flush() is called
-*/
+// TransactionPipe stores the contents of the current pending Transaction Group
+// and writes it to WAL when flush() is called
 type TransactionPipe struct {
 	tgID         int64              // Current transaction group ID
 	writeChannel chan *WriteCommand // Channel for write commands
-	flushChannel chan interface{}   // Channel for flush request
+	flushChannel chan chan struct{} // Channel for flush request
 }
 
+// NewTransactionPipe creates a new transaction pipe that channels all
+// of the write transactions to the WAL and primary writers
 func NewTransactionPipe() *TransactionPipe {
 	tgc := new(TransactionPipe)
 	// Allocate the write channel with enough depth to allow all conceivable writers concurrent access
 	tgc.writeChannel = make(chan *WriteCommand, WriteChannelCommandDepth)
-	tgc.flushChannel = make(chan interface{}, WriteChannelCommandDepth)
+	tgc.flushChannel = make(chan chan struct{}, WriteChannelCommandDepth)
 	tgc.NewTGID()
 	return tgc
 }
 
+// NewTGID monotonically increases the transaction group ID using
+// the current unix epoch nanosecond timestamp
 func (tgc *TransactionPipe) NewTGID() int64 {
-	// TODO: use atomic.Add() to guarantee monotonically-increasing behavior
-	return atomic.SwapInt64(&tgc.tgID, time.Now().UTC().UnixNano())
+	return atomic.AddInt64(&tgc.tgID, time.Now().UTC().UnixNano()-tgc.tgID)
 }
 
+// TGID returns the latest transaction group ID
 func (tgc *TransactionPipe) TGID() int64 {
 	return atomic.LoadInt64(&tgc.tgID)
 }

--- a/utils/io/columnseries.go
+++ b/utils/io/columnseries.go
@@ -219,7 +219,7 @@ func (cs *ColumnSeries) GetEpoch() []int64 {
 }
 func (cs *ColumnSeries) ToRowSeries(itemKey TimeBucketKey) (rs *RowSeries) {
 	dsv := cs.GetDataShapes()
-	data, recordLen := SerializeColumnsToRows(cs, dsv, false)
+	data, recordLen := SerializeColumnsToRows(cs, dsv, true)
 	rs = NewRowSeries(itemKey, 0, data, dsv, recordLen, cs.GetCandleAttributes(), NOTYPE)
 	return rs
 }
@@ -260,7 +260,7 @@ func (csm ColumnSeriesMap) ToRowSeriesMap(dataShapesMap map[TimeBucketKey][]Data
 	rsMap = make(map[TimeBucketKey]*RowSeries)
 	for key, columns := range csm {
 		dataShapes := dataShapesMap[key]
-		data, recordLen := SerializeColumnsToRows(columns, dataShapes, false)
+		data, recordLen := SerializeColumnsToRows(columns, dataShapes, true)
 		rsMap[key] = NewRowSeries(key, 0, data, dataShapes, recordLen, columns.GetCandleAttributes(), NOTYPE)
 	}
 	return rsMap


### PR DESCRIPTION
Batching was added to the Slait plugin because writes were too slow. Writes have since been optimized ~20x in https://github.com/alpacahq/marketstore/pull/52, so the batching was adding unnecessary complexity, and was preventing single writes from immediately being written to the DB. It has now been removed.

RequestFlush was also unnecessarily blocking in WriteCSM. The function will now not block if a flush is already queued in the TransactionGroupCache, since it is already going to flash as soon as possible.

On-disk data was also not being properly aligned to 64-bit. This has also been fixed.