### PR TITLE
fix: update circleCI version from 2.0 to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,6 @@ executors:
     working_directory: ~/github.com/alpacahq/marketstore
     docker:
       - image: circleci/golang:1.12.6
-        environment:
-          GOFLAGS: -mod=vendor
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,22 @@
-version: 2
-jobs:
-  build:
+version: 2.1
+
+executors:
+  golang:
+    working_directory: ~/github.com/alpacahq/marketstore
     docker:
       - image: circleci/golang:1.12.6
+        environment:
+          GOFLAGS: -mod=vendor
 
-    working_directory: ~/github.com/alpacahq/marketstore
+jobs:
+  build:
+    executor: golang
     steps:
       - checkout
       - run: make all plugins
 
   test:
-    docker:
-      - image: circleci/golang:1.12.6
-
-    working_directory: ~/github.com/alpacahq/marketstore
+    executor: golang
     steps:
       - checkout
       - setup_remote_docker
@@ -23,10 +26,7 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash)
   deploy:
-    docker:
-      - image: circleci/golang:1.12.6
-
-    working_directory: ~/github.com/alpacahq/marketstore
+    executor: golang
     steps:
       - checkout
       - setup_remote_docker

--- a/go.mod
+++ b/go.mod
@@ -59,4 +59,3 @@ require (
 	gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e
 	gopkg.in/yaml.v2 v2.2.2
 )
-


### PR DESCRIPTION
- WHAT
update circle CI version from 2.0 to 2.1.

- WHY
We can get many benefits by using the new features of Circle CI 2.1.
https://circleci.com/docs/ja/2.0/configuration-reference/#version-1

For just an example, I defined `executors` and reused the image definition in jobs.