### PR TITLE
Loglevel update

### DIFF
--- a/cmd/start/plugins.go
+++ b/cmd/start/plugins.go
@@ -42,7 +42,8 @@ func RunBgWorkers() {
 	log.Info("InitializeBgWorkers")
 	config := utils.InstanceConfig
 	for _, bgWorkerSetting := range config.BgWorkers {
-		log.Info("bgWorkerSetting = %v", bgWorkerSetting)
+		// bgWorkerSetting may contain sensitive data such as a password or token.
+		log.Debug("bgWorkerSetting = %v", bgWorkerSetting)
 		bgWorker := NewBgWorker(bgWorkerSetting)
 		if bgWorker != nil {
 			// we should probably keep track of this process status


### PR DESCRIPTION
https://github.com/alpacahq/marketstore/blob/master/contrib/xignitefeeder/configs/config.go#L28
Some plugins have sensitive data such as a password or a token in their configs, and they shouldn't be output to the log.
We want to change the log level of the config dump log from `Info` to `Debug` so that we can hide the information by changing the log level.