### PR TITLE
fix a bug about index for write

### DIFF
--- a/executor/writer.go
+++ b/executor/writer.go
@@ -70,6 +70,7 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte) {
 
 	var (
 		prevIndex int64
+		prevYear  int16
 		cc        *WriteCommand
 		outBuf    []byte
 		rowLen    = len(data) / numRows
@@ -110,6 +111,7 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte) {
 
 		if i == 0 {
 			prevIndex = index
+			prevYear = year
 			cc = &WriteCommand{
 				RecordType: rt,
 				WALKeyPath: wkp,
@@ -118,14 +120,17 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte) {
 				Index:      index,
 				Data:       nil}
 		}
-		if index == prevIndex {
+		// Because index is relative time from the beginning of the year
+		// To confirm that the next data is a different data, both index and year should be checked.
+		// (ex. when writing "2017-02-03 04:05:06" and "2018-02-03 04:05:06", index (02-03 04:05:06) is the same)
+		if index == prevIndex && year == prevYear {
 			/*
 				This is the interior of a multi-row write buffer
 			*/
 			outBuf = formatRecord(outBuf, record, t, index, w.tbi.GetIntervals())
 			cc.Data = outBuf
 		}
-		if index != prevIndex {
+		if index != prevIndex || year != prevYear {
 			/*
 				This row is at a new index, output previous output buffer
 			*/


### PR DESCRIPTION
This PR is to fix the following bug:

write 2 records with the same day&time (ex. 01-02 03:04:05)
```
cli = pymkts.Client(endpoint="http://localhost:5993/rpc")
data = np.array(
    [
        (pd.Timestamp("2017-01-02 03:04:05").value / 10 ** 9, 10.0),
        (pd.Timestamp("2018-01-02 03:04:05").value / 10 ** 9, 20.0),
    ],
    dtype=[("Epoch", "i8"), ("Ask", "f4")],
)
cli.write(data, "TEST_2/1Min/Tick")
```

show data
```
» \show TEST_2/1Min/Tick 1970-01-01
=============================  ==========  
                        Epoch  Ask         
=============================  ==========  
2017-01-02 03:04:00 +0000 UTC    20          
=============================  ========== 
```
Why only 1 record is written!?!??!??!?!
