### PR TITLE
trigger refactor & aggtrigger optimization

### DIFF
--- a/contrib/ondiskagg/aggtrigger/aggtrigger.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger.go
@@ -25,9 +25,10 @@ package aggtrigger
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alpacahq/marketstore/contrib/calendar"
@@ -49,14 +50,13 @@ type AggTriggerConfig struct {
 // OnDiskAggTrigger is the main trigger.
 type OnDiskAggTrigger struct {
 	config       map[string]interface{}
-	destinations []string
+	destinations timeframes
 	// filter by market hours if this is "nasdaq"
-	filter string
+	filter   string
+	aggCache *sync.Map
 }
 
 var _ trigger.Trigger = &OnDiskAggTrigger{}
-
-var loadError = errors.New("plugin load error")
 
 func recast(config map[string]interface{}) *AggTriggerConfig {
 	data, _ := json.Marshal(config)
@@ -68,132 +68,153 @@ func recast(config map[string]interface{}) *AggTriggerConfig {
 // NewTrigger returns a new on-disk aggregate trigger based on the configuration.
 func NewTrigger(conf map[string]interface{}) (trigger.Trigger, error) {
 	config := recast(conf)
+
 	if len(config.Destinations) == 0 {
 		glog.Errorf("no destinations are configured")
-		return nil, loadError
+		return nil, fmt.Errorf("plugin load error")
 	}
 
 	glog.Infof("%d destination(s) configured", len(config.Destinations))
+
 	filter := config.Filter
 	if filter != "" && filter != "nasdaq" {
-		glog.Infof("filter value \"%s\" is not recognized", filter)
+		glog.Warningf("filter value \"%s\" is not recognized", filter)
 		filter = ""
 	}
+
+	var tfs timeframes
+
+	for _, dest := range config.Destinations {
+		tf := utils.TimeframeFromString(dest)
+		if tf == nil {
+			glog.Fatalf("invalid destination: %s", dest)
+		}
+		tfs = append(tfs, *tf)
+	}
+
 	return &OnDiskAggTrigger{
 		config:       conf,
-		destinations: config.Destinations,
+		destinations: tfs,
 		filter:       filter,
+		aggCache:     &sync.Map{},
 	}, nil
 }
 
-func minInt64(values []int64) int64 {
-	min := values[0]
-	for _, v := range values[1:] {
-		if v < min {
-			min = v
-		}
-	}
-	return min
-}
-
-func maxInt64(values []int64) int64 {
-	max := values[0]
-	for _, v := range values[1:] {
-		if v > max {
-			max = v
-		}
-	}
-	return max
-}
-
 // Fire implements trigger interface.
-func (s *OnDiskAggTrigger) Fire(keyPath string, indexes []int64) {
-	headIndex := minInt64(indexes)
-	tailIndex := maxInt64(indexes)
-
-	for _, timeframe := range s.destinations {
-		s.processFor(timeframe, keyPath, headIndex, tailIndex)
-	}
-}
-
-func (s *OnDiskAggTrigger) processFor(timeframe, keyPath string, headIndex, tailIndex int64) {
-	theInstance := executor.ThisInstance
-	catalogDir := theInstance.CatalogDir
+func (s *OnDiskAggTrigger) Fire(keyPath string, records []trigger.Record) {
 	elements := strings.Split(keyPath, "/")
-	tbkString := strings.Join(elements[:len(elements)-1], "/")
 	tf := utils.NewTimeframe(elements[1])
 	fileName := elements[len(elements)-1]
 	year, _ := strconv.Atoi(strings.Replace(fileName, ".bin", "", 1))
-	tbk := io.NewTimeBucketKey(tbkString)
-	headTs := io.IndexToTime(headIndex, tf.Duration, int16(year))
-	tailTs := io.IndexToTime(tailIndex, tf.Duration, int16(year))
-	timeWindow := utils.CandleDurationFromString(timeframe)
-	start := timeWindow.Truncate(headTs)
-	end := timeWindow.Ceil(tailTs)
-	// TODO: this is not needed once we support "<" operator
-	end = end.Add(-time.Second)
+	tbk := io.NewTimeBucketKey(strings.Join(elements[:len(elements)-1], "/"))
 
-	targetTbkString := elements[0] + "/" + timeframe + "/" + elements[2]
-	targetTbk := io.NewTimeBucketKey(targetTbkString)
+	head := io.IndexToTime(
+		records[0].Index(),
+		tf.Duration,
+		int16(year))
 
-	// Scan
-	q := planner.NewQuery(catalogDir)
-	q.AddTargetKey(tbk)
-	q.SetRange(start.Unix(), end.Unix())
+	tail := io.IndexToTime(
+		records[len(records)-1].Index(),
+		tf.Duration,
+		int16(year))
 
-	// decide whether to apply market-hour filter
-	applyingFilter := false
-	if s.filter == "nasdaq" && timeWindow.Duration() >= utils.Day {
-		calendarTz := calendar.Nasdaq.Tz()
-		if utils.InstanceConfig.Timezone.String() != calendarTz.String() {
-			glog.Errorf("misconfiguration... system must be configure in %s", calendarTz)
-		} else {
-			q.AddTimeQual(calendar.Nasdaq.EpochIsMarketOpen)
-			applyingFilter = true
+	// query the upper bound since it will contain the most candles
+	window := utils.CandleDurationFromString(s.destinations.UpperBound().String)
+
+	// check if we have a valid cache, if not, re-query
+	if v, ok := s.aggCache.Load(tbk.String()); ok {
+		c := v.(*cachedAgg)
+
+		if !c.Valid(tail, head) {
+			s.aggCache.Delete(tbk.String())
+
+			goto Query
 		}
-	}
-	parsed, err := q.Parse()
-	if err != nil {
-		glog.Errorf("%v", err)
+
+		cs := trigger.RecordsToColumnSeries(
+			*tbk, c.cs.GetDataShapes(),
+			c.cs.GetCandleAttributes(),
+			tf.Duration, int16(year), records)
+
+		cs = io.ColumnSeriesUnion(cs, &c.cs)
+
+		s.write(tbk, cs, tail, head, elements)
+
 		return
 	}
-	scanner, err := executor.NewReader(parsed)
+
+Query:
+	csm, err := s.query(tbk, window, head, tail)
 	if err != nil {
-		glog.Errorf("%v", err)
+		glog.Errorf("query error for %v (%v)", tbk.String(), err)
 		return
 	}
-	csm, _, err := scanner.Read()
-	if err != nil {
-		glog.Errorf("%v", err)
-		return
-	}
-	cs := csm[*tbk]
-	if cs == nil || cs.Len() == 0 {
-		if !applyingFilter {
-			// Nothing in there... really?
+
+	cs := (*csm)[*tbk]
+
+	s.write(tbk, cs, tail, head, elements)
+	return
+}
+
+func (s *OnDiskAggTrigger) write(
+	tbk *io.TimeBucketKey,
+	cs *io.ColumnSeries,
+	tail, head time.Time,
+	elements []string) {
+
+	for _, dest := range s.destinations {
+		aggTbk := io.NewTimeBucketKeyFromString(elements[0] + "/" + dest.String + "/" + elements[2])
+
+		if err := s.writeAggregates(aggTbk, tbk, *cs, dest, head, tail); err != nil {
 			glog.Errorf(
-				"result is empty for %s -> %s - query: %v - %v",
-				tbk,
-				targetTbk,
-				q.Range.Start,
-				q.Range.End,
-			)
+				"failed to write %v aggregates (%v)",
+				tbk.String(),
+				err)
+			return
 		}
-		return
 	}
-	// calculate aggregated values
-	outCs := aggregate(cs, targetTbk)
-	outCsm := io.NewColumnSeriesMap()
-	outCsm.AddColumnSeries(*targetTbk, outCs)
-	epoch := outCs.GetEpoch()
-	if err := executor.WriteCSM(outCsm, false); err != nil {
-		glog.Errorf(
-			"failed to write %v CSM from: %v to %v - Error: %v",
-			targetTbk.String(),
-			time.Unix(epoch[0], 0),
-			time.Unix(epoch[len(epoch)-1], 0),
-			err)
+}
+
+type cachedAgg struct {
+	cs         io.ColumnSeries
+	tail, head time.Time
+}
+
+func (c *cachedAgg) Valid(tail, head time.Time) bool {
+	return tail.Equal(tail) && head.Equal(head)
+}
+
+func (s *OnDiskAggTrigger) writeAggregates(
+	aggTbk, baseTbk *io.TimeBucketKey,
+	cs io.ColumnSeries,
+	dest utils.Timeframe,
+	head, tail time.Time) error {
+
+	csm := io.NewColumnSeriesMap()
+
+	window := utils.CandleDurationFromString(dest.String)
+	start := window.Truncate(head).Unix()
+	end := window.Ceil(tail).Add(-time.Second).Unix()
+
+	slc, err := io.SliceColumnSeriesByEpoch(cs, &start, &end)
+	if err != nil {
+		return err
 	}
+
+	// store when writing for upper bound
+	if dest.Duration == s.destinations.UpperBound().Duration {
+		defer func() {
+			s.aggCache.Store(baseTbk.String(), &cachedAgg{
+				cs:   slc,
+				tail: time.Unix(start, 0),
+				head: time.Unix(end, 0),
+			})
+		}()
+	}
+
+	csm.AddColumnSeries(*aggTbk, aggregate(&slc, aggTbk))
+
+	return executor.WriteCSM(csm, false)
 }
 
 func aggregate(cs *io.ColumnSeries, tbk *io.TimeBucketKey) *io.ColumnSeries {
@@ -235,4 +256,65 @@ func aggregate(cs *io.ColumnSeries, tbk *io.TimeBucketKey) *io.ColumnSeries {
 	outCs.AddColumn("Epoch", outEpoch)
 	accumGroup.addColumns(outCs)
 	return outCs
+}
+
+func (s *OnDiskAggTrigger) query(
+	tbk *io.TimeBucketKey,
+	window *utils.CandleDuration,
+	head, tail time.Time) (*io.ColumnSeriesMap, error) {
+
+	cDir := executor.ThisInstance.CatalogDir
+
+	start := window.Truncate(head)
+
+	// TODO: adding 1 second is not needed once we support "<" operator
+	end := window.Ceil(tail).Add(-time.Second)
+
+	// Scan
+	q := planner.NewQuery(cDir)
+	q.AddTargetKey(tbk)
+	q.SetRange(start.Unix(), end.Unix())
+
+	// decide whether to apply market-hour filter
+	applyingFilter := false
+	if s.filter == "nasdaq" && window.Duration() >= utils.Day {
+		calendarTz := calendar.Nasdaq.Tz()
+		if utils.InstanceConfig.Timezone.String() != calendarTz.String() {
+			glog.Errorf("misconfiguration... system must be configure in %s", calendarTz)
+		} else {
+			q.AddTimeQual(calendar.Nasdaq.EpochIsMarketOpen)
+			applyingFilter = true
+		}
+	}
+
+	parsed, err := q.Parse()
+	if err != nil {
+		return nil, err
+	}
+
+	scanner, err := executor.NewReader(parsed)
+	if err != nil {
+		return nil, err
+	}
+
+	csm, _, err := scanner.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	cs := csm[*tbk]
+	if cs == nil || cs.Len() == 0 {
+		if !applyingFilter {
+			// Nothing in there... really?
+			glog.Errorf(
+				"result is empty for %s - query: %v - %v",
+				tbk,
+				q.Range.Start,
+				q.Range.End,
+			)
+		}
+		return nil, err
+	}
+
+	return &csm, nil
 }

--- a/contrib/ondiskagg/aggtrigger/util.go
+++ b/contrib/ondiskagg/aggtrigger/util.go
@@ -1,0 +1,45 @@
+package aggtrigger
+
+import (
+	"github.com/alpacahq/marketstore/utils"
+)
+
+type timeframes []utils.Timeframe
+
+func (tfs *timeframes) UpperBound() (tf *utils.Timeframe) {
+	if tfs == nil {
+		return nil
+	}
+
+	for _, t := range *tfs {
+		if tf == nil {
+			tf = &t
+			continue
+		}
+
+		if t.Duration > tf.Duration {
+			tf = &t
+		}
+	}
+
+	return
+}
+
+func (tfs *timeframes) LowerBound() (tf *utils.Timeframe) {
+	if tfs == nil {
+		return nil
+	}
+
+	for _, t := range *tfs {
+		if tf == nil {
+			tf = &t
+			continue
+		}
+
+		if t.Duration < tf.Duration {
+			tf = &t
+		}
+	}
+
+	return
+}

--- a/contrib/stream/streamtrigger/streamtrigger.go
+++ b/contrib/stream/streamtrigger/streamtrigger.go
@@ -67,7 +67,12 @@ func maxInt64(values []int64) int64 {
 
 // Fire is the hook to retrieve the latest written data
 // and stream it over the websocket
-func (s *StreamTrigger) Fire(keyPath string, indexes []int64) {
+func (s *StreamTrigger) Fire(keyPath string, records []trigger.Record) {
+	indexes := make([]int64, len(records))
+	for i, record := range records {
+		indexes[i] = record.Index()
+	}
+
 	tail := maxInt64(indexes)
 
 	cDir := executor.ThisInstance.CatalogDir

--- a/executor/wal.go
+++ b/executor/wal.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/alpacahq/marketstore/plugins/trigger"
+
 	"bytes"
 	"io/ioutil"
 	"path/filepath"
@@ -207,7 +209,7 @@ func (wf *WALFileType) flushToWAL(tgc *TransactionPipe) (err error) {
 		- WAL file with synchronization to physical storage - in case we need to recover from a crash
 	*/
 
-	defer dispatchWrittenIndexes()
+	defer dispatchRecords()
 
 	WALBypass := ThisInstance.WALBypass
 	//WALBypass = true // Bypass all writing to the WAL File, leaving the writes to the primary
@@ -294,7 +296,7 @@ func (wf *WALFileType) flushToWAL(tgc *TransactionPipe) (err error) {
 			return err
 		}
 		for i, buffer := range writes {
-			addWrittenIndex(keyPath, buffer.Index())
+			appendRecord(keyPath, trigger.Record(buffer.IndexAndPayload()))
 			writes[i] = nil // for GC
 		}
 		writesPerFile[keyPath] = nil // for GC

--- a/plugins/trigger/trigger_test.go
+++ b/plugins/trigger/trigger_test.go
@@ -1,8 +1,12 @@
 package trigger
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
+	"github.com/alpacahq/marketstore/utils"
+	"github.com/alpacahq/marketstore/utils/io"
 	. "gopkg.in/check.v1"
 )
 
@@ -20,7 +24,7 @@ func (s *TestSuite) TearDownSuite(c *C) {}
 
 type EmptyTrigger struct{}
 
-func (t *EmptyTrigger) Fire(keyPath string, offsets []int64) {
+func (t *EmptyTrigger) Fire(keyPath string, records []Record) {
 	// do nothing
 }
 
@@ -32,4 +36,70 @@ func (s *TestSuite) TestMatch(c *C) {
 	c.Check(matched, Equals, true)
 	matched = matcher.Match("TSLA/5Min/OHLC")
 	c.Check(matched, Equals, false)
+}
+
+func (s *TestSuite) TestRecordsToColumnSeries(c *C) {
+	epoch := []int64{
+		time.Date(2017, 12, 14, 10, 3, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+		time.Date(2017, 12, 14, 10, 4, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+		time.Date(2017, 12, 14, 10, 5, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+		time.Date(2017, 12, 14, 10, 6, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+		time.Date(2017, 12, 14, 10, 10, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+		time.Date(2017, 12, 15, 10, 3, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+		time.Date(2017, 12, 15, 10, 4, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+		time.Date(2017, 12, 15, 10, 5, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+		time.Date(2017, 12, 15, 10, 6, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+		time.Date(2017, 12, 15, 10, 10, 0, 0, utils.InstanceConfig.Timezone).Unix(),
+	}
+	open := []float32{1., 2., 3., 4., 5., 1., 2., 3., 4., 5.}
+	high := []float32{1.1, 2.1, 3.1, 4.1, 5.1, 1.1, 2.1, 3.1, 4.1, 5.1}
+	low := []float32{0.9, 1.9, 2.9, 3.9, 4.9, 0.9, 1.9, 2.9, 3.9, 4.9}
+	close := []float32{1.05, 2.05, 3.05, 4.05, 5.05, 1.05, 2.05, 3.05, 4.05, 5.05}
+
+	tbk := io.NewTimeBucketKey("TEST/1Min/OHLC")
+	cs := io.NewColumnSeries()
+	cs.AddColumn("Epoch", epoch)
+	cs.AddColumn("Open", open)
+	cs.AddColumn("High", high)
+	cs.AddColumn("Low", low)
+	cs.AddColumn("Close", close)
+
+	rs := cs.ToRowSeries(*tbk)
+	rowData := rs.GetData()
+	times := rs.GetTime()
+	numRows := len(times)
+	rowLen := len(rowData) / numRows
+
+	records := make([]Record, numRows)
+
+	for i := 0; i < numRows; i++ {
+		pos := i * rowLen
+		record := rowData[pos : pos+rowLen]
+		index := io.TimeToIndex(times[i], time.Minute)
+
+		buf, _ := io.Serialize(nil, index)
+		buf = append(buf, record[8:]...)
+
+		records[i] = Record(buf)
+	}
+
+	testCS := RecordsToColumnSeries(
+		*tbk, cs.GetDataShapes(),
+		cs.GetCandleAttributes(),
+		time.Minute, int16(2017),
+		records)
+
+	for name, col := range cs.GetColumns() {
+		testCol := testCS.GetByName(name)
+
+		cV := reflect.ValueOf(col)
+		tcV := reflect.ValueOf(testCol)
+
+		c.Check(cV.Len(), Equals, tcV.Len())
+	}
+
+	c.Check(len(cs.GetEpoch()), Equals, len(testCS.GetEpoch()))
+	for i := 0; i < len(epoch); i++ {
+		c.Check(cs.GetEpoch()[i], Equals, testCS.GetEpoch()[i])
+	}
 }


### PR DESCRIPTION
`aggtrigger.so` was taking too long in combination with the polgyon plugin to aggregate 4 timeframes on the fly, hence this refactor and optimization. Now, instead of querying separately for each aggregate timeframe, only the base timeframe window is queried. The resulting column series is then cached, and as long as the next record is within that window, it will remain cached, and repeat queries will not be run. Once the trigger receives a record that is past the window, then the data will be re-queried, and the cache will be replaced.

This also required a change in how triggers work. Rather than only sending the index of records written, we are now sending the full index and payload as a `trigger.Record`. `streamtrigger.so` has been updated for this change.