### PR TITLE
docs(installation): add homebrew section for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ Optionally, you can install the project's included plugins using
 make plugins
 ```
 
+### Homebrew on macOS
+
+You can also install marketstore using the [Homebrew](https://brew.sh)
+package manager for macOS.
+
+```sh
+$ brew tap zjhmale/marketstore
+$ brew install --HEAD marketstore
+```
+
+To upgrade marketstore in the future, use `upgrade` instead of `install`.
+
+Then you are equipped with marketstore service plist also
+
+```sh
+$ brew services start marketstore
+$ brew services stop marketstore
+```
+
 ## Usage
 You can list available commands by running
 ```


### PR DESCRIPTION
Hi, I think homebrew is a proper way for macOS developers to manage software installation and extra plist for launchctl can be embraced via `brew services` for free.

a few issues still need to be addressed after then

* the [homebrew-marketstore](https://github.com/zjhmale/homebrew-marketstore) tap repository can be moved from my personal account to alpacahq account and I'm volunteered to be the maintainer
* the reason why I use `--HEAD` installation here is that the [latest release (v3.2.17)](https://github.com/alpacahq/marketstore/releases/tag/v3.2.17) of marketstore can not really work well with go@1.13.7 or newer, so I created the homebrew formula based on the master branch of the git repository instead of the `tar.gz` release file.