### PR TITLE
fix: trigger grpcServer.GracefulStop when interrupted

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -71,7 +71,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to parse configuration file error: %v", err.Error())
 	}
 
-	// Add grpc middleware for logging and metrics collection.
+	// New grpc server.
 	grpcServer := grpc.NewServer()
 	proto.RegisterMarketstoreServer(grpcServer, frontend.GRPCService{})
 

--- a/tests/integ/dockerfiles/pyclient/requirements.txt
+++ b/tests/integ/dockerfiles/pyclient/requirements.txt
@@ -1,2 +1,2 @@
 pytest==3.6.1
-git+https://github.com/alpacahq/pymarketstore.git@c3d553fdac90f627524b8c5940328bc79c4330cf#egg=pymarketstore
+git+https://github.com/alpacahq/pymarketstore.git@e3e63301026a7e771ae82d8c691b25aac3a63067#egg=pymarketstore

--- a/tests/integ/dockerfiles/pyclient/requirements.txt
+++ b/tests/integ/dockerfiles/pyclient/requirements.txt
@@ -1,2 +1,2 @@
 pytest==3.6.1
-git+https://github.com/alpacahq/pymarketstore.git@e3e63301026a7e771ae82d8c691b25aac3a63067#egg=pymarketstore
+git+https://github.com/alpacahq/pymarketstore.git@812104a6254b889b5c50a4744b88950384e28180#egg=pymarketstore


### PR DESCRIPTION
WHAT:
always trigger grpcServer.GracefulStop when interrupted

WHY:
when I stop marketstore by Ctrl+C , sometimes grpc port is not closed and I can't restart it for "address already used" error