### PR TITLE
fix: follow polygon REST api change on backfilling bars

### DIFF
--- a/contrib/polygon/api/api.go
+++ b/contrib/polygon/api/api.go
@@ -27,10 +27,11 @@ const (
 )
 
 var (
-	baseURL = "https://api.polygon.io"
-	servers = "ws://socket.polygon.io:30328" // default
-	apiKey  string
-	NY, _   = time.LoadLocation("America/New_York")
+	baseURL      = "https://api.polygon.io"
+	servers      = "wss://socket.polygon.io"
+	apiKey       string
+	NY, _        = time.LoadLocation("America/New_York")
+	completeDate = "2006-01-02"
 )
 
 type GetAggregatesResponse struct {
@@ -168,7 +169,7 @@ func GetHistoricAggregates(
 	limit *int) (*HistoricAggregates, error) {
 	// FIXME: This function does not handle pagination
 
-	u, err := url.Parse(fmt.Sprintf(aggURL, baseURL, ticker, multiplier, timespan, from.Format(time.CompleteDate), to.Format(time.CompleteDate)))
+	u, err := url.Parse(fmt.Sprintf(aggURL, baseURL, ticker, multiplier, timespan, from.Format(completeDate), to.Format(completeDate)))
 	if err != nil {
 		return nil, err
 	}

--- a/contrib/polygon/api/api.go
+++ b/contrib/polygon/api/api.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	aggURL     = "%v/v1/historic/agg/%v/%v"
+	aggURL     = "%v/v2/aggs/ticker/%v/range/%v/%v/%v/%v"
 	tradesURL  = "%v/v2/ticks/stocks/trades/%v/%v"
 	quotesURL  = "%v/v1/historic/quotes/%v/%v"
 	tickersURL = "%v/v2/reference/tickers"
@@ -158,31 +158,23 @@ func ListTickers() (*ListTickersResponse, error) {
 	return &resp, nil
 }
 
-// GetHistoricAggregates requests polygon's REST API for historic aggregates
-// for the provided resolution based on the provided query parameters.
+// GetHistoricAggregates requests polygon's REST API for aggregates
+// for the provided resolution based on the provided parameters.
 func GetHistoricAggregates(
-	symbol,
-	resolution string,
+	ticker,
+	timespan string,
+	multiplier int,
 	from, to time.Time,
 	limit *int) (*HistoricAggregates, error) {
-	// FIXME: Move this to Polygon API v2
 	// FIXME: This function does not handle pagination
 
-	u, err := url.Parse(fmt.Sprintf(aggURL, baseURL, resolution, symbol))
+	u, err := url.Parse(fmt.Sprintf(aggURL, baseURL, ticker, multiplier, timespan, from.Format(time.CompleteDate), to.Format(time.CompleteDate)))
 	if err != nil {
 		return nil, err
 	}
 
 	q := u.Query()
 	q.Set("apiKey", apiKey)
-
-	if !from.IsZero() {
-		q.Set("from", from.Format(time.RFC3339))
-	}
-
-	if !to.IsZero() {
-		q.Set("to", to.Format(time.RFC3339))
-	}
 
 	if limit != nil {
 		q.Set("limit", strconv.FormatInt(int64(*limit), 10))

--- a/contrib/polygon/api/schema.go
+++ b/contrib/polygon/api/schema.go
@@ -82,28 +82,24 @@ Historical data
 // HistoricAggregates is the structure that defines
 // aggregate data served through polygon's REST API.
 type HistoricAggregates struct {
-	Symbol        string `json:"symbol"`
-	AggregateType string `json:"aggType"`
-	Map           struct {
-		O string `json:"o"`
-		C string `json:"c"`
-		H string `json:"h"`
-		L string `json:"l"`
-		V string `json:"v"`
-		D string `json:"d"`
-	} `json:"map"`
-	Ticks []AggTick `json:"ticks"`
+	Ticker      string      `json:"ticker"`
+	Status      string      `json:"status"`
+	Adjusted    bool        `json:"adjusted"`
+	QueryCount  int         `json:"queryCount"`
+	ResultCount int         `json:"resultCount"`
+	Results     []AggResult `json:"results"`
 }
 
-// AggTick is the structure that contains the actual
-// tick data included in a HistoricAggregates response
-type AggTick struct {
-	EpochMilliseconds int64   `json:"d"`
+// AggResult is the structure that defines the actual Aggregate result
+type AggResult struct {
+	// Volume should be int but json.Decode fails with: "cannot unmarshal number 1.70888e+06 into Go struct"
+	Volume            float64 `json:"v"`
 	Open              float64 `json:"o"`
+	Close             float64 `json:"c"`
 	High              float64 `json:"h"`
 	Low               float64 `json:"l"`
-	Close             float64 `json:"c"`
-	Volume            int     `json:"v"`
+	EpochMilliseconds int64   `json:"t"`
+	NumberOfItems     int     `json:"n"`
 }
 
 // HistoricTrades is the structure that defines trade

--- a/contrib/polygon/backfill/backfill.go
+++ b/contrib/polygon/backfill/backfill.go
@@ -97,26 +97,26 @@ func Bars(symbol string, from, to time.Time) (err error) {
 		to = time.Now()
 	}
 
-	resp, err := api.GetHistoricAggregates(symbol, "minute", from, to, nil)
+	resp, err := api.GetHistoricAggregates(symbol, "minute", 1, from, to, nil)
 	if err != nil {
 		return err
 	}
 
-	if len(resp.Ticks) == 0 {
+	if len(resp.Results) == 0 {
 		return
 	}
 
 	tbk := io.NewTimeBucketKeyFromString(symbol + "/1Min/OHLCV")
 	csm := io.NewColumnSeriesMap()
 
-	epoch := make([]int64, len(resp.Ticks))
-	open := make([]float32, len(resp.Ticks))
-	high := make([]float32, len(resp.Ticks))
-	low := make([]float32, len(resp.Ticks))
-	close := make([]float32, len(resp.Ticks))
-	volume := make([]int32, len(resp.Ticks))
+	epoch := make([]int64, len(resp.Results))
+	open := make([]float32, len(resp.Results))
+	high := make([]float32, len(resp.Results))
+	low := make([]float32, len(resp.Results))
+	close := make([]float32, len(resp.Results))
+	volume := make([]int32, len(resp.Results))
 
-	for i, bar := range resp.Ticks {
+	for i, bar := range resp.Results {
 		epoch[i] = bar.EpochMilliseconds / 1000
 		open[i] = float32(bar.Open)
 		high[i] = float32(bar.High)

--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -131,8 +131,9 @@ func main() {
 			log.Info("[polygon] backfilling bars for %v", sym)
 
 			for e.After(s) {
-				log.Info("Checking %v", s)
-				if calendar.Nasdaq.IsMarketDay(e) {
+				if calendar.Nasdaq.IsMarketDay(s) {
+					log.Info("[polygon] backfilling bars for %v on %v", sym, s)
+
 					sem <- struct{}{}
 					go func(t time.Time) {
 						defer func() { <-sem }()
@@ -163,8 +164,9 @@ func main() {
 			log.Info("[polygon] backfilling quotes for %v", sym)
 
 			for e.After(s) {
-				log.Info("Checking %v", s)
-				if calendar.Nasdaq.IsMarketDay(e) {
+				if calendar.Nasdaq.IsMarketDay(s) {
+					log.Info("[polygon] backfilling quotes for %v on %v", sym, s)
+
 					sem <- struct{}{}
 					go func(t time.Time) {
 						defer func() { <-sem }()
@@ -190,7 +192,9 @@ func main() {
 
 			for e.After(s) {
 				log.Info("Checking %v", s)
-				if calendar.Nasdaq.IsMarketDay(e) {
+				if calendar.Nasdaq.IsMarketDay(s) {
+					log.Info("[polygon] backfilling trades for %v on %v", sym, s)
+
 					sem <- struct{}{}
 					go func(t time.Time) {
 						defer func() { <-sem }()
@@ -211,6 +215,9 @@ func main() {
 	}
 
 	log.Info("[polygon] backfilling complete")
+
+	log.Info("[polygon] waiting for 10 more seconds for ondiskagg triggers to complete")
+	time.Sleep(10 * time.Second)
 }
 
 func initWriter() {

--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -36,8 +36,8 @@ var (
 
 func init() {
 	flag.StringVar(&dir, "dir", "/project/data", "mktsdb directory to backfill to")
-	flag.StringVar(&from, "from", time.Now().Add(-365*24*time.Hour).Format(format), "backfill from date (YYYY-MM-DD)")
-	flag.StringVar(&to, "to", time.Now().Format(format), "backfill from date (YYYY-MM-DD)")
+	flag.StringVar(&from, "from", time.Now().Add(-365*24*time.Hour).Format(format), "backfill from date (YYYY-MM-DD) [included]")
+	flag.StringVar(&to, "to", time.Now().Format(format), "backfill to date (YYYY-MM-DD) [not included]")
 	flag.StringVar(&exchanges, "exchanges", "*", "comma separated list of exchange")
 	flag.BoolVar(&bars, "bars", false, "backfill bars")
 	flag.BoolVar(&quotes, "quotes", false, "backfill quotes")
@@ -131,23 +131,24 @@ func main() {
 			log.Info("[polygon] backfilling bars for %v", sym)
 
 			for e.After(s) {
+				log.Info("Checking %v", s)
 				if calendar.Nasdaq.IsMarketDay(e) {
 					sem <- struct{}{}
 					go func(t time.Time) {
 						defer func() { <-sem }()
 
 						if len(exchangeIDs) == 0 {
-							if err = backfill.Bars(sym, t.Add(-24*time.Hour), t); err != nil {
-								log.Warn("[polygon] failed to backfill trades for %v (%v)", sym, err)
+							if err = backfill.Bars(sym, t, t.Add(24*time.Hour)); err != nil {
+								log.Warn("[polygon] failed to backfill bars for %v (%v)", sym, err)
 							}
 						} else {
 							if err = backfill.BuildBarsFromTrades(sym, t, exchangeIDs, batchSize); err != nil {
 								log.Warn("[polygon] failed to backfill bars for %v @ %v (%v)", sym, t, err)
 							}
 						}
-					}(e)
+					}(s)
 				}
-				e = e.Add(-24 * time.Hour)
+				s = s.Add(24 * time.Hour)
 			}
 		}
 	}
@@ -162,17 +163,18 @@ func main() {
 			log.Info("[polygon] backfilling quotes for %v", sym)
 
 			for e.After(s) {
+				log.Info("Checking %v", s)
 				if calendar.Nasdaq.IsMarketDay(e) {
 					sem <- struct{}{}
 					go func(t time.Time) {
 						defer func() { <-sem }()
 
-						if err = backfill.Quotes(sym, t.Add(-24*time.Hour), t, batchSize); err != nil {
+						if err = backfill.Quotes(sym, t, t.Add(24*time.Hour), batchSize); err != nil {
 							log.Warn("[polygon] failed to backfill quotes for %v (%v)", sym, err)
 						}
-					}(e)
+					}(s)
 				}
-				e = e.Add(-24 * time.Hour)
+				s = s.Add(24 * time.Hour)
 			}
 		}
 	}
@@ -187,6 +189,7 @@ func main() {
 			log.Info("[polygon] backfilling trades for %v", sym)
 
 			for e.After(s) {
+				log.Info("Checking %v", s)
 				if calendar.Nasdaq.IsMarketDay(e) {
 					sem <- struct{}{}
 					go func(t time.Time) {
@@ -197,7 +200,7 @@ func main() {
 						}
 					}(e)
 				}
-				e = e.Add(-24 * time.Hour)
+				s = s.Add(24 * time.Hour)
 			}
 		}
 	}

--- a/executor/rewritebuffer.go
+++ b/executor/rewritebuffer.go
@@ -1,6 +1,5 @@
 package executor
 
-import "C"
 import (
 	"encoding/binary"
 	"math"

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -1,6 +1,5 @@
 package executor
 
-import "C"
 import (
 	"sort"
 

--- a/tests/integ/tests/test_grpc.py
+++ b/tests/integ/tests/test_grpc.py
@@ -144,7 +144,7 @@ def test_grpc_query_all_symbols():
     client.write(data2, tbk2)
     client.write(data3, tbk3)
 
-    time.sleep(0.5)
+    time.sleep(5)
 
     # --- query all symbols using * ---
     resp = client.query(pymkts.Params("*", timeframe, attribute, limit=2, ))


### PR DESCRIPTION
* changed historical aggregates endpoint from `v1/historic/agg` to `v2/aggs/ticker`
* changed how command line `-from` and `-to` date parameters are handled: **from** is included and **to** is not
* removed `import "C"` lines to be able to cross-compile `backfiller` binary