### PR TITLE
memory related improvements

### DIFF
--- a/contrib/polygon/api/api.go
+++ b/contrib/polygon/api/api.go
@@ -434,14 +434,21 @@ func GetHistoricAggregates(
 // GetHistoricTrades requests polygon's REST API for historic trades
 // on the provided date .
 func GetHistoricTrades(symbol, date string) (totalTrades *HistoricTrades, err error) {
-	offset := int64(0)
+	var (
+		offset = int64(0)
+		resp   *http.Response
+		u      *url.URL
+		q      url.Values
+		trades = &HistoricTrades{}
+	)
+
 	for {
-		u, err := url.Parse(fmt.Sprintf(tradesURL, baseURL, symbol, date))
+		u, err = url.Parse(fmt.Sprintf(tradesURL, baseURL, symbol, date))
 		if err != nil {
 			return nil, err
 		}
 
-		q := u.Query()
+		q = u.Query()
 		q.Set("apiKey", apiKey)
 		q.Set("limit", strconv.FormatInt(10000, 10))
 
@@ -450,8 +457,6 @@ func GetHistoricTrades(symbol, date string) (totalTrades *HistoricTrades, err er
 		}
 
 		u.RawQuery = q.Encode()
-
-		var resp *http.Response
 
 		if err = try.Do(func(attempt int) (bool, error) {
 			resp, err = http.Get(u.String())
@@ -463,8 +468,6 @@ func GetHistoricTrades(symbol, date string) (totalTrades *HistoricTrades, err er
 		if resp.StatusCode >= http.StatusMultipleChoices {
 			return nil, fmt.Errorf("status code %v", resp.StatusCode)
 		}
-
-		trades := &HistoricTrades{}
 
 		if err = unmarshal(resp, trades); err != nil {
 			return nil, err
@@ -489,14 +492,21 @@ func GetHistoricTrades(symbol, date string) (totalTrades *HistoricTrades, err er
 // GetHistoricQuotes requests polygon's REST API for historic quotes
 // on the provided date.
 func GetHistoricQuotes(symbol, date string) (totalQuotes *HistoricQuotes, err error) {
-	offset := int64(0)
+	var (
+		offset = int64(0)
+		resp   *http.Response
+		u      *url.URL
+		q      url.Values
+		quotes = &HistoricQuotes{}
+	)
+
 	for {
-		u, err := url.Parse(fmt.Sprintf(quotesURL, baseURL, symbol, date))
+		u, err = url.Parse(fmt.Sprintf(quotesURL, baseURL, symbol, date))
 		if err != nil {
 			return nil, err
 		}
 
-		q := u.Query()
+		q = u.Query()
 		q.Set("apiKey", apiKey)
 		q.Set("limit", strconv.FormatInt(10000, 10))
 
@@ -505,8 +515,6 @@ func GetHistoricQuotes(symbol, date string) (totalQuotes *HistoricQuotes, err er
 		}
 
 		u.RawQuery = q.Encode()
-
-		var resp *http.Response
 
 		if err = try.Do(func(attempt int) (bool, error) {
 			resp, err = http.Get(u.String())
@@ -518,8 +526,6 @@ func GetHistoricQuotes(symbol, date string) (totalQuotes *HistoricQuotes, err er
 		if resp.StatusCode >= http.StatusMultipleChoices {
 			return nil, fmt.Errorf("status code %v", resp.StatusCode)
 		}
-
-		quotes := &HistoricQuotes{}
 
 		if err = unmarshal(resp, quotes); err != nil {
 			return nil, err
@@ -537,18 +543,6 @@ func GetHistoricQuotes(symbol, date string) (totalQuotes *HistoricQuotes, err er
 			break
 		}
 	}
-
-	// ts := time.Unix(0, totalQuotes.Ticks[0].Timestamp*1000*100)
-	// for _, tick := range totalQuotes.Ticks[1:] {
-	// 	newTS := time.Unix(0, tick.Timestamp*1000*100)
-	// 	if newTS.Before(ts) {
-	// 		log.Fatal("NOT STRICTLY INCREASING [%v < %v]", newTS.UnixNano(), ts.UnixNano())
-	// 	} else {
-	// 		ts = newTS
-	// 	}
-	// }
-
-	// log.Fatal("STRICTLY INCREASING")
 
 	return totalQuotes, nil
 }

--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"runtime"
+	"runtime/debug"
 	"time"
 
+	"code.cloudfoundry.org/bytefmt"
 	"github.com/alpacahq/marketstore/contrib/calendar"
 	"github.com/alpacahq/marketstore/contrib/ondiskagg/aggtrigger"
 	"github.com/alpacahq/marketstore/contrib/polygon/api"
@@ -41,6 +43,27 @@ func init() {
 }
 
 func main() {
+	// free memory in the backound every 1 minute for long running
+	// backfills with very high parallelism
+	go func() {
+		for {
+			<-time.After(time.Minute)
+			var m runtime.MemStats
+			runtime.ReadMemStats(&m)
+			memStart := m.Alloc
+			log.Info("freeing memory...")
+			debug.FreeOSMemory()
+			runtime.ReadMemStats(&m)
+			memEnd := m.Alloc
+			log.Info(
+				"mem stats: [start: %v end: %v freed: %v]",
+				bytefmt.ByteSize(memStart),
+				bytefmt.ByteSize(memEnd),
+				bytefmt.ByteSize(memStart-memEnd),
+			)
+		}
+	}()
+
 	initWriter()
 
 	if apiKey == "" {

--- a/executor/timsort.go
+++ b/executor/timsort.go
@@ -38,6 +38,8 @@ import (
 //		memcpy(buf+i*rec_nel, &words[i*rec_nel+4], rec_nel-4);
 //		memcpy(buf+((i+1)*rec_nel)-4, &words[i*rec_nel], 4);
 //  }
+//
+//  free(words);
 //}
 import "C"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/alpacahq/marketstore
 
 require (
+	code.cloudfoundry.org/bytefmt v0.0.0-20180906201452-2aa6f33b730c
 	github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398 // indirect
 	github.com/adshao/go-binance v0.0.0-20181012004556-e9a4ac01ca48
 	github.com/alpacahq/rpc v1.3.0
@@ -20,7 +21,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/iris-contrib/blackfriday v2.0.0+incompatible // indirect
 	github.com/kataras/iris v11.1.0+incompatible // indirect
-	github.com/klauspost/compress v1.4.1
+	github.com/klauspost/compress v1.4.1 // indirect
 	github.com/klauspost/cpuid v1.2.0 // indirect
 	github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2 // indirect
 	github.com/moul/http2curl v1.0.0 // indirect


### PR DESCRIPTION
Mainly in polygon plugin path - tick backfilling exposed some inefficient allocations. Cleaned those up, also explicitly freeing the `words` pointer when done with it in timsort C routine, just to be extra tidy.