### PR TITLE
Make polygon db schema configurable

### DIFF
--- a/contrib/polygon/handlers/handlers.go
+++ b/contrib/polygon/handlers/handlers.go
@@ -108,7 +108,13 @@ func QuoteHandler(msg []byte) {
 	metrics.PolygonStreamLastUpdate.WithLabelValues("quote").SetToCurrentTime()
 }
 
-func BarsHandler(msg []byte) {
+func BarsHandlerWrapper(addTickCount bool) func([]byte) {
+	return func(msg []byte) {
+		BarsHandler(msg, addTickCount)
+	}
+}
+
+func BarsHandler(msg []byte, addTickCount bool) {
 	if msg == nil {
 		return
 	}
@@ -138,7 +144,9 @@ func BarsHandler(msg []byte) {
 		cs.AddColumn("Low", []float32{float32(bar.Low)})
 		cs.AddColumn("Close", []float32{float32(bar.Close)})
 		cs.AddColumn("Volume", []int32{int32(bar.Volume)})
-		cs.AddColumn("TickCnt", []int32{int32(0)})
+		if addTickCount {
+			cs.AddColumn("TickCnt", []int32{int32(0)})
+		}
 		csm.AddColumnSeries(*tbk, cs)
 
 		if err := executor.WriteCSM(csm, false); err != nil {

--- a/contrib/polygon/polygon.go
+++ b/contrib/polygon/polygon.go
@@ -24,6 +24,8 @@ type PolygonFetcher struct {
 }
 
 type FetcherConfig struct {
+	// AddTickCountToBars controls if TickCnt is added to the schema for Bars or not
+	AddTickCountToBars bool `json:"add_bar_tick_count,omitempty"`
 	// polygon API key for authenticating with their APIs
 	APIKey string `json:"api_key"`
 	// polygon API base URL in case it is being proxied
@@ -94,7 +96,7 @@ func (pf *PolygonFetcher) Run() {
 		switch t {
 		case "bars":
 			prefix = api.Agg
-			handler = handlers.BarsHandler
+			handler = handlers.BarsHandlerWrapper(pf.config.AddTickCountToBars)
 		case "quotes":
 			prefix = api.Quote
 			handler = handlers.QuoteHandler

--- a/tests/integ/tests/test_grpc.py
+++ b/tests/integ/tests/test_grpc.py
@@ -2,6 +2,7 @@
 Integration Test for GRPC client
 """
 import pytest
+import time
 
 import numpy as np
 import pandas as pd
@@ -142,6 +143,8 @@ def test_grpc_query_all_symbols():
     client.write(data, tbk)
     client.write(data2, tbk2)
     client.write(data3, tbk3)
+
+    time.sleep(0.5)
 
     # --- query all symbols using * ---
     resp = client.query(pymkts.Params("*", timeframe, attribute, limit=2, ))


### PR DESCRIPTION
Polygon SIP and Polygon Polyfeed database schemas are different. SIP does not contain TickCnt for bars while Polyfeed does. This change allows us to use the same image for both.

Relates to: #313 Fix polygon database schema difference