### PR TITLE
support using double quotes around literals in `query.parseFunctionCall`

### DIFF
--- a/frontend/query.go
+++ b/frontend/query.go
@@ -364,15 +364,25 @@ func parseFunctionCall(call string) (funcName string, literalList, parameterList
 	*/
 	var newCall string
 	for {
-		left = strings.Index(call, "'")
-		if left == -1 {
+		leftSingle := strings.Index(call, "'")
+		leftDouble := strings.Index(call, "\"")
+		var delimeter string
+		if leftSingle == -1 && leftDouble == -1 {
 			newCall = newCall + call
 			break
-		} else if left != 0 {
+		} else if leftSingle != -1 {
+			left = leftSingle
+			delimeter = "'"
+		} else {
+			left = leftDouble
+			delimeter = "\""
+		}
+
+		if left != 0 {
 			newCall = newCall + call[:left]
 		}
 		call = call[left+1:]
-		right = strings.Index(call, "'")
+		right = strings.Index(call, delimeter)
 		if right == -1 {
 			return "", nil, nil, fmt.Errorf("unclosed literal %s", call)
 		}

--- a/frontend/query_test.go
+++ b/frontend/query_test.go
@@ -290,12 +290,36 @@ func (s *ServerTestSuite) TestFunctions(c *C) {
 	service := &DataService{}
 	service.Init()
 
-	call := "candlecandler('1Min',Open,High,Low,Close,Sum::Volume)"
+	call := "candlecandler(\"1Min\", Open, High, Low, Close, Sum::Volume)"
 	fname, l_list, p_list, err := parseFunctionCall(call)
 	if err != nil {
 		fmt.Println(err)
 		c.FailNow()
 	}
+	c.Assert(fname, Equals, "candlecandler")
+	c.Assert(len(l_list), Equals, 1)
+	c.Assert(l_list[0], Equals, "1Min")
+	c.Assert(p_list[0], Equals, "Open")
+	c.Assert(p_list[1], Equals, "High")
+	c.Assert(p_list[2], Equals, "Low")
+	c.Assert(p_list[3], Equals, "Close")
+	c.Assert(p_list[4], Equals, "Sum::Volume")
+	//	printFuncParams(fname, l_list, p_list)
+
+	call = "candlecandler('1Min',Open,High,Low,Close,Sum::Volume)"
+	fname, l_list, p_list, err = parseFunctionCall(call)
+	if err != nil {
+		fmt.Println(err)
+		c.FailNow()
+	}
+	c.Assert(fname, Equals, "candlecandler")
+	c.Assert(len(l_list), Equals, 1)
+	c.Assert(l_list[0], Equals, "1Min")
+	c.Assert(p_list[0], Equals, "Open")
+	c.Assert(p_list[1], Equals, "High")
+	c.Assert(p_list[2], Equals, "Low")
+	c.Assert(p_list[3], Equals, "Close")
+	c.Assert(p_list[4], Equals, "Sum::Volume")
 	//	printFuncParams(fname, l_list, p_list)
 
 	call = "FuncName (P1, 'Lit1', P2,P3,P4, 'Lit2' , Sum::P5, Avg::P6)"


### PR DESCRIPTION
This PR adds support for quoting literals in user-defined functions with double quotes.

```python
# For example, this works with marketstore@master:
amd = c.query(pymkts.Params('AMD', '1Min', 'OHLCV', functions=[
    "candlecandler('5Min',Open,High,Low,Close,Volume)",
])).first().df()

# But this doesn't (at least not without this PR):
amd = c.query(pymkts.Params('AMD', '1Min', 'OHLCV', functions=[
    'candlecandler("5Min",Open,High,Low,Close,Volume)',
])).first().df()
```