### PR TITLE
Add binance plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ plugins:
 	$(MAKE) -C contrib/stream
 	$(MAKE) -C contrib/polygon
 	$(MAKE) -C contrib/bitmexfeeder
+	$(MAKE) -C contrib/binancefeeder
 
 unittest:
 	go fmt ./...

--- a/contrib/binancefeeder/Makefile
+++ b/contrib/binancefeeder/Makefile
@@ -1,0 +1,3 @@
+GOPATH0 := $(firstword $(subst :, ,$(GOPATH)))
+all:
+	go build -o $(GOPATH0)/bin/binancefeeder.so -buildmode=plugin .

--- a/contrib/binancefeeder/README.md
+++ b/contrib/binancefeeder/README.md
@@ -1,27 +1,24 @@
-# GDAX Data Fetcher
-
+# Binance Data Fetcher
+Replicates many of the features from [gdaxfeeder] (https://github.com/alpacahq/marketstore/tree/master/contrib/gdaxfeeder)
 This module builds a MarketStore background worker which fetches historical
-price data of cryptocurrencies from GDAX public API.  It runs as a goroutine
+price data of cryptocurrencies from Binance's public API.  It runs as a goroutine
 behind the MarketStore process and keeps writing to the disk.
 
 ## Configuration
-gdaxfeeder.so comes with the server by default, so you can simply configure it
+binancefeeder.so comes with the server by default, so you can simply configure it
 in MarketStore configuration file.
 
 ### Options
 Name | Type | Default | Description
 --- | --- | --- | ---
 query_start | string | none | The point in time from which to start fetching price data
+query_end | string | none | The point in time from which to end fetching price data. 
 base_timeframe | string | 1Min | The bar aggregation duration
-symbols | slice of strings | [BTC, ETH, LTC, BCH] | The symbols to retrieve data for
+symbols | slice of strings | [All "trading" symbols from https://api.binance.com/api/v1/exchangeInfo] | The symbols to retrieve data for
 
 #### Query Start
 The fetcher keeps filling data up to the current time eventually and writes new data as it is
-generated.  Once data starts to fetch, it restarts from the last-written data
-timestamp even after the server is restarted.  You can specify fewer symbols
-if you don't need others.  Since GDAX API has rate limit, this may help to
-fill the historical data if you start from old.  Note that the data fetch timestamp
-is identical among symbols, so if one symbol lags other fetches may not be
+generated. It writes data every 30 * your time interval. It then pauses for 1 second after each call. Note that the data fetch timestamp is identical among symbols, so if one symbol lags other fetches may not be
 up to speed.
 
 #### Base Timeframe
@@ -31,12 +28,14 @@ The daily bars are written at the boundary of system timezone configured in the 
 Add the following to your config file:
 ```
 bgworkers:
-  - module: gdaxfeeder.so
+  - module: binancefeeder.so
+    name: BinanceFetcher
     config:
-      query_start: "2018-01-01 00:00"
       symbols:
-        - BTC
-      base_timeframe: "1D"
+        - ETH
+      base_timeframe: "1Min"
+      query_start: "2018-01-01 00:00"
+      query_end: "2018-01-02 00:00"
 ```
 
 

--- a/contrib/binancefeeder/binancefeeder.go
+++ b/contrib/binancefeeder/binancefeeder.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	binance "github.com/adshao/go-binance"
+	"github.com/alpacahq/marketstore/executor"
+	"github.com/alpacahq/marketstore/plugins/bgworker"
+	"github.com/alpacahq/marketstore/utils"
+	"github.com/alpacahq/marketstore/utils/io"
+	"github.com/golang/glog"
+)
+
+var suffixBinanceDefs = map[string]string{
+	"Min": "m",
+	"H":   "h",
+	"D":   "d",
+	"W":   "w",
+}
+
+//For ConvertStringToFloat function and Run() function to making exiting easier
+var errorsConversion []error
+
+type FetcherConfig struct {
+	Symbols       []string `json:"symbols"`
+	QueryStart    string   `json:"query_start"`
+	QueryEnd      string   `json:"query_end"`
+	BaseTimeframe string   `json:"base_timeframe"`
+}
+
+//BinanceFetcher is the main worker for Binance
+type BinanceFetcher struct {
+	config        map[string]interface{}
+	symbols       []string
+	queryStart    time.Time
+	queryEnd      time.Time
+	baseTimeframe *utils.Timeframe
+}
+
+func recast(config map[string]interface{}) *FetcherConfig {
+	data, _ := json.Marshal(config)
+	ret := FetcherConfig{}
+	json.Unmarshal(data, &ret)
+	return &ret
+}
+
+func ConvertStringToFloat(str string) float64 {
+	convertedString, err := strconv.ParseFloat(str, 64)
+	//Store error in string array which will be checked in main fucntion later to see if there is a need to exit
+	if err != nil {
+		glog.Errorf("String to float error: %v", err)
+		errorsConversion = append(errorsConversion, err)
+	}
+	return convertedString
+}
+
+//Checks time string and returns correct time format
+func QueryTime(query string) time.Time {
+	trials := []string{
+		"2006-01-02 03:04:05",
+		"2006-01-02T03:04:05",
+		"2006-01-02 03:04",
+		"2006-01-02T03:04",
+		"2006-01-02",
+	}
+	for _, layout := range trials {
+		qs, err := time.Parse(layout, query)
+		if err == nil {
+			//Returns time in correct time.Time object once it matches correct time format
+			return qs.In(utils.InstanceConfig.Timezone)
+		}
+	}
+	//Return null if no time matches time format
+	return time.Time{}
+}
+
+//Gets all symbols from binance
+func GetAllSymbols() []string {
+	client := binance.NewClient("", "")
+	exchangeinfo, err := client.NewExchangeInfoService().Do(context.Background())
+	symbol := make([]string, 0)
+	status := make([]string, 0)
+	validSymbols := make([]string, 0)
+
+	if err != nil {
+		fmt.Println(err)
+		symbols := []string{"BTC", "EOS", "ETH", "BNB", "TRX", "ONT", "XRP", "ADA",
+			"LTC", "BCC", "TUSD", "IOTA", "ETC", "ICX", "NEO", "XLM", "QTUM", "BCH"}
+		return symbols
+	} else {
+		for _, info := range exchangeinfo.Symbols {
+			symbol = append(symbol, info.Symbol)
+			status = append(status, info.Status)
+		}
+
+		//Check status and append to symbols list if valid
+		for index, s := range status {
+			if s == "TRADING" {
+				validSymbols = append(validSymbols, symbol[index])
+			}
+		}
+	}
+
+	return validSymbols
+}
+
+//Register new background worker
+func NewBgWorker(conf map[string]interface{}) (bgworker.BgWorker, error) {
+	config := recast(conf)
+	var queryStart time.Time
+	var queryEnd time.Time
+	timeframeStr := "1Min"
+	var symbols []string
+
+	//First see if config has symbols, if not retrieve all from binance as default
+	if len(config.Symbols) > 0 {
+		symbols = config.Symbols
+	} else {
+		symbols = GetAllSymbols()
+	}
+
+	if config.BaseTimeframe != "" {
+		timeframeStr = config.BaseTimeframe
+	}
+
+	queryStart = QueryTime(config.QueryStart)
+	queryEnd = QueryTime(config.QueryEnd)
+
+	if config.BaseTimeframe != "" {
+		timeframeStr = config.BaseTimeframe
+	}
+	return &BinanceFetcher{
+		config:        conf,
+		symbols:       symbols,
+		queryStart:    queryStart,
+		queryEnd:      queryEnd,
+		baseTimeframe: utils.NewTimeframe(timeframeStr),
+	}, nil
+}
+
+//Grab data in hour intervals from starting time to ending time
+func (bn *BinanceFetcher) Run() {
+	symbols := bn.symbols
+	client := binance.NewClient("", "")
+	timeStart := time.Time{}
+	finalTime := bn.queryEnd
+
+	originalInterval := bn.baseTimeframe.String
+	re := regexp.MustCompile("[0-9]+")
+	re2 := regexp.MustCompile("[a-zA-Z]+")
+
+	timeIntervalLettersOnly := re.ReplaceAllString(originalInterval, "")
+	timeIntervalNumsOnly := re2.ReplaceAllString(originalInterval, "")
+
+	correctIntervalSymbol := suffixBinanceDefs[timeIntervalLettersOnly]
+
+	//If Interval is formmatted incorrectly
+	if len(correctIntervalSymbol) <= 0 {
+		glog.Errorf("Interval Symbol Format Incorrect. Setting to time interval to default '1Min'")
+		correctIntervalSymbol = "1Min"
+	}
+
+	//Replace interval string with correct one with API call
+	timeInterval := timeIntervalNumsOnly + correctIntervalSymbol
+
+	for {
+		if timeStart.IsZero() {
+			if !bn.queryStart.IsZero() {
+				timeStart = bn.queryStart
+			} else {
+				timeStart = time.Now().UTC().Add(-time.Hour)
+			}
+		} else {
+			timeStart = timeStart.Add(bn.baseTimeframe.Duration * 300)
+		}
+
+		timeEnd := timeStart.Add(bn.baseTimeframe.Duration * 300)
+
+		diffTimes := finalTime.Sub(timeEnd)
+
+		if diffTimes < 0 {
+			glog.Infof("Got all data from: %v to %v", bn.queryStart, bn.queryEnd)
+			glog.Infof("Continuing...")
+		}
+
+		var timeStartM int64
+		var timeEndM int64
+
+		timeStartM = timeStart.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		timeEndM = timeEnd.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+
+		for _, symbol := range symbols {
+			glog.Infof("Requesting %s %v - %v", symbol, timeStart, timeEnd)
+
+			rates, err := client.NewKlinesService().Symbol(symbol + "USDT").Interval(timeInterval).StartTime(timeStartM).EndTime(timeEndM).Do(context.Background())
+
+			if err != nil {
+				glog.Errorf("Response error: %v", err)
+				time.Sleep(time.Minute)
+				continue
+			}
+			if len(rates) == 0 {
+				glog.Info("len(rates) == 0")
+				continue
+			}
+
+			openTime := make([]int64, 0)
+			open := make([]float64, 0)
+			high := make([]float64, 0)
+			low := make([]float64, 0)
+			close := make([]float64, 0)
+			volume := make([]float64, 0)
+
+			for _, rate := range rates {
+				errorsConversion = errorsConversion[:0]
+				openTime = append(openTime, rate.OpenTime)
+				open = append(open, ConvertStringToFloat(rate.Open))
+				high = append(high, ConvertStringToFloat(rate.High))
+				low = append(low, ConvertStringToFloat(rate.Low))
+				close = append(close, ConvertStringToFloat(rate.Close))
+				volume = append(volume, ConvertStringToFloat(rate.Volume))
+
+				for _, e := range errorsConversion {
+					if e != nil {
+						return
+					}
+				}
+			}
+
+			cs := io.NewColumnSeries()
+			cs.AddColumn("Epoch", openTime)
+			cs.AddColumn("Open", open)
+			cs.AddColumn("High", high)
+			cs.AddColumn("Low", low)
+			cs.AddColumn("Close", close)
+			cs.AddColumn("Volume", volume)
+			// glog.Infof("%s: %d rates between %v - %v", symbol, len(rates),
+			// 	timeStart.String(), timeEnd.String())
+			csm := io.NewColumnSeriesMap()
+			tbk := io.NewTimeBucketKey(symbol + "/" + timeStart.String() + "/" + timeEnd.String() + "/" + bn.baseTimeframe.String + "/OHLCV")
+			csm.AddColumnSeries(*tbk, cs)
+			executor.WriteCSM(csm, false)
+		}
+
+		//Sleep for a second before next call
+		time.Sleep(time.Second)
+	}
+}
+
+func main() {
+	symbol := "BTCUSDT"
+	interval := "1m"
+
+	client := binance.NewClient("", "")
+	klines, err := client.NewKlinesService().Symbol(symbol).
+		Interval(interval).Do(context.Background())
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	for _, k := range klines {
+		fmt.Println(k)
+	}
+}

--- a/contrib/binancefeeder/binancefeeder_test.go
+++ b/contrib/binancefeeder/binancefeeder_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alpacahq/marketstore/plugins/bgworker"
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+var _ = Suite(&TestSuite{})
+
+type TestSuite struct{}
+
+func getConfig(data string) (ret map[string]interface{}) {
+	json.Unmarshal([]byte(data), &ret)
+	return
+}
+
+func (t *TestSuite) TestNew(c *C) {
+	var config = getConfig(`{
+        "symbols": ["BTC"]
+        }`)
+	var worker *BinanceFetcher
+	var ret bgworker.BgWorker
+	var err error
+	ret, err = NewBgWorker(config)
+	worker = ret.(*BinanceFetcher)
+	c.Assert(len(worker.symbols), Equals, 1)
+	c.Assert(worker.symbols[0], Equals, "BTC")
+	c.Assert(err, IsNil)
+
+	//The symbols from the biannce API can very well change so
+	//if this test fails, consider that the API might of changed with more symbols
+
+	config = getConfig(``)
+	ret, err = NewBgWorker(config)
+	worker = ret.(*BinanceFetcher)
+	c.Assert(err, IsNil)
+	c.Assert(len(worker.symbols), Equals, 357)
+
+	config = getConfig(`{
+        "query_start": "2017-01-02 00:00"
+        }`)
+	ret, err = NewBgWorker(config)
+	worker = ret.(*BinanceFetcher)
+	c.Assert(err, IsNil)
+	c.Assert(worker.queryStart.IsZero(), Equals, false)
+}


### PR DESCRIPTION
Can be run by the following code in mkts.yml as such: 
```
bgworkers:
  - module: binancefeeder.so
    name: BinanceFetcher
    config:
      symbols:
        - ETH
      base_timeframe: "1Min"
      query_start: "2018-01-01 00:00"
      query_end: "2018-01-02 00:00"
```

Follows https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md and uses  https://github.com/adshao/go-binance gowrapper for binance. 

My main goal was to allow users to get cryptodata from binance for whatever currency, certain time range, and/or time frame. 

Also uses timeframe go library functionalities. Since the suffixes are different for the specific time intervals (ex: "1m" instead of "1Min"), I just mapped it to the correct one right before the API call.