### PR TITLE
update bitmexFeeder to load correct symbols and save to bitmex_SYMBOL

### DIFF
--- a/contrib/bitmexfeeder/README.md
+++ b/contrib/bitmexfeeder/README.md
@@ -11,22 +11,21 @@ in MarketStore configuration file.
 
 ### Options
 
-| Name           | Type             | Default                | Description                                               |
-| -------------- | ---------------- | ---------------------- | --------------------------------------------------------- |
-| query_start    | string           | 2017-01-01 00:00       | The point in time from which to start fetching price data |
-| base_timeframe | string           | [1Min, 5Min, 1H, 1D]   | The bar aggregation duration                              |
-| symbols        | slice of strings | [.XBT, XBTM18, XBTU18] | The symbols to retrieve data for                          |
+| Name           | Type             | Default              | Description                                               |
+| -------------- | ---------------- | -------------------- | --------------------------------------------------------- |
+| query_start    | string           | 2017-01-01 00:00     | The point in time from which to start fetching price data |
+| base_timeframe | string           | [1Min, 5Min, 1H, 1D] | The bar aggregation duration                              |
+| symbols        | slice of strings | [XBTUSD]             | The symbols to retrieve data for                          |
 
-Symbols available:
+[Active Bitmex symbols](https://www.bitmex.com/api/v1/instrument/active)
 
 ```text
-.ADAXBT, .BCHXBT, .BXBT, .BXBTJPY,
-.DASHXBT, .EOSXBT, .ETCXBT, .ETHBON,
-.ETHXBT, .LTCXBT, .NEOXBT, .USDBON,
-.XBT, .XBTBON, .XBTJPY, .XBTUSDPI,
-.XLMXBT, .XMRXBT, .XRPXBT, .ZECXBT,
-EOSM18, ETHM18, LTCM18, XBT7D_D95,
-XBT7D_U105, XBTM18, XBTU18, XRPM18
+Perpetual contracts:
+XBTUSD, ETHUSD
+Quarterly contracts:
+XBTM19, ETHM19
+Upside Profit contracts:
+XBT7D_U105, XBT7D_D95
 ```
 
 #### Query Start
@@ -47,14 +46,14 @@ The daily bars are written at the boundary of system timezone configured in the 
 
 Add the following to your config file:
 
-```text
+```yml
 bgworkers:
   - module: bitmexfeeder.so
     config:
-      query_start: "2018-01-01 00:00"
+      query_start: '2018-01-01 00:00'
       symbols:
-        - .XBT
-      base_timeframe: "1D"
+        - XBTUSD
+      base_timeframe: '1D'
 ```
 
 ## Build
@@ -66,7 +65,7 @@ $ make configure
 $ make all
 ```
 
-It installs the new .so file to the first $GOPATH/bin directory.
+It installs the new .so file to the first \$GOPATH/bin directory.
 
 ## Caveat
 

--- a/contrib/bitmexfeeder/README.md
+++ b/contrib/bitmexfeeder/README.md
@@ -11,11 +11,11 @@ in MarketStore configuration file.
 
 ### Options
 
-| Name           | Type             | Default              | Description                                               |
-| -------------- | ---------------- | -------------------- | --------------------------------------------------------- |
-| query_start    | string           | 2017-01-01 00:00     | The point in time from which to start fetching price data |
-| base_timeframe | string           | [1Min, 5Min, 1H, 1D] | The bar aggregation duration                              |
-| symbols        | slice of strings | [XBTUSD]             | The symbols to retrieve data for                          |
+| Name           | Type             | Default                         | Description                                               |
+| -------------- | ---------------- | ------------------------------- | --------------------------------------------------------- |
+| query_start    | string           | 2017-01-01 00:00                | The point in time from which to start fetching price data |
+| base_timeframe | string           | [1Min, 5Min, 1H, 1D]            | The bar aggregation duration                              |
+| symbols        | slice of strings | [XBTUSD, ...all active symbols] | The symbols to retrieve data for                          |
 
 [Active Bitmex symbols](https://www.bitmex.com/api/v1/instrument/active)
 

--- a/contrib/bitmexfeeder/api/api.go
+++ b/contrib/bitmexfeeder/api/api.go
@@ -108,9 +108,6 @@ func (c *BitmexClient) GetBuckets(symbol string, from time.Time, binSize string)
 	if err != nil {
 		return nil, err
 	}
-	if len(resp) == 0 {
-		fmt.Printf("len(rates) == 0\n")
-	}
 
 	return resp, nil
 }

--- a/contrib/bitmexfeeder/api/api_test.go
+++ b/contrib/bitmexfeeder/api/api_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+var client BitmexClient
+
+func init() {
+	client = Init()
+}
+
+func TestGetInstruments(t *testing.T) {
+	symbols, err := client.GetInstruments()
+	if err != nil {
+		t.Error(err)
+	}
+	found := false
+	for _, symbol := range symbols {
+		if symbol == "XBTUSD" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("Did not find XBTUSD symbol")
+	}
+}
+
+func TestGetBucket(t *testing.T) {
+	symbol := "XBTUSD"
+	lastWeek := time.Now().AddDate(0, -1, 0)
+	trades, err := client.GetBuckets(symbol, lastWeek, "1H")
+	if err != nil {
+		t.Error(err)
+	}
+	if len(trades) == 0 {
+		t.Errorf("Did not load any trades from GetBucket()")
+	}
+	if trades[0].Symbol != symbol {
+		t.Errorf("Did not load trades from correct symbol %s", symbol)
+	}
+}

--- a/contrib/bitmexfeeder/bitmexfeeder_test.go
+++ b/contrib/bitmexfeeder/bitmexfeeder_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	bitmex "github.com/alpacahq/marketstore/contrib/bitmexfeeder/api"
 	"github.com/alpacahq/marketstore/plugins/bgworker"
 	. "gopkg.in/check.v1"
 )
