### PR TITLE
feat: list TBK names by json-rpc client

### DIFF
--- a/frontend/query.go
+++ b/frontend/query.go
@@ -254,7 +254,7 @@ func (s *DataService) ListSymbols(r *http.Request, req *ListSymbolsRequest, resp
 	}
 
 	// TBK format (e.g. ["AMZN/1Min/TICK", "AAPL/1Sec/OHLCV", ...])
-	if req.Format == "tbk" {
+	if req != nil && req.Format == "tbk" {
 		response.Results = catalog.ListTimeBucketKeyNames(executor.ThisInstance.CatalogDir)
 		return nil
 	}

--- a/frontend/query_test.go
+++ b/frontend/query_test.go
@@ -277,9 +277,9 @@ func (s *ServerTestSuite) TestListSymbols(c *C) {
 
 	var resp ListSymbolsResponse
 
-	args := &ListSymbolsArgs{}
+	req := &ListSymbolsRequest{}
 
-	if err := service.ListSymbols(nil, args, &resp); err != nil {
+	if err := service.ListSymbols(nil, req, &resp); err != nil {
 		c.Fatalf("error returned: %s", err)
 	}
 

--- a/tests/integ/dockerfiles/pyclient/requirements.txt
+++ b/tests/integ/dockerfiles/pyclient/requirements.txt
@@ -1,2 +1,2 @@
 pytest==3.6.1
-git+https://github.com/alpacahq/pymarketstore.git@19bc96ffe712717f32306e27bb529a56c74e8f82#egg=pymarketstore
+git+https://github.com/alpacahq/pymarketstore.git@e69781570521f8aaffb07f5973b884890377444b#egg=pymarketstore


### PR DESCRIPTION
WHAT
- `pymkts_cli.list_symbols(fmt=ListSymbolsFormat.TBK)` returns TBK names (e.g.  ['TSLA/1Min/OHLCV' , 'AAPL/1Min/TICK'] )
- change the default response of list_symbols API from `None` to `[]` because it will be easier to handle (e.g. `len(cli.list_symbols())` returns an error if `None` is returned)