### PR TITLE
fix: parallelize build and unit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,15 +13,21 @@ jobs:
       - checkout
       - run: make build plugins
 
-  test:
+  unit-test:
     executor: golang
     steps:
-      - setup_remote_docker
-      - run: make unittest
+      - run: make unit-test
       - run:
           name: Upload coverages to codecov
           command: |
             bash <(curl -s https://codecov.io/bash)
+
+  integration-test:
+    executor: golang
+    steps:
+      - setup_remote_docker
+      - run: make integration-test
+
   deploy:
     executor: golang
     steps:
@@ -43,7 +49,13 @@ workflows:
                 paths:
                   # reuse the built binary at test job
                   - marketstore
-      - test:
+      - unit-test:
+          pre-steps:
+            - checkout
+          filters:
+            tags:
+              only: /.*/
+      - integration-test:
           requires:
             - build
           pre-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,8 @@ workflows:
       - deploy:
           requires:
             - build
-            - test
+            - unit-test
+            - integration-test
           filters:
             tags:
               only: /.*/

--- a/Makefile
+++ b/Makefile
@@ -40,16 +40,16 @@ plugins:
 	$(MAKE) -C contrib/iex
 	$(MAKE) -C contrib/xignitefeeder
 
-unittest:
+unit-test:
 	GOFLAGS=$(GOFLAGS) go fmt ./...
 	$(MAKE) coverage
-	$(MAKE) integration-test
 
 integration-test:
 	$(MAKE) -C tests/integ test
 
-test:
-	GOFLAGS=$(GOFLAGS) go test ./...
+test: build
+	$(MAKE) unit-test
+	$(MAKE) integration-test
 
 coverage:
 	# marketstore/contrib/stream/shelf/shelf_test.go fails if "-race" enabled...


### PR DESCRIPTION
WHAT and WHY:
improve the build time by parallelizing unit-test and build processes.

