### PR TITLE
Remove the recent change that logs the whole catalog

### DIFF
--- a/contrib/polygon/api/websocket.go
+++ b/contrib/polygon/api/websocket.go
@@ -91,7 +91,7 @@ func (s *Subscription) Subscribe(handler func(msg []byte)) {
 		tickDebug := time.NewTicker(time.Second)
 		for range tickDebug.C {
 			log.Debug(
-				"{%s:%v,%s:%v,%s:%v}",
+				"{%s:%v,%s:%v,%s:%v,%s:%v}",
 				"subscription", s.pConn.scope.GetSubScope(),
 				"goroutines", runtime.NumGoroutine(),
 				"channel_depth", len(s.Incoming),

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -298,7 +298,7 @@ func (q *query) Parse() (pr *ParseResult, err error) {
 	*/
 	getFileList(q.DataDir, &pr.QualifiedFiles, "", "")
 	if len(pr.QualifiedFiles) == 0 {
-		return pr, fmt.Errorf("No files returned from query parse, DataDir: %v", q.DataDir)
+		return pr, fmt.Errorf("No files returned from query parse")
 	}
 
 	/*


### PR DESCRIPTION
In production we run marketstore with 70,000 symbols - this log message was causing the server to stop responding completely when our users were querying non-existent symbols