### PR TITLE
fix: bit mex API integration test - panic-able code

### DIFF
--- a/contrib/bitmexfeeder/api/api.go
+++ b/contrib/bitmexfeeder/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -102,7 +103,12 @@ func (c *BitmexClient) GetBuckets(symbol string, from time.Time, binSize string)
 	}
 	defer res.Body.Close()
 	if res.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("status code %v", res.StatusCode)
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("status code %v, response=%v", res.StatusCode, string(body))
 	}
 	err = json.NewDecoder(res.Body).Decode(&resp)
 	if err != nil {

--- a/contrib/bitmexfeeder/api/api_test.go
+++ b/contrib/bitmexfeeder/api/api_test.go
@@ -29,13 +29,13 @@ func TestGetInstruments(t *testing.T) {
 
 func TestGetBucket(t *testing.T) {
 	symbol := "XBTUSD"
-	lastWeek := time.Now().AddDate(0, -1, 0)
-	trades, err := client.GetBuckets(symbol, lastWeek, "1H")
+	startTime := time.Date(2017,1,0,0,0,0,0,time.UTC)
+	trades, err := client.GetBuckets(symbol, startTime, "1H")
 	if err != nil {
 		t.Error(err)
 	}
 	if len(trades) == 0 {
-		t.Errorf("Did not load any trades from GetBucket()")
+		t.Fatalf("Did not load any trades from GetBucket()")
 	}
 	if trades[0].Symbol != symbol {
 		t.Errorf("Did not load trades from correct symbol %s", symbol)


### PR DESCRIPTION
Let me fix the test that is failing on master branch.
- change "Errorf" to "Fatalf" so that the test stops there
- change the "startTime" request parameter to a valid one according to BitMex API spec
- print the error response to the log