### PR TITLE
add length check to avoid panic

### DIFF
--- a/executor/writer.go
+++ b/executor/writer.go
@@ -299,6 +299,9 @@ func WriteCSM(csm io.ColumnSeriesMap, isVariableLength bool) (err error) {
 				recordType = io.FIXED
 			}
 
+			if len(cs.GetTime()) == 0 {
+				continue
+			}
 			year := int16(cs.GetTime()[0].Year())
 			tbi = io.NewTimeBucketInfo(
 				*tf,


### PR DESCRIPTION
https://github.com/alpacahq/marketstore/compare/master...dakimura:fix/empty-csm-write?expand=1#diff-aa8668e426918b293917b241076b4820L302
`cs.GetTime()[0].Year()` can occur a panic if `cs.GetTime` is empty, and it was happening at a plugin that I am writing (XigniteFeeder Plugin)

This PR is to add a length check to avoid the panic!