### PR TITLE
fix: build and version information for --version parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 GOFLAGS=""
 GOPATH0 := $(firstword $(subst :, ,$(GOPATH)))
-UTIL_PATH := github.com/alpacahq/marketstore/utils
+UTIL_PATH := github.com/alpacahq/marketstore/v4/utils
 
 build:
 	GOFLAGS=$(GOFLAGS) go build -ldflags "-s -X $(UTIL_PATH).Tag=$(DOCKER_TAG) -X $(UTIL_PATH).BuildStamp=$(shell date -u +%Y-%m-%d-%H-%M-%S) -X $(UTIL_PATH).GitHash=$(shell git rev-parse HEAD)" .


### PR DESCRIPTION
The freshly built image does not output version information:
```sh
root@ae18fa7238c1:/# marketstore --version
{"level":"info","timestamp":"2020-06-12T10:04:10.050Z","msg":"Running single threaded"}
version:
commit hash:
utc build time:
```

With this fix:
```sh
root@eafef63756c8:/# marketstore --version
{"level":"info","timestamp":"2020-06-12T10:05:00.162Z","msg":"Running single threaded"}
version: latest
commit hash: ba8dd4ea082e78ee571c54d9a5bf9e70d3b29fbd
utc build time: 2020-06-12-10-00-06
```