### PR TITLE
refactor Makefiles of integration tests

### DIFF
--- a/tests/integ/Makefile
+++ b/tests/integ/Makefile
@@ -43,7 +43,6 @@ test:
 .PHONY: clean
 clean: stop
 	rm -rf data tests/__pycache__
-	rm -rf ${MARKETSTORE_DEV_DB_TMPFILE}
 
 
 # Utils
@@ -83,8 +82,10 @@ _start_pyclient_container:
 
 .PHONY: test_driver
 test_driver: clean run _start_pyclient_container
-	TEST_FILENAME='/project/tests/$@.py' make -C dockerfiles/pyclient test
+	TEST_FILENAME='/project/tests/$@.py'; \
+	make -C dockerfiles/pyclient test
 
 .PHONY: test_not_empty
 test_not_empty: clean run _start_pyclient_container
-	TEST_FILENAME='/project/tests/$@.py' make -C dockerfiles/pyclient test
+	TEST_FILENAME='/project/tests/$@.py'; \
+	make -C dockerfiles/pyclient test

--- a/tests/integ/Makefile
+++ b/tests/integ/Makefile
@@ -5,54 +5,86 @@
 LATEST_TAG ?= $(shell bin/dockertags alpacamarkets/marketstore | tail -1)
 IMAGE_NAME ?= alpacamarkets/marketstore:${LATEST_TAG}
 CONTAINER_NAME = integration_tests_mstore
+MARKETSTORE_DEV_DB_URL = https://s3.amazonaws.com/dev.alpaca.markets/gobroker/mktsdb.tar.gz
+MARKETSTORE_DEV_DB_TMPFILE = /tmp/mktsdb.tgz
 
 # User targets
 ################################################################################
+
+# start a marketstore docker container and check if ListSymbols API can be consumed
+.PHONY: connect
 connect: run
-	@curl -s --data-binary '{"jsonrpc":"2.0", "method":"DataService.ListSymbols", "id":1, "params": {"parameters": {}}}' -H 'Content-Type: application/json' http://localhost:5993/rpc ; if [ $$? -ne 0 ]; then echo "Failed"; else echo "Passed"; fi
+	@curl -s \
+	--data-binary '{"jsonrpc":"2.0", "method":"DataService.ListSymbols", "id":1, "params": {"parameters": {}}}' \
+	-H 'Content-Type: application/json' http://localhost:5993/rpc ; \
+	\
+	if [ $$? -ne 0 ]; then \
+		echo "Failed"; \
+	else \
+		echo "Passed"; \
+	fi
 
-
+.PHONY: run
 run: _init
-	@if [ `bin/check_running ${CONTAINER_NAME}` -eq 0 ]; then $(MAKE) _startup; fi
+	@if [ `bin/check_running ${CONTAINER_NAME}` -eq 0 ]; then \
+		$(MAKE) _startup; \
+	fi
 
+.PHONY: stop
 stop:
 	-if [ `bin/check_running ${CONTAINER_NAME}` -eq 1 ]; then \
 		docker stop ${CONTAINER_NAME}; fi
 	-docker rm -f ${CONTAINER_NAME}
 
+.PHONY: test
 test:
 	@bin/runtests.sh
 
+.PHONY: clean
 clean: stop
 	rm -rf data tests/__pycache__
+	rm -rf ${MARKETSTORE_DEV_DB_TMPFILE}
+
 
 # Utils
 ################################################################################
+.PHONY: _init
 _init:
-	@if [ ! -d data/mktsdb ]; then rm -rf data; $(MAKE) _get_data; fi
+	@if [ ! -d data/mktsdb ]; then \
+		rm -rf data; \
+		$(MAKE) _get_data; \
+	fi
 
+.PHONY: _get_data
 _get_data:
 	@rm -rf data && mkdir data
-	@if [ ! -f /tmp/mktsdb.tgz ]; then wget https://s3.amazonaws.com/dev.alpaca.markets/gobroker/mktsdb.tar.gz -O /tmp/mktsdb.tgz; fi
-	@tar -C data -xzf /tmp/mktsdb.tgz
+	@if [ ! -f ${MARKETSTORE_DEV_DB_TMPFILE} ]; then \
+		wget ${MARKETSTORE_DEV_DB_URL} -O ${MARKETSTORE_DEV_DB_TMPFILE}; \
+	fi
+	@tar -C data -xzf ${MARKETSTORE_DEV_DB_TMPFILE}
 
-
+.PHONY: _startup
 _startup: stop
+	@echo "Starting a marketstore instance..."
 	docker run --name ${CONTAINER_NAME} -d -p 5993:5993 -v $(CURDIR):/project -w /project $(IMAGE_NAME) \
 		start --config /project/bin/mkts.yml
 	@sleep 2
 	@if [ `bin/check_running ${CONTAINER_NAME}` -eq 0 ]; then \
-		echo "Failed to start a marketstore instance"; false; fi
-
+		echo "Failed to start a marketstore instance"; \
+		false; \
+	fi
 
 
 # Tests
 ################################################################################
+.PHONY: _start_pyclient_container
 _start_pyclient_container:
 	make -C dockerfiles/pyclient rm build run
 
+.PHONY: test_driver
 test_driver: clean run _start_pyclient_container
 	TEST_FILENAME='/project/tests/$@.py' make -C dockerfiles/pyclient test
 
+.PHONY: test_not_empty
 test_not_empty: clean run _start_pyclient_container
 	TEST_FILENAME='/project/tests/$@.py' make -C dockerfiles/pyclient test

--- a/tests/integ/README.md
+++ b/tests/integ/README.md
@@ -13,7 +13,7 @@ This is a work in progress and tests will be modified or added according to the 
 ## Connection Test
 - Command
 ```
-make connect
+make -C tests/integ connect
 ```
 
 ## WIP

--- a/tests/integ/dockerfiles/pyclient/Makefile
+++ b/tests/integ/dockerfiles/pyclient/Makefile
@@ -7,7 +7,6 @@ DOCKER_ADDOPTS=	-v $(CURDIR)/../../tests:/project/tests \
 
 
 
-
 test:
-	docker exec -i -t $(CONTAINER_NAME) bash -c \
+	docker exec $(CONTAINER_NAME) bash -c \
 		"pytest -v -v -v $(TEST_FILENAME)"

--- a/tests/integ/requirements.txt
+++ b/tests/integ/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pandas
+pytest
+pymarketstore

--- a/tests/integ/requirements.txt
+++ b/tests/integ/requirements.txt
@@ -1,4 +1,0 @@
-numpy
-pandas
-pytest
-pymarketstore


### PR DESCRIPTION
[tests/integ/Makefile]
- improved readability
- added `.PHONY` to each task

[tests/integ/dockerfiles/pyclient/Makefile]
- removed `-i -t` (interactive mode) from `docker run` to avoid `The input device is not a TTY` error that occurs when run from OSX
