### PR TITLE
support querying for all known symbols with *

### DIFF
--- a/frontend/query.go
+++ b/frontend/query.go
@@ -134,6 +134,16 @@ func (s *DataService) Query(r *http.Request, reqs *MultiQueryRequest, response *
 			if len(Timeframe) == 0 || len(RecordFormat) == 0 || len(Symbols) == 0 {
 				return fmt.Errorf("destinations must have a Symbol, Timeframe and AttributeGroup, have: %s",
 					dest.String())
+			} else if len(Symbols) == 1 && Symbols[0] == "*" {
+				// replace the * "symbol" with a list all known actual symbols
+				allSymbols := executor.ThisInstance.CatalogDir.GatherCategoriesAndItems()["Symbol"]
+				symbols := make([]string, 0, len(allSymbols))
+				for symbol := range allSymbols {
+					symbols = append(symbols, symbol)
+				}
+				keyParts := []string{strings.Join(symbols, ","), Timeframe, RecordFormat}
+				itemKey := strings.Join(keyParts, "/")
+				dest = io.NewTimeBucketKey(itemKey, req.KeyCategory)
 			}
 
 			epochStart := int64(0)


### PR DESCRIPTION
This PR adds support for querying all known symbols by using `*/<Timeframe>/<AttributeGroup>`

This does raise a question for me though: how is the list of known symbols actually determined? (how does it know data for the requested timeframe exists?) From my unfamiliar vantage point, it seems that if a symbol is listed in `mkts.yml` at all, then it appears to assume minutely data exists (and has been aggregated to higher timeframes)?

PS. This is the first Go code I've ever written, so if I'm doing something stupid, please do tell :)