### PR TITLE
small refactor for WriteCSM function

### DIFF
--- a/executor/writer.go
+++ b/executor/writer.go
@@ -264,7 +264,7 @@ func WriteBufferToFileIndirect(fp *os.File, buffer offsetIndexBuffer, varRecLen 
 // not already exist for the given ColumnSeriesMap based on its TimeBucketKey.
 func WriteCSM(csm io.ColumnSeriesMap, isVariableLength bool) (err error) {
 	cDir := ThisInstance.CatalogDir
-	var timeBucketCreator TimeBucketCreator = &TimeBucketCreatorImpl{
+	timeBucketCreator := &TimeBucketCreatorImpl{
 		CatalogDir:       cDir,
 		RootPath:         cDir.GetPath(),
 		IsVariableLength: isVariableLength,


### PR DESCRIPTION
I found a bug in `executor.WriteCSM` function but it's so hard to write unit test for the function.
First of all, in order to improve the testability of the function, I made a new interface `TimeBucketCreator` and its implementation, and used it from `executor.WriteCSM` function while keeping the compatibility.

For most of the part of this PR, I just copied the existing implementation and paste it under the new interface.

