### PR TITLE
Handle DELAYED_OTC error IEX batch fetch can encoutner

### DIFF
--- a/contrib/iex/api/api.go
+++ b/contrib/iex/api/api.go
@@ -21,7 +21,7 @@ var (
 	NY, _ = time.LoadLocation("America/New_York")
 	token string
 	base  = "https://cloud.iexapis.com/stable"
-	symbolsexcluded = map[string]bool{}
+	symbolsExcluded = map[string]bool{}
 )
 
 func SetToken(t string) {
@@ -108,7 +108,7 @@ func GetBars(symbols []string, barRange string, limit *int, retries int) (*GetBa
 	} else {
 		var newsymbols []string
 		for _, sym := range symbols {
-			if !symbolsexcluded[sym] {
+			if !symbolsExcluded[sym] {
 				newsymbols = append(newsymbols, sym)
 			}
 		}
@@ -167,8 +167,8 @@ func GetBars(symbols []string, barRange string, limit *int, retries int) (*GetBa
 		// One of the symbols is DELAYED_OTC
 		// Binary divide the symbols list until we can identify the conflict
 		if len(symbols) == 1 {  // Idenified an OTC symbol
-			symbolsexcluded[symbols[0]] = true
-			return nil, errors.New(fmt.Sprintf("%s: %s [Symbol: %s]", res.Status, string(body), symbols[0]))
+			symbolsExcluded[symbols[0]] = true
+			return nil, fmt.Errorf("OTC Error: %s: %s [Symbol: %s]", res.Status, string(body), symbols[0])
 		} else {
 			var resp0 *GetBarsResponse
 			var resp1 *GetBarsResponse
@@ -180,14 +180,14 @@ func GetBars(symbols []string, barRange string, limit *int, retries int) (*GetBa
 			resp0, err1 := GetBars(symbols[:split], barRange, limit, retries)
 			resp1, err2 := GetBars(symbols[split:], barRange, limit, retries)
 			if err1 != nil {
-				log.Error(fmt.Sprintf("OTC Error: %v", err1))
+				log.Error(err1.Error())
 			} else {
 				for k,v := range *resp0 {
 					resp[k] = v
 				}
 			}
 			if err2 != nil {
-				log.Error(fmt.Sprintf("OTC Error: %v", err2))
+				log.Error(err2.Error())
 			} else {
 				for k,v := range *resp1 {
 					resp[k] = v

--- a/contrib/iex/api/api.go
+++ b/contrib/iex/api/api.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/alpacahq/marketstore/utils/log"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
-	"github.com/alpacahq/marketstore/utils/log"
 )
 
 const (
@@ -18,9 +18,9 @@ const (
 )
 
 var (
-	NY, _ = time.LoadLocation("America/New_York")
-	token string
-	base  = "https://cloud.iexapis.com/stable"
+	NY, _           = time.LoadLocation("America/New_York")
+	token           string
+	base            = "https://cloud.iexapis.com/stable"
 	symbolsExcluded = map[string]bool{}
 )
 
@@ -166,7 +166,7 @@ func GetBars(symbols []string, barRange string, limit *int, retries int) (*GetBa
 	if res.StatusCode == http.StatusUnavailableForLegalReasons {
 		// One of the symbols is DELAYED_OTC
 		// Binary divide the symbols list until we can identify the conflict
-		if len(symbols) == 1 {  // Idenified an OTC symbol
+		if len(symbols) == 1 { // Idenified an OTC symbol
 			symbolsExcluded[symbols[0]] = true
 			return nil, fmt.Errorf("OTC Error: %s: %s [Symbol: %s]", res.Status, string(body), symbols[0])
 		} else {
@@ -182,14 +182,14 @@ func GetBars(symbols []string, barRange string, limit *int, retries int) (*GetBa
 			if err1 != nil {
 				log.Error(err1.Error())
 			} else {
-				for k,v := range *resp0 {
+				for k, v := range *resp0 {
 					resp[k] = v
 				}
 			}
 			if err2 != nil {
 				log.Error(err2.Error())
 			} else {
-				for k,v := range *resp1 {
+				for k, v := range *resp1 {
 					resp[k] = v
 				}
 			}

--- a/contrib/iex/iex.go
+++ b/contrib/iex/iex.go
@@ -3,11 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
-	"os"
 
 	"github.com/alpacahq/marketstore/contrib/iex/api"
 	"github.com/alpacahq/marketstore/executor"
@@ -25,12 +25,12 @@ const (
 )
 
 type IEXFetcher struct {
-	config            FetcherConfig
-	backfillM         *sync.Map
-	queue             chan []string
-	lastM             *sync.Map
-	refreshSymbols    bool
-	lastDailyRunDate  int
+	config           FetcherConfig
+	backfillM        *sync.Map
+	queue            chan []string
+	lastM            *sync.Map
+	refreshSymbols   bool
+	lastDailyRunDate int
 }
 
 type FetcherConfig struct {
@@ -65,11 +65,11 @@ func NewBgWorker(conf map[string]interface{}) (bgworker.BgWorker, error) {
 	}
 
 	f := IEXFetcher{
-		backfillM: &sync.Map{},
-		config:    config,
-		queue:     make(chan []string, int(len(config.Symbols)/api.BatchSize)+1),
-		lastM:     &sync.Map{},
-		refreshSymbols: len(config.Symbols) == 0,
+		backfillM:        &sync.Map{},
+		config:           config,
+		queue:            make(chan []string, int(len(config.Symbols)/api.BatchSize)+1),
+		lastM:            &sync.Map{},
+		refreshSymbols:   len(config.Symbols) == 0,
 		lastDailyRunDate: 0,
 	}
 
@@ -118,7 +118,7 @@ func (f *IEXFetcher) Run() {
 	for batch := range f.queue {
 		f.pollIntraday(batch)
 
-		if (onceDaily(&f.lastDailyRunDate, 0, 10)) {
+		if onceDaily(&f.lastDailyRunDate, 0, 10) {
 			f.UpdateSymbolList()
 			f.pollDaily(batch)
 		}
@@ -349,7 +349,7 @@ func limiter() time.Duration {
 func onceDaily(lastDailyRunDate *int, runHour int, runMinute int) bool {
 	now := time.Now()
 
-	if ( *lastDailyRunDate == 0 || ( *lastDailyRunDate != now.Day() && runHour == now.Hour() && runMinute == now.Minute() )) {
+	if *lastDailyRunDate == 0 || (*lastDailyRunDate != now.Day() && runHour == now.Hour() && runMinute == now.Minute()) {
 		*lastDailyRunDate = now.Day()
 		return true
 	} else {


### PR DESCRIPTION
This fix handles the IEX DELAYED_OTC error that can be encountered if you are not authorized for OTC tickers and you happen to request a ticker.  IEX has a bug in that if a symbol is both in OTC and non-OTC, the error condition can still occur.

As IEX does not report the offending symbol(s), this fix works by batching the symbol(s) into smaller batches if this error is encountered, recursively dividing the list until the affected symbol can be weeded out.  The symbol is also added to the blacklist and will not be queried for again.
