### PR TITLE
Revert "Queryable Timeframe Aggregation"

### DIFF
--- a/contrib/ondiskagg/aggtrigger/aggtrigger.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger.go
@@ -267,16 +267,16 @@ func (s *OnDiskAggTrigger) writeAggregates(
 		// normally this will always be true, but when there are random bars
 		// on the weekend, it won't be, so checking to avoid panic
 		if len(tqSlc.GetEpoch()) > 0 {
-			csm.AddColumnSeries(*aggTbk, Aggregate(tqSlc, aggTbk))
+			csm.AddColumnSeries(*aggTbk, aggregate(tqSlc, aggTbk))
 		}
 	} else {
-		csm.AddColumnSeries(*aggTbk, Aggregate(&slc, aggTbk))
+		csm.AddColumnSeries(*aggTbk, aggregate(&slc, aggTbk))
 	}
 
 	return executor.WriteCSM(csm, false)
 }
 
-func Aggregate(cs *io.ColumnSeries, tbk *io.TimeBucketKey) *io.ColumnSeries {
+func aggregate(cs *io.ColumnSeries, tbk *io.TimeBucketKey) *io.ColumnSeries {
 	timeWindow := utils.CandleDurationFromString(tbk.GetItemInCategory("Timeframe"))
 
 	params := []accumParam{

--- a/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
@@ -66,7 +66,7 @@ func (t *TestSuite) TestAgg(c *C) {
 	cs.AddColumn("Low", low)
 	cs.AddColumn("Close", close)
 
-	outCs := Aggregate(cs, tbk)
+	outCs := aggregate(cs, tbk)
 	c.Assert(outCs.Len(), Equals, 3)
 	c.Assert(outCs.GetColumn("Open").([]float32)[0], Equals, float32(1.))
 	c.Assert(outCs.GetColumn("High").([]float32)[1], Equals, float32(4.1))
@@ -91,7 +91,7 @@ func (t *TestSuite) TestAgg(c *C) {
 	cs.AddColumn("Low", low)
 	cs.AddColumn("Close", close)
 
-	outCs = Aggregate(cs, tbk)
+	outCs = aggregate(cs, tbk)
 	c.Assert(outCs.Len(), Equals, 2)
 	d1 := time.Date(2017, 12, 15, 0, 0, 0, 0, utils.InstanceConfig.Timezone)
 	d2 := time.Date(2017, 12, 16, 0, 0, 0, 0, utils.InstanceConfig.Timezone)

--- a/contrib/ondiskagg/ondiskagg.go
+++ b/contrib/ondiskagg/ondiskagg.go
@@ -1,4 +1,4 @@
-// This is a shim package for building a plugin module wrapping
+// This is a shim package for buiding a plugin module wrapping
 // the importable aggtrigger package.  For more details, see aggtrigger.
 package main
 

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -185,12 +185,6 @@ func NewQuery(d *Directory) *query {
 	return q
 }
 
-func (q *query) Reset() {
-	q.Restriction = NewRestrictionList()
-	q.Range = NewDateRange()
-	q.Limit = NewRowLimit()
-}
-
 func (q *query) SetRowLimit(direction DirectionEnum, rowLimit int) {
 	q.Limit = NewRowLimit()
 	q.Limit.Number = int32(rowLimit)
@@ -302,7 +296,7 @@ func (q *query) Parse() (pr *ParseResult, err error) {
 
 	/*
 		Obtain the Timeframe from the qualified files and validate that the files all share the same timeframe
-		This is necessary because the IO plan will use timeframe / interval information to target the data
+		This is necessary because the IO plan will use timeeframe / interval information to target the data
 		location directly
 	*/
 	for i, qf := range pr.QualifiedFiles {


### PR DESCRIPTION
Reverts alpacahq/marketstore#205

This just failed in production by panic() when trying use a nil CS

I don't understand the code as written - I do see what look like some attractive immediate fixes, e.g. for the support of the 1Y timeframe - maybe we can break that out?

WRT queryable agg - maybe we can do a simpler thing here? Is this intended to allow for specification of arbitrary timeframes? 