### PR TITLE
log more helpful IEX cloud error messages

### DIFF
--- a/contrib/iex/api/api.go
+++ b/contrib/iex/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -153,7 +154,7 @@ func GetBars(symbols []string, barRange string, limit *int, retries int) (*GetBa
 	}
 
 	if err = json.Unmarshal(body, &resp); err != nil {
-		return nil, err
+		return nil, errors.New(res.Status + ": " + string(body))
 	}
 
 	if q.Get("types") == "intraday-prices" {


### PR DESCRIPTION
IEX returns error messages in the body, as opposed to returning valid JSON with an errors key. On `master` the code logs an error about parsing the JSON, eg:

`invalid character 'Y' looking for beginning of value`

Hiding the real error: 

`402 Payment Required: You have exceeded your allotted message quota. Please enable pay-as-you-go to regain access`

This PR fixes it to show the real error in the logs