### PR TITLE
Document how to bind-mount a mkt.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ docker run --mount type=bind,source="/full/path/to/ms_etc/",target="/etc" \
 ```
 This allows you to easily test out the image [included
 plugins](https://github.com/alpacahq/marketstore/tree/master/plugins#included) with ease.
+**Note that** this will override the container's `/etc/` related
+networking files (such as `hosts`, `hostname` and `resolv.conf`) with
+your host's local directory which may cause problems if deploying
+`marketstore` in the wild in which case use the copying method from above.
+
+By default the container will not persist any written data to your
+container's host storage. To accomplish this, bind the `data` directory to
+a local location:
+```sh
+docker run -i -p 5993:5993 alpacamarkets/marketstore:latest \
+  --mount type=bind,source="/<path_to_data>/marketstore",target="/data"
+```
+Once data is written to the server you should see a file tree layout
+like the following that will persist across container runs:
+```sh
+>>> tree /<path_to_data>/marketstore
+/<path_to_data>/marketstore
+├── category_name
+├── WALFile.1590868038674814776.walfile
+├── SYMBOL_1
+├── SYMBOL_2
+├── SYMBOL_3
+```
 
 If you have built the
 [cmd](https://github.com/alpacahq/marketstore/tree/master/cmd) package

--- a/README.md
+++ b/README.md
@@ -22,19 +22,35 @@ MarketStore is production ready! At [Alpaca](https://alpaca.markets) it has been
 
 ### Docker
 If you want to get started right away, you can bootstrap a marketstore db instance using our latest [docker image](https://hub.docker.com/r/alpacamarkets/marketstore/tags/). The image comes pre-loaded with the default mkts.yml file and declares the VOLUME `/data`, as its root directory. To run the container with the defaults:
-``` sh
+```sh
 docker run -i -p 5993:5993 alpacamarkets/marketstore:latest
 ```
 
-If you want to run a custom `mkts.yml` with your instance, you can create a new container, load your mkts.yml file into it, then run it.
-``` sh
+If you want to run a custom `mkts.yml` you can create a new container
+and load your mkts.yml file into it:
+```sh
 docker create --name mktsdb -p 5993:5993 alpacamarkets/marketstore:latest
 docker cp mkts.yml mktsdb:/etc/mkts.yml
 docker start -i mktsdb
 ```
 
-Open a session with your running docker instance using
-``` sh
+You can also [bind mount](https://docs.docker.com/storage/bind-mounts/)
+the container to a local host directory where you've placed your custom
+`mkts.yml`:
+
+```sh
+mkdir ms_etc/
+mv /path/to/mkts.yml ./ms_etc/
+docker run --mount type=bind,source="/full/path/to/ms_etc/",target="/etc" \
+  -i -p 5993:5993 alpacamarkets/marketstore:latest
+```
+This allows you to easily test out the image [included
+plugins](https://github.com/alpacahq/marketstore/tree/master/plugins#included) with ease.
+
+If you have built the
+[cmd](https://github.com/alpacahq/marketstore/tree/master/cmd) package
+locally, you can open a session with your running docker instance using:
+```sh
 marketstore connect --url localhost:5993
 ```
 
@@ -159,7 +175,7 @@ After starting up a MarketStore instance on your machine, you're all set to be a
 [pymarketstore](https://github.com/alpacahq/pymarketstore) is the standard
 python client. Make sure that in another terminal, you have marketstore running
 * query data
-```py
+```python
 import pymarketstore as pymkts
 param = pymkts.Params('BTC', '1Min', 'OHLCV', limit=10)
 cli = pymkts.Client()
@@ -167,7 +183,7 @@ reply = cli.query(param)
 reply.first().df()
 ```
 shows
-```
+```python
 Out[5]:
                                Open      High       Low     Close     Volume
 Epoch
@@ -183,7 +199,7 @@ Epoch
 2018-01-17 17:28:00+00:00  10124.95  10142.39  10124.94  10142.39   2.262249
 ```
 * write data
-```py
+```python
 import numpy as np
 import pandas as pd
 data = np.array([(pd.Timestamp('2017-01-01 00:00').value / 10**9, 10.0)], dtype=[('Epoch', 'i8'), ('Ask', 'f4')])
@@ -193,7 +209,7 @@ cli.write(data, 'TEST/1Min/Tick')
 cli.query(pymkts.Params('TEST', '1Min', 'Tick')).first().df()
 ```
 shows
-```
+```python
                             Ask
 Epoch
 2017-01-01 00:00:00+00:00  10.0

--- a/README.md
+++ b/README.md
@@ -35,28 +35,19 @@ docker start -i mktsdb
 ```
 
 You can also [bind mount](https://docs.docker.com/storage/bind-mounts/)
-the container to a local host directory where you've placed your custom
-`mkts.yml`:
-
+the container to a local host config file: a custom `mkts.yml`:
 ```sh
-mkdir ms_etc/
-mv /path/to/mkts.yml ./ms_etc/
-docker run --mount type=bind,source="/full/path/to/ms_etc/",target="/etc" \
-  -i -p 5993:5993 alpacamarkets/marketstore:latest
+docker run -v /full/path/to/mkts.yml:/etc/mkts.yml -i -p 5993:5993 alpacamarkets/marketstore:latest
 ```
-This allows you to easily test out the image [included
-plugins](https://github.com/alpacahq/marketstore/tree/master/plugins#included) with ease.
-**Note that** this will override the container's `/etc/` related
-networking files (such as `hosts`, `hostname` and `resolv.conf`) with
-your host's local directory which may cause problems if deploying
-`marketstore` in the wild in which case use the copying method from above.
+This allows you to test out the image [included
+plugins](https://github.com/alpacahq/marketstore/tree/master/plugins#included)
+with ease if you prefer to skip the copying step suggested above.
 
 By default the container will not persist any written data to your
 container's host storage. To accomplish this, bind the `data` directory to
 a local location:
 ```sh
-docker run -i -p 5993:5993 alpacamarkets/marketstore:latest \
-  --mount type=bind,source="/<path_to_data>/marketstore",target="/data"
+docker run -v "/path/to/store/data:/data" -i -p 5993:5993 alpacamarkets/marketstore:latest
 ```
 Once data is written to the server you should see a file tree layout
 like the following that will persist across container runs:


### PR DESCRIPTION
Document how to bind-mount in a `mkts.yml` config for quick testing of
the image included plugins. Fix the python blocks so they highlight
correctly. Mention that you have to build the `cmd` package before using
the `connect` command.