### PR TITLE
binanceFeeder to take multiple base currencies

### DIFF
--- a/contrib/binancefeeder/README.md
+++ b/contrib/binancefeeder/README.md
@@ -1,55 +1,64 @@
 # Binance Data Fetcher
-Replicates many of the features from [gdaxfeeder] (https://github.com/alpacahq/marketstore/tree/master/contrib/gdaxfeeder)
+
+Replicates many of the features from [gdaxfeeder](https://github.com/alpacahq/marketstore/tree/master/contrib/gdaxfeeder)
 This module builds a MarketStore background worker which fetches historical
-price data of cryptocurrencies from Binance's public API.  It runs as a goroutine
+price data of cryptocurrencies from Binance's public API. It runs as a goroutine
 behind the MarketStore process and keeps writing to the disk.
 
 ## Configuration
+
 binancefeeder.so comes with the server by default, so you can simply configure it
 in MarketStore configuration file.
 
 ### Options
-Name | Type | Default | Description
---- | --- | --- | ---
-query_start | string | none | The point in time from which to start fetching price data
-base_currency | string | USDT | Base currency for symbols. ex: BTC, ETH, USDT
-base_timeframe | string | 1Min | The bar aggregation duration
-symbols | slice of strings | [All "trading" symbols from https://api.binance.com/api/v1/exchangeInfo] | The symbols to retrieve data for
+
+| Name            | Type             | Default                                                                  | Description                                               |
+| --------------- | ---------------- | ------------------------------------------------------------------------ | --------------------------------------------------------- |
+| query_start     | string           | none                                                                     | The point in time from which to start fetching price data |
+| base_currencies | slice of strings | ["USDT"]                                                                 | Base currency for symbols. ex: BTC, ETH, USDT             |
+| base_timeframe  | string           | 1Min, 1H, 1D                                                             | The bar aggregation duration                              |
+| symbols         | slice of strings | [All "trading" symbols from https://api.binance.com/api/v1/exchangeInfo] | The symbols to retrieve data for                          |
 
 #### Query Start
+
 The fetcher keeps filling data up to the current time eventually and writes new data as it is
-generated. It writes data every 30 * your time interval. It then pauses for 1 second after each call. Note that the data fetch timestamp is identical among symbols, so if one symbol lags other fetches may not be
+generated. It writes data every 30 \* your time interval. It then pauses for 1 second after each call. Note that the data fetch timestamp is identical among symbols, so if one symbol lags other fetches may not be
 up to speed.
 
 #### Base Timeframe
+
 The daily bars are written at the boundary of system timezone configured in the same file.
 
 ### Example
+
 Add the following to your config file:
-```
+
+```yml
 bgworkers:
   - module: binancefeeder.so
     name: BinanceFetcher
     config:
       symbols:
         - ETH
-      base_timeframe: "1Min"
-      base_currency: "USDT"
-      query_start: "2018-01-01 00:00"
+      base_timeframe: '1Min'
+      base_currencies:
+        - USDT
+        - BTC
+      query_start: '2018-01-01 00:00'
 ```
-
 
 ## Build
+
 If you need to change the fetcher, you can build it by:
 
-```
+```bash
 $ make configure
 $ make all
 ```
 
 It installs the new .so file to the first GOPATH/bin directory.
 
-
 ## Caveat
+
 Since this is implemented based on the Go's plugin mechanism, it is supported only
 on Linux & MacOS as of Go 1.10

--- a/contrib/binancefeeder/binancefeeder.go
+++ b/contrib/binancefeeder/binancefeeder.go
@@ -27,35 +27,11 @@ var suffixBinanceDefs = map[string]string{
 
 // ExchangeInfo exchange info
 type ExchangeInfo struct {
-	// Timezone   string `json:"timezone"`
-	// ServerTime int64  `json:"serverTime"`
-	RateLimits []struct {
-		RateLimitType string `json:"rateLimitType"`
-		Interval      string `json:"interval"`
-		Limit         int    `json:"limit"`
-	} `json:"rateLimits"`
-	// ExchangeFilters []interface{} `json:"exchangeFilters"`
 	Symbols []struct {
-		Symbol    string `json:"symbol"`
-		Status    string `json:"status"`
-		BaseAsset string `json:"baseAsset"`
-		// BaseAssetPrecision int      `json:"baseAssetPrecision"`
+		Symbol     string `json:"symbol"`
+		Status     string `json:"status"`
+		BaseAsset  string `json:"baseAsset"`
 		QuoteAsset string `json:"quoteAsset"`
-		// QuotePrecision     int      `json:"quotePrecision"`
-		// OrderTypes         []string `json:"orderTypes"`
-		// IcebergAllowed     bool     `json:"icebergAllowed"`
-		// Filters            []struct {
-		// 	FilterType       string `json:"filterType"`
-		// 	MinPrice         string `json:"minPrice,omitempty"`
-		// 	MaxPrice         string `json:"maxPrice,omitempty"`
-		// 	TickSize         string `json:"tickSize,omitempty"`
-		// 	MinQty           string `json:"minQty,omitempty"`
-		// 	MaxQty           string `json:"maxQty,omitempty"`
-		// 	StepSize         string `json:"stepSize,omitempty"`
-		// 	MinNotional      string `json:"minNotional,omitempty"`
-		// 	Limit            int    `json:"limit,omitempty"`
-		// 	MaxNumAlgoOrders int    `json:"maxNumAlgoOrders,omitempty"`
-		// } `json:"filters"`
 	} `json:"symbols"`
 }
 

--- a/contrib/binancefeeder/binancefeeder_test.go
+++ b/contrib/binancefeeder/binancefeeder_test.go
@@ -21,7 +21,8 @@ func getConfig(data string) (ret map[string]interface{}) {
 
 func (t *TestSuite) TestNew(c *C) {
 	var config = getConfig(`{
-        "symbols": ["BTC"]
+		"symbols": ["ETH"],
+		"base_currencies": ["USDT", "BTC"]
         }`)
 	var worker *BinanceFetcher
 	var ret bgworker.BgWorker
@@ -29,7 +30,10 @@ func (t *TestSuite) TestNew(c *C) {
 	ret, err = NewBgWorker(config)
 	worker = ret.(*BinanceFetcher)
 	c.Assert(len(worker.symbols), Equals, 1)
-	c.Assert(worker.symbols[0], Equals, "BTC")
+	c.Assert(worker.symbols[0], Equals, "ETH")
+	c.Assert(len(worker.baseCurrencies), Equals, 2)
+	c.Assert(worker.baseCurrencies[0], Equals, "USDT")
+	c.Assert(worker.baseCurrencies[1], Equals, "BTC")
 	c.Assert(err, IsNil)
 
 	//The symbols from the biannce API can very well change so

--- a/contrib/gdaxfeeder/README.md
+++ b/contrib/gdaxfeeder/README.md
@@ -1,56 +1,62 @@
 # GDAX Data Fetcher
 
 This module builds a MarketStore background worker which fetches historical
-price data of cryptocurrencies from GDAX public API.  It runs as a goroutine
+price data of cryptocurrencies from GDAX public API. It runs as a goroutine
 behind the MarketStore process and keeps writing to the disk.
 
 ## Configuration
+
 gdaxfeeder.so comes with the server by default, so you can simply configure it
 in MarketStore configuration file.
 
 ### Options
-Name | Type | Default | Description
---- | --- | --- | ---
-query_start | string | none | The point in time from which to start fetching price data
-base_timeframe | string | 1Min | The bar aggregation duration
-symbols | slice of strings | [BTC, ETH, LTC, BCH] | The symbols to retrieve data for
+
+| Name           | Type             | Default                              | Description                                               |
+| -------------- | ---------------- | ------------------------------------ | --------------------------------------------------------- |
+| query_start    | string           | none                                 | The point in time from which to start fetching price data |
+| base_timeframe | string           | 1Min, 5Min, 15Min, 1H, 1D            | The bar aggregation duration                              |
+| symbols        | slice of strings | [BTC-USD, ETH-USD, LTC-USD, BCH-USD] | The symbols to retrieve data for                          |
 
 #### Query Start
+
 The fetcher keeps filling data up to the current time eventually and writes new data as it is
-generated.  Once data starts to fetch, it restarts from the last-written data
-timestamp even after the server is restarted.  You can specify fewer symbols
-if you don't need others.  Since GDAX API has rate limit, this may help to
-fill the historical data if you start from old.  Note that the data fetch timestamp
+generated. Once data starts to fetch, it restarts from the last-written data
+timestamp even after the server is restarted. You can specify fewer symbols
+if you don't need others. Since GDAX API has rate limit, this may help to
+fill the historical data if you start from old. Note that the data fetch timestamp
 is identical among symbols, so if one symbol lags other fetches may not be
 up to speed.
 
 #### Base Timeframe
+
 The daily bars are written at the boundary of system timezone configured in the same file.
 
 ### Example
+
 Add the following to your config file:
-```
+
+```yml
 bgworkers:
   - module: gdaxfeeder.so
     config:
-      query_start: "2018-01-01 00:00"
+      query_start: '2018-01-01 00:00'
       symbols:
-        - BTC
-      base_timeframe: "1D"
+        - BTC-USD
+      base_timeframe: '1D'
 ```
-
 
 ## Build
+
 If you need to change the fetcher, you can build it by:
 
-```
+```bash
 $ make configure
 $ make all
 ```
 
 It installs the new .so file to the first GOPATH/bin directory.
 
-
 ## Caveat
+
 Since this is implemented based on the Go's plugin mechanism, it is supported only
 on Linux & MacOS as of Go 1.10

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -143,9 +143,10 @@ func (gd *GdaxFetcher) Run() {
 	client := gdax.NewClient("", "", "")
 	timeStart := time.Time{}
 	for _, symbol := range symbols {
-		tbk := io.NewTimeBucketKey(symbol + "/" + gd.baseTimeframe.String + "/OHLCV")
-		lastTimestamp := findLastTimestamp(symbol, tbk)
-		fmt.Printf("lastTimestamp for %s = %v\n", symbol, lastTimestamp)
+		symbolDir := fmt.Sprintf("gdax_%s", symbol)
+		tbk := io.NewTimeBucketKey(symbolDir + "/" + gd.baseTimeframe.String + "/OHLCV")
+		lastTimestamp := findLastTimestamp(symbolDir, tbk)
+		fmt.Printf("lastTimestamp for %s = %v\n", symbolDir, lastTimestamp)
 		if timeStart.IsZero() || (!lastTimestamp.IsZero() && lastTimestamp.Before(timeStart)) {
 			timeStart = lastTimestamp
 		}
@@ -205,8 +206,9 @@ func (gd *GdaxFetcher) Run() {
 			cs.AddColumn("Volume", volume)
 			fmt.Printf("%s: %d rates between %v - %v\n", symbol, len(rates),
 				rates[0].Time, rates[(len(rates))-1].Time)
+			symbolDir := fmt.Sprintf("gdax_%s", symbol)
 			csm := io.NewColumnSeriesMap()
-			tbk := io.NewTimeBucketKey(symbol + "/" + gd.baseTimeframe.String + "/OHLCV")
+			tbk := io.NewTimeBucketKey(symbolDir + "/" + gd.baseTimeframe.String + "/OHLCV")
 			csm.AddColumnSeries(*tbk, cs)
 			executor.WriteCSM(csm, false)
 		}

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -15,13 +15,13 @@ import (
 	gdax "github.com/preichenberger/go-gdax"
 )
 
-type ByTime []gdax.HistoricRate
+type byTime []gdax.HistoricRate
 
-func (a ByTime) Len() int           { return len(a) }
-func (a ByTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a ByTime) Less(i, j int) bool { return a[i].Time.Before(a[j].Time) }
+func (a byTime) Len() int           { return len(a) }
+func (a byTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byTime) Less(i, j int) bool { return a[i].Time.Before(a[j].Time) }
 
-// FetchConfig is the configuration for GdaxFetcher you can define in
+// FetcherConfig is the configuration for GdaxFetcher you can define in
 // marketstore's config file through bgworker extension.
 type FetcherConfig struct {
 	// list of currency symbols, defults to ["BTC", "ETH", "LTC", "BCH"]
@@ -158,7 +158,7 @@ func (gd *GdaxFetcher) Run() {
 			low := make([]float64, 0)
 			close := make([]float64, 0)
 			volume := make([]float64, 0)
-			sort.Sort(ByTime(rates))
+			sort.Sort(byTime(rates))
 			for _, rate := range rates {
 				if rate.Time.After(lastTime) {
 					lastTime = rate.Time

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
 	"sort"
 	"time"
 
@@ -49,10 +50,35 @@ func recast(config map[string]interface{}) *FetcherConfig {
 	return &ret
 }
 
+type gdaxProduct struct {
+	ID string `json:"id"`
+}
+
+func getSymbols() ([]string, error) {
+	resp, err := http.Get("https://api.pro.coinbase.com/products")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	products := []gdaxProduct{}
+	err = json.NewDecoder(resp.Body).Decode(&products)
+	if err != nil {
+		return nil, err
+	}
+	symbols := make([]string, len(products))
+	for i, symbol := range products {
+		symbols[i] = symbol.ID
+	}
+	return symbols, nil
+}
+
 // NewBgWorker returns the new instance of GdaxFetcher.  See FetcherConfig
 // for the details of available configurations.
 func NewBgWorker(conf map[string]interface{}) (bgworker.BgWorker, error) {
-	symbols := []string{"BTC", "ETH", "LTC", "BCH"}
+	symbols, err := getSymbols()
+	if err != nil {
+		return nil, err
+	}
 
 	config := recast(conf)
 	if len(config.Symbols) > 0 {
@@ -109,7 +135,7 @@ func findLastTimestamp(symbol string, tbk *io.TimeBucketKey) time.Time {
 	return ts[0]
 }
 
-// Run() runs forever to get public historical rate for each configured symbol,
+// Run () runs forever to get public historical rate for each configured symbol,
 // and writes in marketstore data format.  In case any error including rate limit
 // is returned from GDAX, it waits for a minute.
 func (gd *GdaxFetcher) Run() {
@@ -141,7 +167,7 @@ func (gd *GdaxFetcher) Run() {
 				Granularity: int(gd.baseTimeframe.Duration.Seconds()),
 			}
 			fmt.Printf("Requesting %s %v - %v\n", symbol, timeStart, timeEnd)
-			rates, err := client.GetHistoricRates(symbol+"-USD", params)
+			rates, err := client.GetHistoricRates(symbol, params)
 			if err != nil {
 				fmt.Printf("Response error: %v\n", err)
 				// including rate limit case

--- a/contrib/gdaxfeeder/gdaxfeeder_test.go
+++ b/contrib/gdaxfeeder/gdaxfeeder_test.go
@@ -35,19 +35,18 @@ func (t *TestSuite) TestNew(c *C) {
 
 	config = getConfig(``)
 	ret, err = NewBgWorker(config)
-	worker = ret.(*GdaxFetcher)
-	resp, err := http.Get("https://api.pro.coinbase.com/products")
-	if err != nil {
-		c.Fatalf("Unable to connect to GDAX API: %v", err)
-	}
-	defer resp.Body.Close()
-	var products []interface{}
-	err = json.NewDecoder(resp.Body).Decode(&products)
-	if err != nil {
-		c.Fatalf("Unable to decode json form GDAX /products API: %v", err)
-	}
 	c.Assert(err, IsNil)
-	c.Assert(len(worker.symbols), Equals, len(products))
+	worker = ret.(*GdaxFetcher)
+	if resp, err := http.Get("https://api.pro.coinbase.com/products"); err != nil {
+		c.Fatalf("Unable to connect to GDAX API: %v", err)
+	} else {
+		defer resp.Body.Close()
+		var products []interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&products); err != nil {
+			c.Fatalf("Unable to decode json form GDAX /products API: %v", err)
+		}
+		c.Assert(len(worker.symbols), Equals, len(products))
+	}
 
 	config = getConfig(`{
         "query_start": "2017-01-02 00:00"


### PR DESCRIPTION
As per #94 this allows the binanceFeeder plugin to take any symbol available from the binance endpoint (https://api.binance.com/api/v1/exchangeInfo) I have updated the tests and have tested the new plugin locally.

You will need to update your database folders to reference the correct product ID. All output folders are prefixed with bianance_ this is for future crypto plugins to not clash if they share the same symbol. To retain your already downloaded data, rename your database folders like so:
```
BTC -> binance_BTC-USDT
ETH -> binance_ETH-USDT
```

example of the new mkts.yml configuration:
```yml
bgworkers:
  - module: binancefeeder.so
    name: BinanceFetcher
    config:
      symbols:
        - ETH
      base_timeframe: '1Min'
      base_currencies:
        - USDT
        - BTC
      query_start: '2018-01-01 00:00'
```

This will make 2 folders in your database `binance_ETH-USDT & binance_ETH-BTC`. Note the change of the config `base_currency -> base_currencies`