### PR TITLE
Fix polygon database schema difference

### DIFF
--- a/contrib/polygon/handlers/handlers.go
+++ b/contrib/polygon/handlers/handlers.go
@@ -133,6 +133,7 @@ func BarsHandler(msg []byte) {
 		cs.AddColumn("Low", []float32{float32(bar.Low)})
 		cs.AddColumn("Close", []float32{float32(bar.Close)})
 		cs.AddColumn("Volume", []int32{int32(bar.Volume)})
+		cs.AddColumn("TickCnt", []int32{int32(0)})
 		csm.AddColumnSeries(*tbk, cs)
 
 		if err := executor.WriteCSM(csm, false); err != nil {


### PR DESCRIPTION
* Fix for the following error:
```{"level":"error","timestamp":"2020-04-24T13:34:04.109Z","msg":"[polygon] csm write failure for key: [BTU/1Min/OHLCV:Symbol/Timeframe/AttributeGroup] (unable to match data columns ([{Epoch INT64} {Open FLOAT32} {High FLOAT32} {Low FLOAT32} {Close FLOAT32} {Volume INT32}]) to bucket columns ([{Epoch INT64} {Open FLOAT32} {High FLOAT32} {Low FLOAT32} {Close FLOAT32} {Volume INT32} {TickCnt INT32}]))"}```