### PR TITLE
add logs for loading plugins

### DIFF
--- a/plugins/load.go
+++ b/plugins/load.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 	"plugin"
@@ -57,6 +58,7 @@ func Load(pluginName string) (pi *plugin.Plugin, err error) {
 			return pi, nil
 		}
 	}
+	log.Debug("failed to load module from GOPATHs. err="+ err.Error())
 	/*
 		Check the local directory - helpful for testing
 	*/
@@ -64,8 +66,8 @@ func Load(pluginName string) (pi *plugin.Plugin, err error) {
 	pi, err = plugin.Open(pluginPath)
 	if err != nil {
 		return nil,
-			fmt.Errorf("module %s not found in bin under any paths in GOPATH=%s or local directory\n",
-				pluginName, envGOPATH)
+			errors.Wrap(err, fmt.Sprintf("module %s not found in bin under any paths in GOPATH=%s or local directory\n",
+				pluginName, envGOPATH))
 	}
 	return pi, err
 }


### PR DESCRIPTION
I encountered an issue while trying to load my plugin, and I was able to find the cause with an additional log and additional info in an existing log.... so I'd like to add it

```
{"level":"debug","timestamp":"2019-08-08T09:08:05.781+0900","msg":"failed to load module from GOPATHs. err=plugin.Open(\"/Users/dakimura/go/bin/xignitefeeder\"): plugin was built with a different version of package math/bits"}
```