### PR TITLE
CI speed improvement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
     executor: golang
     steps:
       - setup_remote_docker
-          docker_layer_caching: true
       - run: make integration-test
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,16 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash)
 
+  import-csv-test:
+    executor: golang
+    steps:
+      - run: make import-csv-test
+
   integration-test:
     executor: golang
     steps:
       - setup_remote_docker
+          docker_layer_caching: true
       - run: make integration-test
 
   deploy:
@@ -65,13 +71,19 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - integration-test:
+      - import-csv-test:
           requires:
             - build
           pre-steps:
             - checkout
             - attach_workspace:
                 at: ~/github.com/alpacahq/marketstore
+          filters:
+            tags:
+              only: /.*/
+      - integration-test:
+          pre-steps:
+            - checkout
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,13 @@ jobs:
     executor: golang
     steps:
       - checkout
-      - run: make build plugins
+      - run: make build
+
+  plugins:
+    executor: golang
+    steps:
+      - checkout
+      - run: make plugins
 
   unit-test:
     executor: golang
@@ -49,6 +55,10 @@ workflows:
                 paths:
                   # reuse the built binary at test job
                   - marketstore
+      - plugins:
+          filters:
+            tags:
+              only: /.*/
       - unit-test:
           pre-steps:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,13 @@ executors:
     docker:
       - image: circleci/golang:1.12.6
 
+variables:
+  - filters: &all
+      branches:
+        only: /.*/
+      tags:
+        only: /.*/
+
 jobs:
   build:
     executor: golang
@@ -51,9 +58,7 @@ workflows:
   build_test_deploy:
     jobs:
       - build:
-          filters:
-            tags:
-              only: /.*/
+          filters: *all
           post-steps:
             - persist_to_workspace:
                 root: ~/github.com/alpacahq/marketstore
@@ -61,15 +66,11 @@ workflows:
                   # reuse the built binary at test job
                   - marketstore
       - plugins:
-          filters:
-            tags:
-              only: /.*/
+          filters: *all
       - unit-test:
           pre-steps:
             - checkout
-          filters:
-            tags:
-              only: /.*/
+          filters: *all
       - import-csv-test:
           requires:
             - build
@@ -77,15 +78,11 @@ workflows:
             - checkout
             - attach_workspace:
                 at: ~/github.com/alpacahq/marketstore
-          filters:
-            tags:
-              only: /.*/
+          filters: *all
       - integration-test:
           pre-steps:
             - checkout
-          filters:
-            tags:
-              only: /.*/
+          filters: *all
       - deploy:
           requires:
             - build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,14 @@
 #
 FROM golang:1.13.0-buster as builder
 ARG tag=latest
+ARG INCLUDE_PLUGINS=true
 ENV DOCKER_TAG=$tag
 ENV GOPATH=/go
 
 WORKDIR /go/src/github.com/alpacahq/marketstore/
 ADD ./ ./
 RUN make vendor
-RUN make build plugins
+RUN if [ "$INCLUDE_PLUGINS" = "true" ] ; then make build plugins ; else make build ; fi
 
 #
 # STAGE 2
@@ -23,8 +24,8 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates tzdata libc6-compat
 WORKDIR /
 COPY --from=builder /go/src/github.com/alpacahq/marketstore/marketstore /bin/
