### PR TITLE
gdaxFeeder to take any product ID

### DIFF
--- a/contrib/gdaxfeeder/README.md
+++ b/contrib/gdaxfeeder/README.md
@@ -1,56 +1,62 @@
 # GDAX Data Fetcher
 
 This module builds a MarketStore background worker which fetches historical
-price data of cryptocurrencies from GDAX public API.  It runs as a goroutine
+price data of cryptocurrencies from GDAX public API. It runs as a goroutine
 behind the MarketStore process and keeps writing to the disk.
 
 ## Configuration
+
 gdaxfeeder.so comes with the server by default, so you can simply configure it
 in MarketStore configuration file.
 
 ### Options
-Name | Type | Default | Description
---- | --- | --- | ---
-query_start | string | none | The point in time from which to start fetching price data
-base_timeframe | string | 1Min | The bar aggregation duration
-symbols | slice of strings | [BTC, ETH, LTC, BCH] | The symbols to retrieve data for
+
+| Name           | Type             | Default                              | Description                                               |
+| -------------- | ---------------- | ------------------------------------ | --------------------------------------------------------- |
+| query_start    | string           | none                                 | The point in time from which to start fetching price data |
+| base_timeframe | string           | 1Min, 5Min, 15Min, 1H, 1D            | The bar aggregation duration                              |
+| symbols        | slice of strings | [BTC-USD, ETH-USD, LTC-USD, BCH-USD] | The symbols to retrieve data for                          |
 
 #### Query Start
+
 The fetcher keeps filling data up to the current time eventually and writes new data as it is
-generated.  Once data starts to fetch, it restarts from the last-written data
-timestamp even after the server is restarted.  You can specify fewer symbols
-if you don't need others.  Since GDAX API has rate limit, this may help to
-fill the historical data if you start from old.  Note that the data fetch timestamp
+generated. Once data starts to fetch, it restarts from the last-written data
+timestamp even after the server is restarted. You can specify fewer symbols
+if you don't need others. Since GDAX API has rate limit, this may help to
+fill the historical data if you start from old. Note that the data fetch timestamp
 is identical among symbols, so if one symbol lags other fetches may not be
 up to speed.
 
 #### Base Timeframe
+
 The daily bars are written at the boundary of system timezone configured in the same file.
 
 ### Example
+
 Add the following to your config file:
-```
+
+```yml
 bgworkers:
   - module: gdaxfeeder.so
     config:
-      query_start: "2018-01-01 00:00"
+      query_start: '2018-01-01 00:00'
       symbols:
-        - BTC
-      base_timeframe: "1D"
+        - BTC-USD
+      base_timeframe: '1D'
 ```
-
 
 ## Build
+
 If you need to change the fetcher, you can build it by:
 
-```
+```bash
 $ make configure
 $ make all
 ```
 
 It installs the new .so file to the first GOPATH/bin directory.
 
-
 ## Caveat
