### PR TITLE
Fix missing time frame in backfill

### DIFF
--- a/contrib/iex/backfill/backfill.go
+++ b/contrib/iex/backfill/backfill.go
@@ -249,7 +249,7 @@ func initWriter() {
 
 	config := map[string]interface{}{
 		"filter":       "nasdaq",
-		"destinations": []string{"5Min", "15Min", "1H"},
+		"destinations": []string{"5Min", "15Min", "1H", "4H"},
 	}
 
 	trig, err := aggtrigger.NewTrigger(config)


### PR DESCRIPTION
Marketstore supports `1Min`, `5Min`, `15Min`, `1H`, `4H`, `1D` time frames, but iex plugin doesn't fill `4H` timeframe. This PR fixes this