### PR TITLE
Updated IEX polling to use multiple threads

### DIFF
--- a/contrib/iex/iex.go
+++ b/contrib/iex/iex.go
@@ -367,7 +367,7 @@ func (f *IEXFetcher) workBackfill() {
 					}
 				}()
 			} else {
-				log.Info("skipping backfill [%v|%v]", symbol, timeframe)
+				log.Debug("skipping backfill [%v|%v]", symbol, timeframe)
 			}
 
 			// limit 10 goroutines per CPU core

--- a/contrib/iex/iex.go
+++ b/contrib/iex/iex.go
@@ -168,11 +168,13 @@ func (f *IEXFetcher) pollIntraday(symbols []string) {
 	resp, err := api.GetBars(symbols, oneDay, &limit, 5)
 	if err != nil {
 		log.Error("failed to query intraday bar batch (%v)", err)
+		return
 	}
 	fetched := time.Now()
 
 	if err = f.writeBars(resp, true, false); err != nil {
 		log.Error("failed to write intraday bar batch (%v)", err)
+		return
 	}
 	done := time.Now()
 	log.Debug("Done Batch (fetched: %s, wrote: %s)", done.Sub(fetched).String(), fetched.Sub(start).String())


### PR DESCRIPTION
needed to complete intraday batches within minute timeframe (~10s now)

Also fixes the daily symbol refresh so that it updates the Symbols once a day (as well as Daily bar fetches if configured) and the batch work queue is refreshed from the new symbol list.
