### PR TITLE
Add websocket usage in Polygon plugin

### DIFF
--- a/contrib/polygon/README.md
+++ b/contrib/polygon/README.md
@@ -1,10 +1,10 @@
 # Polygon Data Fetcher
 
 This module builds a MarketStore background worker which fetches historical
-price data of US stocks from [Polygon's API](https://polygon.io/).  It runs
+price data of US stocks from [Polygon's WebSockets Clusters](https://polygon.io/sockets).  It runs
 as a goroutine behind the MarketStore process and keeps writing to the disk.
 The module uses both the HTTP interface (to backfill from MarketStore's last
-written record), and the NATS streaming interface (to receive real-time updates).
+written record), and websockets streaming interface (to receive real-time updates).
 
 ## Configuration
 polygon.so comes with the server by default, so you can simply configure it
@@ -17,6 +17,7 @@ data_types | slice of strings | none | List of data types (bars, quotes, trades)
 api_key | string | none | Your polygon api key
 base_url | string | none | The URL to use in the HTTP client
 nats_servers | string | Comma separated list of nats servers to connect to
+ws_servers | string | Comma separated list of websocket servers to connect to
 symbols | slice of strings | none | The symbols to retrieve chart bars for
 
 ### Example
@@ -25,10 +26,10 @@ Add the following to your config file:
 bgworkers:
   - module: polygon.so
     config:
-        api_key: your_api_key
-        base_url: https://api.polygon.io
-        nats_servers: nats://nats1.polygon.io:30401, nats://nats2.polygon.io:30402, nats://nats3.polygon.io:30403
-        symbols:
-          - AAPL
-          - SPY
+      api_key: your_api_key
+      ws_servers: wss://alpaca.socket.polygon.io
+      data_types: ["bars"]
+      symbols:
+        - AAPL
+        - SPY
 ```


### PR DESCRIPTION
Polygon's preferred method of subscribing to streaming services is no longer NATS.  Instead, users should use websockets.  The old readme did not detail how to use websockets, so I added `ws_servers` to the table and updated the example.