### PR TITLE
Bug Fix: historic trades limited to 20k with duplicates

### DIFF
--- a/contrib/polygon/api/api.go
+++ b/contrib/polygon/api/api.go
@@ -176,7 +176,6 @@ func GetHistoricTrades(symbol, date string) (totalTrades *HistoricTrades, err er
 		resp   *http.Response
 		u      *url.URL
 		q      url.Values
-		trades = &HistoricTrades{}
 	)
 
 	for {
@@ -206,6 +205,7 @@ func GetHistoricTrades(symbol, date string) (totalTrades *HistoricTrades, err er
 			return nil, fmt.Errorf("status code %v", resp.StatusCode)
 		}
 
+		trades := &HistoricTrades{}
 		if err = unmarshal(resp, trades); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This bug causes GetHistoricTrades function to limit total trades to 20,000 with a significant number of duplicate trades.

Cause: previously trades variable was declared outside the loop which was being reused for each iteration, hence the bug.

FIx: Declare trades variable inside the loop just before its use.