### PR TITLE
fix: catch sigterm signal

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -77,7 +77,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 			case syscall.SIGINT:
 				fallthrough
 			case syscall.SIGTERM:
-				log.Info("initiating graceful shutdown due to %v request", s)
+				log.Info("initiating graceful shutdown due to '%v' request", s)
 				atomic.StoreUint32(&frontend.Queryable, uint32(0))
 				log.Info("waiting a grace period of %v to shutdown...", utils.InstanceConfig.StopGracePeriod)
 				time.Sleep(utils.InstanceConfig.StopGracePeriod)
@@ -85,8 +85,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}()
-	signal.Notify(signalChan, syscall.SIGUSR1)
-	signal.Notify(signalChan, syscall.SIGINT)
+	signal.Notify(signalChan, syscall.SIGUSR1, syscall.SIGINT, syscall.SIGTERM)
 
 	// Initialize marketstore services.
 	// --------------------------------

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -75,7 +75,9 @@ func executeStart(cmd *cobra.Command, args []string) error {
 				log.Info("dumping stack traces due to SIGUSR1 request")
 				pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 			case syscall.SIGINT:
-				log.Info("initiating graceful shutdown due to SIGINT request")
+				fallthrough
+			case syscall.SIGTERM:
+				log.Info("initiating graceful shutdown due to %v request", s)
 				atomic.StoreUint32(&frontend.Queryable, uint32(0))
 				log.Info("waiting a grace period of %v to shutdown...", utils.InstanceConfig.StopGracePeriod)
 				time.Sleep(utils.InstanceConfig.StopGracePeriod)


### PR DESCRIPTION
start marketstore ->
```
$ kill `pgrep marketstore`
```

The default signal sent is SIGTERM (c.f. [Wikipedia](https://en.wikipedia.org/wiki/Kill_(command)) )
->
```
{"level":"info","timestamp":"2020-03-29T12:39:58.496+0900","msg":"initiating graceful shutdown due to 'terminated' request"}
```