### PR TITLE
add cli command for estimating required storage space

### DIFF
--- a/cmd/estimate/main.go
+++ b/cmd/estimate/main.go
@@ -1,0 +1,105 @@
+package estimate
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"math"
+)
+
+const (
+	usage                 = "estimate"
+	short                 = "Estimate required storage space"
+	long                  = short
+	example               = "marketstore estimate --symbols 5000 --timeframe 1Sec --years 5"
+
+	headerBytes           = 37024
+)
+var intervalsPerDay = map[string]int64{
+	"1D":   1,
+	"1Min": 24 * 60,
+	"1Sec": 24 * 60 * 60,
+	"1ms":  24 * 60 * 60 * 1000,
+	"1us":  24 * 60 * 60 * 1000 * 1000,
+}
+
+var (
+	Cmd = &cobra.Command{
+		Use:        usage,
+		Short:      short,
+		Long:       long,
+		Example:    example,
+		RunE:       executeStart,
+	}
+	Num4ByteCols    int64
+	Num8ByteCols    int64
+	Timeframe       string
+	NumSymbols      int64
+	NumYears        int64
+	HoursPerDay     float64
+	DaysPerYear     int64
+)
+
+func init() {
+	Cmd.Flags().Int64VarP(&Num4ByteCols, "4byteCols", "", 0,
+		"Number of 4byte columns")
+	Cmd.Flags().Int64VarP(&Num8ByteCols, "8byteCols", "", 5,
+		"Number of 8byte columns")
+	Cmd.Flags().StringVarP(&Timeframe, "timeframe", "t", "1Min",
+		"Timeframe to estimate for")
+	Cmd.Flags().Int64VarP(&NumSymbols, "symbols", "s", 1000,
+		"Number of symbols stored")
+	Cmd.Flags().Int64VarP(&NumYears, "years", "y", 10,
+		"Number of years worth of data to store")
+	Cmd.Flags().Int64VarP(&DaysPerYear, "days","d", 261,
+		"Number of trading days in a year")
+	Cmd.Flags().Float64VarP(&HoursPerDay, "hours", "", 6.5,
+		"Number of hours per day the market is open")
+}
+
+func executeStart(cmd *cobra.Command, args []string) error {
+	var (
+		recordBytes    int64
+		padding        int64
+		yearFraction   float64
+		fileBytes      float64
+		totalBytes     float64
+	)
+
+	recordBytes = 8 + (Num4ByteCols * 4) + (Num8ByteCols * 8)  // +8 for the index
+	padding = int64(math.Mod(float64(recordBytes), 8))
+	recordBytes = recordBytes + padding
+
+	yearFraction = float64(DaysPerYear) * (HoursPerDay / 24.0)
+	fileBytes = float64(headerBytes) + (
+		float64(recordBytes) * float64(intervalsPerDay[Timeframe]) * yearFraction)
+
+	totalBytes = fileBytes * float64(NumSymbols) * float64(NumYears)
+
+	/*
+		Print the results and exit
+	 */
+	symbolStr := "symbols"
+	if NumSymbols == 1 {
+		symbolStr = "symbol"
+	}
+	yearStr := "years"
+	if NumYears == 1 {
+		yearStr = "year"
+	}
+	var sizes = []string{"KB", "MB", "GB", "TB", "PB", "EB"}
+	for i := range sizes {
+		sizeBytes := math.Pow(10, float64((i + 1) * 3))
+
+		if totalBytes < (sizeBytes * 10000) {
+			fmt.Printf(
+				"Estimated space required for %d %s with %d %s of %s data: %.0f%s\n",
+				NumSymbols, symbolStr, NumYears, yearStr, Timeframe, totalBytes / sizeBytes, sizes[i],
+			)
+			return nil
+		}
+	}
+
+	// fallback message for ridiculously huge amounts
+	fmt.Println("Estimated space required is more than 10,000EB")
+	return nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alpacahq/marketstore/cmd/connect"
 	"github.com/alpacahq/marketstore/cmd/create"
+	"github.com/alpacahq/marketstore/cmd/estimate"
 	"github.com/alpacahq/marketstore/cmd/start"
 	"github.com/alpacahq/marketstore/cmd/tool"
 	"github.com/alpacahq/marketstore/utils"
@@ -35,6 +36,7 @@ func Execute() error {
 
 	// Adds subcommands and version flag.
 	c.AddCommand(create.Cmd)
+	c.AddCommand(estimate.Cmd)
 	c.AddCommand(start.Cmd)
 	c.AddCommand(tool.Cmd)
 	c.AddCommand(connect.Cmd)

--- a/docs/design/file_format_design.txt
+++ b/docs/design/file_format_design.txt
@@ -115,11 +115,11 @@ For fixed width fields we can use the simplest possible storage scheme - binary 
 
 Example 1) OHLC data, element size: 64-bit, number of elements 4:
     64-bit key, 4 x 64-bit float values, no padding
-    record_size = 40 bytes
+    record_size = 40 bytes (8 bytes key, 32 bytes data)
 
 Example 2) OHLCV data, Element size: 32-bit
     64-bit key, 4 x 32-bit float values, 1 x 32-bit value, 32-bit padding
