### PR TITLE
reduce the number of fp.Sync() calls for a WAL write from 3 to 1

### DIFF
--- a/executor/wal.go
+++ b/executor/wal.go
@@ -282,13 +282,14 @@ func (wf *WALFileType) flushToWAL(tgc *TransactionPipe) (err error) {
 		wf.FilePtr.Write(TG_Serialized)
 		cksum := hash.Sum(nil)
 		wf.FilePtr.Write(cksum) // Checksum
-		wf.FilePtr.Sync()       // Flush the OS buffer
 
 		// WAL Transaction Commit Complete Message
 		TGID := tgc.TGID()
 		wf.WriteTransactionInfo(TGID, WAL, COMMITCOMPLETE)
 		wf.lastCommittedTGID = TGID
 		tgc.NewTGID()
+
+		wf.FilePtr.Sync()       // Flush the OS buffer
 	}
 
 	/*
@@ -537,7 +538,6 @@ func (wf *WALFileType) WriteStatus(FileStatus FileStatusEnum, ReplayState Replay
 }
 func (wf *WALFileType) write(buffer []byte) {
 	wf.FilePtr.Write(buffer)
-	wf.FilePtr.Sync()
 }
 func (wf *WALFileType) WriteTransactionInfo(tid int64, did DestEnum, txnStatus TxnStatusEnum) {
 	buffer := wf.initMessage(TXNINFO)

--- a/go.mod
+++ b/go.mod
@@ -59,4 +59,3 @@ require (
 	gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e
 	gopkg.in/yaml.v2 v2.2.2
 )
-


### PR DESCRIPTION
# WHAT
This pull request makes the response time of `write` operation 2 times faster by reducing the number of `fp.Sync()` calls in WAL write process.

# WHY
The most time-consuming part of a write operation is `fp.Sync()`.
In a write operation, marketstore calls `fp.Sync()` 4 times for the following steps:
[WAL write]
1. [WAL write] write a Transaction Info message with "PREPARING" status to WAL file
1. [WAL write] write a Transaction Group Data message  to WAL file
1. [WAL write] write a Transaction Info message with "COMMIT COMPLETE" status to WAL file
1. [Data write] write the actual data to primary store

One `fp.Sync()` call takes 5-6msec, so it is currently taking 20-24msec for 1 write and it's 80~90% time for the operation.

Of course, we need to `Sync` after WAL write, but we don't need to `Sync` after writing each WAL message (`PREPARING`, `TG Data`, `COMMIT COMPLETE`) because if the application crashes before `COMMIT COMPLETE`, the transaction shouldn't be replayed, so we don't need to ensure the `PREPARING`, `TG Data` messages to be synced before `COMMIT COMPLETE`.

I fixed the implementation and made `fp.Sync()` call only 2 times, 1. after the WAL write, and 2. after the Data write.

Also, I benchmarked the write performance by [a tool I made for marketstore](https://github.com/dakimura/msbench) and it showed that this change makes `write` more than 2 times faster.

master branch: write performance = 25~26msec/write
```
$ msbench --host=localhost:5993 --size=100 --write-num=1 --query-num=0 --limit-from-start=true
timeframe, elapsed_time_per_operation(write/query)
[is_variable_length=False, data_size=100]
1Sec   26.03323ms/write
10Sec  25.82000ms/write
30Sec  25.85944ms/write
1Min   25.73247ms/write
5Min   25.60520ms/write
15Min  25.82590ms/write
30Min  24.22910ms/write
1H     25.17515ms/write
2H     25.49822ms/write
1D     25.21752ms/write
[is_variable_length=True, data_size=100]
1Sec   26.39968ms/write
10Sec  34.39892ms/write
30Sec  26.12972ms/write
1Min   26.20550ms/write
5Min   26.27398ms/write
15Min  26.34412ms/write
30Min  26.38386ms/write
1H     25.86794ms/write
2H     25.73405ms/write
1D     25.74991ms/write
```
This branch: write performance = 10~11msec/write
```
$ msbench --host=localhost:5993 --size=100 --write-num=1 --query-num=0 --limit-from-start=true
timeframe, elapsed_time_per_operation(write/query)
[is_variable_length=False, data_size=100]
1Sec   11.52957ms/write
10Sec  11.51535ms/write
30Sec  11.57577ms/write
1Min   11.11706ms/write
5Min   11.37738ms/write
15Min  11.46368ms/write
30Min  11.52337ms/write
1H     11.13867ms/write
2H     11.16781ms/write
1D     10.27581ms/write
[is_variable_length=True, data_size=100]
1Sec   12.41966ms/write
10Sec  11.97842ms/write
30Sec  11.89474ms/write
1Min   11.88117ms/write
5Min   11.91017ms/write
15Min  11.89669ms/write
30Min  11.77163ms/write
1H     11.40563ms/write
2H     11.51004ms/write
1D     11.51109ms/write
```