### PR TITLE
coerce types on write for column series data to match on-disk types

### DIFF
--- a/executor/writer.go
+++ b/executor/writer.go
@@ -354,13 +354,8 @@ func WriteCSMInner(csm io.ColumnSeriesMap, isVariableLength bool) (err error) {
 		if coercion != nil {
 			for _, dbDS := range coercion {
 				if err := cs.CoerceColumnType(dbDS.Name, dbDS.Type); err != nil {
-					var csDS DataShape
-					for _, csDS := range csDSV {
-						if csDS.Name == dbDS.Name {
-							break
-						}
-					}
-					log.Error("[%s] error coercing %s from %s to %s", tbk.GetItemKey(), csDS.Name, csDS.Type.String(), dbDS.Type.String())
+					csType := GetElementType(cs.GetColumn(dbDS.Name))
+					log.Error("[%s] error coercing %s from %s to %s", tbk.GetItemKey(), dbDS.Name, csType.String(), dbDS.Type.String())
 					return err
 				}
 			}

--- a/executor/writer.go
+++ b/executor/writer.go
@@ -349,12 +349,13 @@ func WriteCSMInner(csm io.ColumnSeriesMap, isVariableLength bool) (err error) {
 		missing, coercion := GetMissingAndTypeCoercionColumns(dbDSV, csDSV)
 		if missing != nil {
 			return fmt.Errorf(columnMismatchError, csDSV, dbDSV)
-		} else if coercion != nil {
+		}
+		
+		if coercion != nil {
 			for _, dbDS := range coercion {
 				if err := cs.CoerceColumnType(dbDS); err != nil {
 					var csDS DataShape
-					for i := range csDSV {
-						csDS = csDSV[i]
+					for _, csDS := range csDSV {
 						if csDS.Name == dbDS.Name {
 							break
 						}

--- a/executor/writer.go
+++ b/executor/writer.go
@@ -353,7 +353,7 @@ func WriteCSMInner(csm io.ColumnSeriesMap, isVariableLength bool) (err error) {
 		
 		if coercion != nil {
 			for _, dbDS := range coercion {
-				if err := cs.CoerceColumnType(dbDS); err != nil {
+				if err := cs.CoerceColumnType(dbDS.Name, dbDS.Type); err != nil {
 					var csDS DataShape
 					for _, csDS := range csDSV {
 						if csDS.Name == dbDS.Name {


### PR DESCRIPTION
This PR makes it so that clients making write requests do not need to know what types `marketstore` uses to store its on-disk data