### PR TITLE
Add message pack annotations to enable "Destroy" endpoint from pymarketstore

### DIFF
--- a/frontend/write.go
+++ b/frontend/write.go
@@ -115,10 +115,10 @@ func (s *DataService) Create(r *http.Request, reqs *MultiCreateRequest, response
 }
 
 type KeyRequest struct {
-	Key string
+	Key string `msgpack:"key"`
 }
 type MultiKeyRequest struct {
-	Requests []KeyRequest
+	Requests []KeyRequest `msgpack:"requests"`
 }
 
 type GetInfoResponse struct {


### PR DESCRIPTION
This PR is to enable the Destroy endpoint from pymarketstore.
See [this PR](https://github.com/alpacahq/pymarketstore/pull/32)