@@ -37,7 +38,10 @@ func (t *TestSuite) TestNew(c *C) {
 	ret, err = NewBgWorker(config)
 	worker = ret.(*BitmexFetcher)
 	c.Assert(err, IsNil)
-	c.Assert(len(worker.symbols), Equals, 28)
+	client := bitmex.Init()
+	symbols, err := client.GetInstruments()
+	c.Assert(err, IsNil)
+	c.Assert(len(worker.symbols), Equals, len(symbols))
 
 	config = getConfig(`{
 	    "query_start": "2017-01-02 00:00"

--- a/contrib/bitmexfeeder/bitmexfeeder_test.go
+++ b/contrib/bitmexfeeder/bitmexfeeder_test.go
@@ -22,7 +22,7 @@ func getConfig(data string) (ret map[string]interface{}) {
 
 func (t *TestSuite) TestNew(c *C) {
 	var config = getConfig(`{
-        "symbols": [".XBT"]
+        "symbols": ["XBTUSD"]
         }`)
 	var worker *BitmexFetcher
 	var ret bgworker.BgWorker
@@ -30,7 +30,7 @@ func (t *TestSuite) TestNew(c *C) {
 	ret, err = NewBgWorker(config)
 	worker = ret.(*BitmexFetcher)
 	c.Assert(len(worker.symbols), Equals, 1)
-	c.Assert(worker.symbols[0], Equals, ".XBT")
+	c.Assert(worker.symbols[0], Equals, "XBTUSD")
 	c.Assert(err, IsNil)
 
 	config = getConfig(``)


### PR DESCRIPTION
Keeping in line with my previous pull requests I have updated the bitmexFeeder to adapt to the new database folder structure. I have fixed a bug for only active symbols to be used by default and I have written tests for the BitMEX API plugin package I initially wrote.

You will need to update your database folders to reference the correct product ID. All output folders are prefixed with bitmex_ this is for future crypto plugins to not clash if they share the same symbol. To retain your already downloaded data, rename your database folders like so:
```
.XBT --> bitmex_XBTUSD
```
You can check the appropriate suffix symbols here: https://www.bitmex.com/api/v1/instrument/active

example of the new mkts.yml configuration:
```yml
bgworkers:
  - module: bitmexfeeder.so
    config:
      query_start: '2018-01-01 00:00'
      symbols:
        - XBTUSD
      base_timeframe: '1D'
```