### PR TITLE
Fix: Add ca-certificates to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ RUN if [ "$INCLUDE_PLUGINS" = "true" ] ; then make build plugins ; else make bui
 #
 FROM debian:10.3
 WORKDIR /
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /go/src/github.com/alpacahq/marketstore/marketstore /bin/
 # copy plugins if any
 COPY --from=builder /go/bin /bin/


### PR DESCRIPTION
The current marketstore version does not contain ca-certificates package
pre-installed, thus the backfill process fails:
```
{"level":"warn","timestamp":"2020-06-07T17:57:59.296Z","msg":"[polygon] failed to backfill bars for NUGY @ 2020-01-31 00:00:00 +0000 UTC (Get \"https://api.polygon.io/v2/ticks/stocks/trades/NUGY/2020-01-31?apiKey=xyz&limit=50000\": x509: certificate signed by unknown authority)"}
```