-COPY --from=builder /go/bin/polygon_backfiller /bin/
-COPY --from=builder /go/bin/*.so /bin/
+# copy plugins if any
+COPY --from=builder /go/bin /bin/
 ENV GOPATH=/
 
 RUN ["marketstore", "init"]

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,15 @@ unit-test:
 	# GOFLAGS=$(GOFLAGS) go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 	GOFLAGS=$(GOFLAGS) go test -coverprofile=coverage.txt -covermode=atomic ./...
 
+import-csv-test:
+	@tests/integ/bin/runtests.sh
+
 integration-test:
 	$(MAKE) -C tests/integ test
 
 test: build
 	$(MAKE) unit-test
+	$(MAKE) import-csv-test
 	$(MAKE) integration-test
 
 image:

--- a/tests/integ/Makefile
+++ b/tests/integ/Makefile
@@ -4,8 +4,6 @@
 
 IMAGE_NAME ?= alpacahq/integrationtests.marketstore
 CONTAINER_NAME = integration_tests_mstore
-MARKETSTORE_DEV_DB_URL = https://s3.amazonaws.com/dev.alpaca.markets/gobroker/mktsdb.tar.gz
-MARKETSTORE_DEV_DB_TMPFILE = /tmp/mktsdb.tgz
 
 # User targets
 ################################################################################
@@ -28,7 +26,7 @@ connect: run
 	fi
 
 .PHONY: run
-run: _init
+run: build_mstore
 	@if [ `bin/check_running ${CONTAINER_NAME}` -eq 0 ]; then \
 		$(MAKE) _startup; \
 	fi
@@ -46,21 +44,6 @@ clean: stop
 
 # Utils
 ################################################################################
-.PHONY: _init
-_init: build_mstore
-	@if [ ! -d data/mktsdb ]; then \
-		rm -rf data; \
-		$(MAKE) _get_data; \
-	fi
-
-.PHONY: _get_data
-_get_data:
-	@rm -rf data && mkdir data
-	@if [ ! -f ${MARKETSTORE_DEV_DB_TMPFILE} ]; then \
-		wget ${MARKETSTORE_DEV_DB_URL} -O ${MARKETSTORE_DEV_DB_TMPFILE}; \
-	fi
-	@tar -C data -xzf ${MARKETSTORE_DEV_DB_TMPFILE}
-
 .PHONY: _startup
 _startup: stop
 	@echo "Starting a marketstore instance..."
@@ -70,6 +53,7 @@ _startup: stop
 	# https://discuss.circleci.com/t/why-circleci-2-0-does-not-support-mounting-folders/11605
 	docker create --name ${CONTAINER_NAME} -p 5993:5993 -w /project  $(IMAGE_NAME) start --config /project/bin/mkts.yml
 	docker cp $(CURDIR)/bin ${CONTAINER_NAME}:/project/
+	@rm -rf data && mkdir -p data/mktsdb
 	docker cp $(CURDIR)/data ${CONTAINER_NAME}:/project/
 	docker start ${CONTAINER_NAME}
 
@@ -86,12 +70,8 @@ _startup: stop
 _start_pyclient_container:
 	make -C dockerfiles/pyclient rm build run
 
-.PHONY: test_import_csv
-test_import_csv:
-	@bin/runtests.sh
-
 # run all tests including CSV Import
 .PHONY: test
-test: test_import_csv clean run _start_pyclient_container connect
+test: clean run _start_pyclient_container connect
 	TEST_FILENAME='/project/tests/$@.py'; \
 	make -C dockerfiles/pyclient test

--- a/tests/integ/Makefile
+++ b/tests/integ/Makefile
@@ -10,7 +10,7 @@ CONTAINER_NAME = integration_tests_mstore
 
 # build marketstore docker container for integration test
 build_mstore:
-	docker build -t ${IMAGE_NAME} ../..
+	docker build -t ${IMAGE_NAME} --build-arg INCLUDE_PLUGINS=false ../..
 
 # start a marketstore docker container and check if ListSymbols API can be consumed
 .PHONY: connect

--- a/tests/integ/bin/runtests.sh
+++ b/tests/integ/bin/runtests.sh
@@ -10,7 +10,7 @@ function exit_if_failed()
 }
 
 # init data
-rm -rf testdata test_ticks.csv && mkdir -p testdata/mktsdb
+rm -rf tests/integ/testdata test_ticks.csv && mkdir -p tests/integ/testdata/mktsdb
 if [ $? -ne 0 ]; then \
     echo "Failed: cannot delete testdata and make testdata/mktsdb directory"
     exit 1;
@@ -18,16 +18,16 @@ fi
 
 
 # import ticks-example-1.csv/yaml to TEST/1Min/TICK and check if the output of show commands match ticks-example-1-output.csv
-../../marketstore connect -d `pwd`/testdata/mktsdb <<- EOF
+./marketstore connect -d `pwd`/tests/integ/testdata/mktsdb <<- EOF
 \create TEST/24H/TICK:Symbol/Timeframe/AttributeGroup Bid,Ask/float32 variable
 \getinfo TEST/24H/TICK
-\load TEST/24H/TICK bin/ticks-example-1.csv bin/ticks-example-1.yaml
+\load TEST/24H/TICK tests/integ/bin/ticks-example-1.csv tests/integ/bin/ticks-example-1.yaml
 \o test_ticks.csv
 \show TEST/24H/TICK 1970-01-01
 EOF
 exit_if_failed $?
 
-diff -q bin/ticks-example-1-output-24H.csv test_ticks.csv && echo "Passed"
+diff -q tests/integ/bin/ticks-example-1-output-24H.csv test_ticks.csv && echo "Passed"
 exit_if_failed $?
 
 rm -f test_ticks.csv
@@ -35,15 +35,15 @@ exit_if_failed $?
 
 
 # import ticks-example-2.csv/yaml to TEST2/1Min/TICK and check if the output of show commands match ticks-example-2-output.csv
-../../marketstore connect -d `pwd`/testdata/mktsdb <<- EOF
+./marketstore connect -d `pwd`/tests/integ/testdata/mktsdb <<- EOF
 \create TEST2/1Min/TICK:Symbol/Timeframe/AttributeGroup Bid,Ask/float32 variable
-\load TEST2/1Min/TICK bin/ticks-example-2.csv bin/ticks-example-2.yaml
+\load TEST2/1Min/TICK tests/integ/bin/ticks-example-2.csv tests/integ/bin/ticks-example-2.yaml
 \o test_ticks.csv
 \show TEST2/1Min/TICK 1970-01-01
 EOF
 exit_if_failed $?
 
-diff -q bin/ticks-example-2-output.csv test_ticks.csv && echo "Passed"
+diff -q tests/integ/bin/ticks-example-2-output.csv test_ticks.csv && echo "Passed"
 exit_if_failed $?
 
 rm -f test_ticks.csv
@@ -52,14 +52,14 @@ exit_if_failed $?
 
 # import ticks-example-1.csv/yaml to TEST/1Min/TICK
 # and check if the output of show commands match ticks-example-1-output.csv + ticks-example-2-output.csv
-../../marketstore connect -d `pwd`/testdata/mktsdb <<- EOF
-\load TEST2/1Min/TICK bin/ticks-example-1.csv bin/ticks-example-1.yaml
+./marketstore connect -d `pwd`/tests/integ/testdata/mktsdb <<- EOF
+\load TEST2/1Min/TICK tests/integ/bin/ticks-example-1.csv tests/integ/bin/ticks-example-1.yaml
 \o test_ticks.csv
 \show TEST2/1Min/TICK 1970-01-01
 EOF
 exit_if_failed $?
 
-cat bin/ticks-example-1-output.csv bin/ticks-example-2-output.csv > tmp.csv
+cat tests/integ/bin/ticks-example-1-output.csv tests/integ/bin/ticks-example-2-output.csv > tmp.csv
 diff -q tmp.csv test_ticks.csv && echo "Passed"
 exit_if_failed $?
 
@@ -69,16 +69,16 @@ exit_if_failed $?
 
 # import ticks-example-not-sorted-by-time.csv/yaml to TEST/1Min/TICK
 # and check if the output of show commands match ticks-example-not-sorted-by-time-output.csv
-../../marketstore connect -d `pwd`/testdata/mktsdb <<- EOF
+./marketstore connect -d `pwd`/tests/integ/testdata/mktsdb <<- EOF
 \create TEST3/1Min/TICK:Symbol/Timeframe/AttributeGroup Bid,Ask/float32 variable
 \getinfo TEST3/1Min/TICK
-\load TEST3/1Min/TICK bin/ticks-example-not-sorted-by-time.csv bin/ticks-example-not-sorted-by-time.yaml
+\load TEST3/1Min/TICK tests/integ/bin/ticks-example-not-sorted-by-time.csv tests/integ/bin/ticks-example-not-sorted-by-time.yaml
 \o test_ticks.csv
 \show TEST3/1Min/TICK 1970-01-01
 EOF
 exit_if_failed $?
 
-diff -q bin/ticks-example-not-sorted-by-time-output.csv test_ticks.csv && echo "Passed"
+diff -q tests/integ/bin/ticks-example-not-sorted-by-time-output.csv test_ticks.csv && echo "Passed"
 exit_if_failed $?
 
 # remove the temporary files

--- a/tests/integ/dockerfiles/pyclient/Makefile
+++ b/tests/integ/dockerfiles/pyclient/Makefile
@@ -6,7 +6,6 @@ DOCKER_ADDOPTS=	-v $(CURDIR)/../../tests:/project/tests \
 	--net=host \
 
 
-
 test:
 	docker exec $(CONTAINER_NAME) bash -c \
 		"pytest -v -v -v $(TEST_FILENAME)"


### PR DESCRIPTION
[WHAT]
- make the build of marketstore and its plugins parallel
- make the CSV import test and other integration tests parallel
- don't include plugins in the docker container for the integration tests
- remove unused test data
- use Circle CI variables for filters

[WHY]
- to make CI fast