+
 Since this is implemented based on the Go's plugin mechanism, it is supported only
 on Linux & MacOS as of Go 1.10

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -143,9 +143,10 @@ func (gd *GdaxFetcher) Run() {
 	client := gdax.NewClient("", "", "")
 	timeStart := time.Time{}
 	for _, symbol := range symbols {
-		tbk := io.NewTimeBucketKey(symbol + "/" + gd.baseTimeframe.String + "/OHLCV")
-		lastTimestamp := findLastTimestamp(symbol, tbk)
-		fmt.Printf("lastTimestamp for %s = %v\n", symbol, lastTimestamp)
+		symbolDir := fmt.Sprintf("gdax_%s", symbol)
+		tbk := io.NewTimeBucketKey(symbolDir + "/" + gd.baseTimeframe.String + "/OHLCV")
+		lastTimestamp := findLastTimestamp(symbolDir, tbk)
+		fmt.Printf("lastTimestamp for %s = %v\n", symbolDir, lastTimestamp)
 		if timeStart.IsZero() || (!lastTimestamp.IsZero() && lastTimestamp.Before(timeStart)) {
 			timeStart = lastTimestamp
 		}
@@ -205,8 +206,9 @@ func (gd *GdaxFetcher) Run() {
 			cs.AddColumn("Volume", volume)
 			fmt.Printf("%s: %d rates between %v - %v\n", symbol, len(rates),
 				rates[0].Time, rates[(len(rates))-1].Time)
+			symbolDir := fmt.Sprintf("gdax_%s", symbol)
 			csm := io.NewColumnSeriesMap()
-			tbk := io.NewTimeBucketKey(symbol + "/" + gd.baseTimeframe.String + "/OHLCV")
+			tbk := io.NewTimeBucketKey(symbolDir + "/" + gd.baseTimeframe.String + "/OHLCV")
 			csm.AddColumnSeries(*tbk, cs)
 			executor.WriteCSM(csm, false)
 		}

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -15,13 +15,13 @@ import (
 	gdax "github.com/preichenberger/go-gdax"
 )
 
-type ByTime []gdax.HistoricRate
+type byTime []gdax.HistoricRate
 
-func (a ByTime) Len() int           { return len(a) }
-func (a ByTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a ByTime) Less(i, j int) bool { return a[i].Time.Before(a[j].Time) }
+func (a byTime) Len() int           { return len(a) }
+func (a byTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byTime) Less(i, j int) bool { return a[i].Time.Before(a[j].Time) }
 
-// FetchConfig is the configuration for GdaxFetcher you can define in
+// FetcherConfig is the configuration for GdaxFetcher you can define in
 // marketstore's config file through bgworker extension.
 type FetcherConfig struct {
 	// list of currency symbols, defults to ["BTC", "ETH", "LTC", "BCH"]
@@ -158,7 +158,7 @@ func (gd *GdaxFetcher) Run() {
 			low := make([]float64, 0)
 			close := make([]float64, 0)
 			volume := make([]float64, 0)
-			sort.Sort(ByTime(rates))
+			sort.Sort(byTime(rates))
 			for _, rate := range rates {
 				if rate.Time.After(lastTime) {
 					lastTime = rate.Time

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -113,7 +113,7 @@ func NewBgWorker(conf map[string]interface{}) (bgworker.BgWorker, error) {
 	}, nil
 }
 
-func findLastTimestamp(tbk *io.TimeBucketKey) time.Time {
+func findLastTimestamp(symbol string, tbk *io.TimeBucketKey) time.Time {
 	cDir := executor.ThisInstance.CatalogDir
 	query := planner.NewQuery(cDir)
 	query.AddTargetKey(tbk)
@@ -145,7 +145,7 @@ func (gd *GdaxFetcher) Run() {
 	for _, symbol := range symbols {
 		symbolDir := fmt.Sprintf("gdax_%s", symbol)
 		tbk := io.NewTimeBucketKey(symbolDir + "/" + gd.baseTimeframe.String + "/OHLCV")
-		lastTimestamp := findLastTimestamp(tbk)
+		lastTimestamp := findLastTimestamp(symbolDir, tbk)
 		fmt.Printf("lastTimestamp for %s = %v\n", symbolDir, lastTimestamp)
 		if timeStart.IsZero() || (!lastTimestamp.IsZero() && lastTimestamp.Before(timeStart)) {
 			timeStart = lastTimestamp

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -113,7 +113,7 @@ func NewBgWorker(conf map[string]interface{}) (bgworker.BgWorker, error) {
 	}, nil
 }
 
-func findLastTimestamp(symbol string, tbk *io.TimeBucketKey) time.Time {
+func findLastTimestamp(tbk *io.TimeBucketKey) time.Time {
 	cDir := executor.ThisInstance.CatalogDir
 	query := planner.NewQuery(cDir)
 	query.AddTargetKey(tbk)
@@ -145,7 +145,7 @@ func (gd *GdaxFetcher) Run() {
 	for _, symbol := range symbols {
 		symbolDir := fmt.Sprintf("gdax_%s", symbol)
 		tbk := io.NewTimeBucketKey(symbolDir + "/" + gd.baseTimeframe.String + "/OHLCV")
-		lastTimestamp := findLastTimestamp(symbolDir, tbk)
+		lastTimestamp := findLastTimestamp(tbk)
 		fmt.Printf("lastTimestamp for %s = %v\n", symbolDir, lastTimestamp)
 		if timeStart.IsZero() || (!lastTimestamp.IsZero() && lastTimestamp.Before(timeStart)) {
 			timeStart = lastTimestamp

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
 	"sort"
 	"time"
 
@@ -49,10 +50,35 @@ func recast(config map[string]interface{}) *FetcherConfig {
 	return &ret
 }
 
+type gdaxProduct struct {
+	ID string `json:"id"`
+}
+
+func getSymbols() ([]string, error) {
+	resp, err := http.Get("https://api.pro.coinbase.com/products")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	products := []gdaxProduct{}
+	err = json.NewDecoder(resp.Body).Decode(&products)
+	if err != nil {
+		return nil, err
+	}
+	symbols := make([]string, len(products))
+	for i, symbol := range products {
+		symbols[i] = symbol.ID
+	}
+	return symbols, nil
+}
+
 // NewBgWorker returns the new instance of GdaxFetcher.  See FetcherConfig
 // for the details of available configurations.
 func NewBgWorker(conf map[string]interface{}) (bgworker.BgWorker, error) {
-	symbols := []string{"BTC", "ETH", "LTC", "BCH"}
+	symbols, err := getSymbols()
+	if err != nil {
+		return nil, err
+	}
 
 	config := recast(conf)
 	if len(config.Symbols) > 0 {
@@ -109,7 +135,7 @@ func findLastTimestamp(symbol string, tbk *io.TimeBucketKey) time.Time {
 	return ts[0]
 }
 
-// Run() runs forever to get public historical rate for each configured symbol,
+// Run () runs forever to get public historical rate for each configured symbol,
 // and writes in marketstore data format.  In case any error including rate limit
 // is returned from GDAX, it waits for a minute.
 func (gd *GdaxFetcher) Run() {
@@ -141,7 +167,7 @@ func (gd *GdaxFetcher) Run() {
 				Granularity: int(gd.baseTimeframe.Duration.Seconds()),
 			}
 			fmt.Printf("Requesting %s %v - %v\n", symbol, timeStart, timeEnd)
-			rates, err := client.GetHistoricRates(symbol+"-USD", params)
+			rates, err := client.GetHistoricRates(symbol, params)
 			if err != nil {
 				fmt.Printf("Response error: %v\n", err)
 				// including rate limit case

--- a/contrib/gdaxfeeder/gdaxfeeder_test.go
+++ b/contrib/gdaxfeeder/gdaxfeeder_test.go
@@ -35,19 +35,18 @@ func (t *TestSuite) TestNew(c *C) {
 
 	config = getConfig(``)
 	ret, err = NewBgWorker(config)
-	worker = ret.(*GdaxFetcher)
-	resp, err := http.Get("https://api.pro.coinbase.com/products")
-	if err != nil {
-		c.Fatalf("Unable to connect to GDAX API: %v", err)
-	}
-	defer resp.Body.Close()
-	var products []interface{}
-	err = json.NewDecoder(resp.Body).Decode(&products)
-	if err != nil {
-		c.Fatalf("Unable to decode json form GDAX /products API: %v", err)
-	}
 	c.Assert(err, IsNil)
-	c.Assert(len(worker.symbols), Equals, len(products))
+	worker = ret.(*GdaxFetcher)
+	if resp, err := http.Get("https://api.pro.coinbase.com/products"); err != nil {
+		c.Fatalf("Unable to connect to GDAX API: %v", err)
+	} else {
+		defer resp.Body.Close()
+		var products []interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&products); err != nil {
+			c.Fatalf("Unable to decode json form GDAX /products API: %v", err)
+		}
+		c.Assert(len(worker.symbols), Equals, len(products))
+	}
 
 	config = getConfig(`{
         "query_start": "2017-01-02 00:00"


### PR DESCRIPTION
As per #95 this allows the gdaxFeeder plugin to take any symbol available from the GDAX endpoint (https://api.pro.coinbase.com/products) I have updated the tests and have tested the new plugin locally.

You will need to update your database folders to reference the correct product ID. All output folders are prefixed with `gdax_` this is for future crypto plugins to not clash if they share the same symbol. To retain your already downloaded data, rename your database folders like so:
```
BTC -> gdax_BTC-USD
ETH -> gdax_ETH-USD
```

example of the new mkts.yml configuration:
```yml
bgworkers:
  - module: gdaxfeeder.so
    config:
      query_start: '2018-01-01 00:00'
      symbols:
        - BTC-USD
        - BTC-GBP
      base_timeframe: '1D'
```