-    record_size = 32 bytes (28 bytes of data, 4 bytes of pad)
+    record_size = 32 bytes (8 bytes key, 20 bytes of data, 4 bytes padding)
 
 *** Note: when mapping structs in C/C++ or Go to the file contents (such as a read buffer), the struct should contain the padding as data items to allow for proper iteration through an array of the struct, for example:
 
@@ -216,7 +216,7 @@ In the implementation of the catalog for this structure, we can generalize this 
 
 --- Metadata management
 
-A program that uses this format can obtain the metadata it needs by using the filesystem organization directly. The names of the attribute group(e.g. "OHLC" is the group of open, high, low and close prices) as used in the filesystem can be used directly within the program to refer to known, mapped fields of interest. In addition, if there are fields that are unknown to that program present in the filesystem, the program can interrogate the file to determine what is inside and provide access to thos fields if needed.
+A program that uses this format can obtain the metadata it needs by using the filesystem organization directly. The names of the attribute group(e.g. "OHLC" is the group of open, high, low and close prices) as used in the filesystem can be used directly within the program to refer to known, mapped fields of interest. In addition, if there are fields that are unknown to that program present in the filesystem, the program can interrogate the file to determine what is inside and provide access to those fields if needed.
 
 For example: if a charting program inquires about symbol BRK - A in a filesystem metadata query, it may determine that BRK - A has data from 2005 to 2016. In 2016, there are OHLC and V data available and the chart defaults to presenting that data. Since the program's filesystem query also reveals additional data including PUTS-2-24-16 for BRK-A, it can query the file header to get the full text and data type description and the user can choose to present some or all of that data on the chart.
 
@@ -245,15 +245,16 @@ However - if we subtract the weekends and non-trading hours(09:30-16:00), we wil
 
     Resolution      Raw Size(GB)   Net Size(GB)
    -----------------------------------
-    1Min            0.021           0.0041
+    1Min            0.021           0.0041/year/symbol
     1Sec            1.261           0.2442
     1ms             1,261           244
     1us             1,261,000       244,000
 
-The overall filesystem size is the number of files times the data file size:
-                    Net
-    Resolution      Filesystem Size(TB)
-   ------------------------------
+The overall filesystem size is the number of files (800K) times the data file size:
+
+    Resolution      Net Filesystem Size(TB)
+   -----------------------------------
+    1Day            0.008 (8GB)
     1Min            3.280
     1Sec            195.4
     1ms             195,400 (195.4PB)


### PR DESCRIPTION
This PR adds a simple subcommand to estimate storage space. The math matches what's in `docs/design/file_format_design.txt`, so hopefully that's still accurate :)

Does not take into account any behavior of configured aggregator plugins, and has its defaults set for equities (matching the doc). Also assumes 1000 bytes per KB, which as far as I can tell, is the math that was used in the design doc.