### PR TITLE
Queryable Timeframe Aggregation

### DIFF
--- a/contrib/ondiskagg/aggtrigger/aggtrigger.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger.go
@@ -267,16 +267,16 @@ func (s *OnDiskAggTrigger) writeAggregates(
 		// normally this will always be true, but when there are random bars
 		// on the weekend, it won't be, so checking to avoid panic
 		if len(tqSlc.GetEpoch()) > 0 {
-			csm.AddColumnSeries(*aggTbk, aggregate(tqSlc, aggTbk))
+			csm.AddColumnSeries(*aggTbk, Aggregate(tqSlc, aggTbk))
 		}
 	} else {
-		csm.AddColumnSeries(*aggTbk, aggregate(&slc, aggTbk))
+		csm.AddColumnSeries(*aggTbk, Aggregate(&slc, aggTbk))
 	}
 
 	return executor.WriteCSM(csm, false)
 }
 
-func aggregate(cs *io.ColumnSeries, tbk *io.TimeBucketKey) *io.ColumnSeries {
+func Aggregate(cs *io.ColumnSeries, tbk *io.TimeBucketKey) *io.ColumnSeries {
 	timeWindow := utils.CandleDurationFromString(tbk.GetItemInCategory("Timeframe"))
 
 	params := []accumParam{

--- a/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
@@ -66,7 +66,7 @@ func (t *TestSuite) TestAgg(c *C) {
 	cs.AddColumn("Low", low)
 	cs.AddColumn("Close", close)
 
-	outCs := aggregate(cs, tbk)
+	outCs := Aggregate(cs, tbk)
 	c.Assert(outCs.Len(), Equals, 3)
 	c.Assert(outCs.GetColumn("Open").([]float32)[0], Equals, float32(1.))
 	c.Assert(outCs.GetColumn("High").([]float32)[1], Equals, float32(4.1))
@@ -91,7 +91,7 @@ func (t *TestSuite) TestAgg(c *C) {
 	cs.AddColumn("Low", low)
 	cs.AddColumn("Close", close)
 
-	outCs = aggregate(cs, tbk)
+	outCs = Aggregate(cs, tbk)
 	c.Assert(outCs.Len(), Equals, 2)
 	d1 := time.Date(2017, 12, 15, 0, 0, 0, 0, utils.InstanceConfig.Timezone)
 	d2 := time.Date(2017, 12, 16, 0, 0, 0, 0, utils.InstanceConfig.Timezone)

--- a/contrib/ondiskagg/ondiskagg.go
+++ b/contrib/ondiskagg/ondiskagg.go
@@ -1,4 +1,4 @@
-// This is a shim package for buiding a plugin module wrapping
+// This is a shim package for building a plugin module wrapping
 // the importable aggtrigger package.  For more details, see aggtrigger.
 package main
 

--- a/frontend/query.go
+++ b/frontend/query.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"fmt"
+	"github.com/alpacahq/marketstore/contrib/ondiskagg/aggtrigger"
 	"math"
 	"net/http"
 	"strings"
@@ -244,43 +245,61 @@ func executeQuery(tbk *io.TimeBucketKey, start, end time.Time, LimitRecordCount 
 	LimitFromStart bool) (io.ColumnSeriesMap, error) {
 
 	query := planner.NewQuery(executor.ThisInstance.CatalogDir)
-
-	/*
-		Alter timeframe inside key to ensure it matches a queryable TF
-	*/
+	queriedTbk := io.NewTimeBucketKeyFromString(tbk.Key)
 
 	tf := tbk.GetItemInCategory("Timeframe")
 	cd := utils.CandleDurationFromString(tf)
-	queryableTimeframe := cd.QueryableTimeframe()
-	tbk.SetItemInCategory("Timeframe", queryableTimeframe)
-	query.AddTargetKey(tbk)
+	queryableTimeframes := cd.QueryableTimeframes()
 
-	if LimitRecordCount != 0 {
-		direction := io.LAST
-		if LimitFromStart {
-			direction = io.FIRST
+	var parseResult *planner.ParseResult
+
+	/*
+		search for the lowest-frequency timeframe with data able to satisfy the request
+	 */
+	for i, timeframe := range queryableTimeframes {
+		queriedTbk.SetItemInCategory("Timeframe", timeframe)
+
+		query.Reset()
+		query.AddTargetKey(queriedTbk)
+		query.SetRange(start.Unix(), end.Unix())
+
+		if LimitRecordCount != 0 {
+			direction := io.LAST
+			if LimitFromStart {
+				direction = io.FIRST
+			}
+			query.SetRowLimit(
+				direction,
+				cd.QueryableNrecords(timeframe, LimitRecordCount),
+			)
 		}
-		query.SetRowLimit(
-			direction,
-			cd.QueryableNrecords(
-				queryableTimeframe,
-				LimitRecordCount,
-			),
-		)
-	}
 
-	query.SetRange(start.Unix(), end.Unix())
-	parseResult, err := query.Parse()
-	if err != nil {
+		result, err := query.Parse()
+		if err == nil {
+			parseResult = result
+			break
+		}
+
 		// No results from query
 		if err.Error() == "No files returned from query parse" {
-			log.Info("No results returned from query: Target: %v, start, end: %v,%v LimitRecordCount: %v",
+			// continue checking higher-frequency timeframes if there are any left in the list
+			if i+1 < len(queryableTimeframes) {
+				continue
+			}
+			// otherwise add contextual details to the error and return early
+			err = fmt.Errorf(
+				"No results returned from query: Target: %v, start, end: %v,%v LimitRecordCount: %v",
 				tbk.String(), start, end, LimitRecordCount)
+			log.Error("Error: %s\n", err)
 		} else {
 			log.Error("Parsing query: %s\n", err)
 		}
 		return nil, err
 	}
+
+	/*
+		read in the query parse data
+	 */
 	scanner, err := executor.NewReader(parseResult)
 	if err != nil {
 		log.Error("Unable to create scanner: %s\n", err)
@@ -291,6 +310,16 @@ func executeQuery(tbk *io.TimeBucketKey, start, end time.Time, LimitRecordCount 
 		log.Error("Error returned from query scanner: %s\n", err)
 		return nil, err
 	}
+
+	/*
+		check if we need to aggregate the queried data to the requested timeframe
+	 */
+	if tf != queriedTbk.GetItemInCategory("Timeframe") {
+		cs := aggtrigger.Aggregate(csm[*queriedTbk], tbk)
+		csm = io.NewColumnSeriesMap()
+		csm[*tbk] = cs
+	}
+
 	return csm, err
 }
 

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -185,6 +185,12 @@ func NewQuery(d *Directory) *query {
 	return q
 }
 
+func (q *query) Reset() {
+	q.Restriction = NewRestrictionList()
+	q.Range = NewDateRange()
+	q.Limit = NewRowLimit()
+}
+
 func (q *query) SetRowLimit(direction DirectionEnum, rowLimit int) {
 	q.Limit = NewRowLimit()
 	q.Limit.Number = int32(rowLimit)
@@ -296,7 +302,7 @@ func (q *query) Parse() (pr *ParseResult, err error) {
 
 	/*
 		Obtain the Timeframe from the qualified files and validate that the files all share the same timeframe
-		This is necessary because the IO plan will use timeeframe / interval information to target the data
+		This is necessary because the IO plan will use timeframe / interval information to target the data
 		location directly
 	*/
 	for i, qf := range pr.QualifiedFiles {

--- a/utils/timeframe.go
+++ b/utils/timeframe.go
@@ -152,10 +152,17 @@ func (cd *CandleDuration) IsWithin(ts, start time.Time) bool {
 // Truncate returns the lower boundary time of this candle window that
 // ts belongs to.
 func (cd *CandleDuration) Truncate(ts time.Time) time.Time {
+	yy, mm, dd := ts.Date()
+	day := time.Date(yy, mm, dd, 0, 0, 0, 0, ts.Location())
+
 	switch cd.suffix {
 	case "D":
-		yy, mm, dd := ts.Date()
-		return time.Date(yy, mm, dd, 0, 0, 0, 0, ts.Location())
+		return day
+	case "W":
+		for day.Weekday() != time.Monday {
+			day = day.AddDate(0, 0, -1)
+		}
+		return day
 	case "M":
 		return time.Date(ts.Year(), ts.Month(), 1, 0, 0, 0, 0, ts.Location())
 	default:

--- a/utils/timeframe.go
+++ b/utils/timeframe.go
@@ -138,7 +138,7 @@ func (cd *CandleDuration) IsWithin(ts, start time.Time) bool {
 			return false
 		}
 	case "Y":
-		if (ts.Year() - start.Year()) <= cd.multiplier {
+		if (ts.Year() - start.Year()) < cd.multiplier {
 			return true
 		}
 	default:
@@ -165,6 +165,8 @@ func (cd *CandleDuration) Truncate(ts time.Time) time.Time {
 		return day
 	case "M":
 		return time.Date(ts.Year(), ts.Month(), 1, 0, 0, 0, 0, ts.Location())
+	case "Y":
+		return time.Date(ts.Year(), time.January, 1, 0, 0, 0, 0, ts.Location())
 	default:
 		return ts.Truncate(cd.duration)
 	}

--- a/utils/timeframe.go
+++ b/utils/timeframe.go
@@ -23,11 +23,13 @@ var timeframeDefs = []Timeframe{
 	{"Y", Year},
 }
 
+// supported persistent aggregated timeframes
 var Timeframes = []*Timeframe{
 	{"1Sec", time.Second},
 	{"1Min", time.Minute},
 	{"5Min", 5 * time.Minute},
 	{"15Min", 15 * time.Minute},
+	{"30Min", 30 * time.Minute},
 	{"1H", time.Hour},
 	{"4H", 4 * time.Hour},
 	{"1D", Day},
@@ -183,15 +185,21 @@ func (cd *CandleDuration) Ceil(ts time.Time) time.Time {
 	return (ts.Add(cd.duration)).Truncate(cd.duration)
 }
 
-func (cd *CandleDuration) QueryableTimeframe() string {
+func (cd *CandleDuration) QueryableTimeframes() []string {
+	timeframes := make([]string, 0)
 	if cd.suffix != "M" {
 		for i := len(Timeframes) - 1; i >= 0; i-- {
 			if cd.duration%Timeframes[i].Duration == time.Duration(0) {
-				return Timeframes[i].String
+				timeframes = append(timeframes, Timeframes[i].String)
 			}
 		}
 	}
-	return "1D"
+
+	if len(timeframes) > 0 {
+		return timeframes
+	}
+
+	return []string{"1D"}
 }
 
 func (cd *CandleDuration) QueryableNrecords(tf string, nrecords int) int {


### PR DESCRIPTION
This PR implements timeframe aggregation on-the-fly.

The previous behavior was IMO a bit surprising, in that if you requested for example `2Min` it would appear to work, but actually it would return `1Min` data. Now, you will get `2Min` data (as long as `1Min` or `1Sec` data exists).

Tested (manually) with both `1Min` and `1D` as input data, as well as with persisted aggregate data (eg the aggtrigger is configured to store `5Min` and I request `10Min` data). Also fixed `CandleDuration.Truncate` so that it works correctly with weekly and yearly data, and monthly support was already correct. 

You can aggregate daily to yearly data, however at least with IEX, out-of-the-box it stores volume as `int32` which overflows for actively traded symbols. Support for persisting weekly/monthly/yearly data has not been added (at least not in this PR), although I expect it shouldn't be too hard to add.