### PR TITLE
refactor polygon_backfiller to use mkts.yml

### DIFF
--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -1,60 +1,49 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
-	"fmt"
-	"github.com/gobwas/glob"
+	"io/ioutil"
+	"os"
 	"runtime"
 	"runtime/debug"
-	"strconv"
-	"strings"
 	"time"
 
 	"code.cloudfoundry.org/bytefmt"
+	"github.com/alpacahq/marketstore/v4/cmd/start"
 	"github.com/alpacahq/marketstore/v4/contrib/calendar"
-	"github.com/alpacahq/marketstore/v4/contrib/ondiskagg/aggtrigger"
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/api"
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/backfill"
+	"github.com/alpacahq/marketstore/v4/contrib/polygon/polygon_config"
 	"github.com/alpacahq/marketstore/v4/executor"
-	"github.com/alpacahq/marketstore/v4/plugins/trigger"
 	"github.com/alpacahq/marketstore/v4/utils"
 	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 var (
-	dir, from, to        string
+	configFilePath       string
+	config               polygon_config.FetcherConfig
+	startTime, endTime   time.Time
 	bars, quotes, trades bool
-	symbols              string
 	parallelism          int
-	apiKey               string
-	exchanges            string
 	batchSize            int
 
-	// NY timezone
-	NY, _  = time.LoadLocation("America/New_York")
 	format = "2006-01-02"
 )
 
 func init() {
-	flag.StringVar(&dir, "dir", "/project/data", "mktsdb directory to backfill to")
-	flag.StringVar(&from, "from", time.Now().Add(-365*24*time.Hour).Format(format), "backfill from date (YYYY-MM-DD) [included]")
-	flag.StringVar(&to, "to", time.Now().Format(format), "backfill to date (YYYY-MM-DD) [not included]")
-	flag.StringVar(&exchanges, "exchanges", "*", "comma separated list of exchange")
-	flag.BoolVar(&bars, "bars", false, "backfill bars")
-	flag.BoolVar(&quotes, "quotes", false, "backfill quotes")
-	flag.BoolVar(&trades, "trades", false, "backfill trades")
-	flag.StringVar(&symbols, "symbols", "*",
-		"glob pattern of symbols to backfill, the default * means backfill all symbols")
+	flag.StringVar(&configFilePath, "polygon_config", "./mkts.yml", "path to the mkts.yml polygon_config file")
 	flag.IntVar(&parallelism, "parallelism", runtime.NumCPU(), "parallelism (default NumCPU)")
 	flag.IntVar(&batchSize, "batchSize", 50000, "batch/pagination size for downloading trades & quotes")
-	flag.StringVar(&apiKey, "apiKey", "", "polygon API key")
 
 	flag.Parse()
 }
 
 func main() {
-	// free memory in the background every 1 minute for long running
-	// backfills with very high parallelism
+	initConfig()
+	initWriter()
+
+	// free memory in the background every 1 minute for long running backfills with very high parallelism
 	go func() {
 		for {
 			<-time.After(time.Minute)
@@ -74,79 +63,59 @@ func main() {
 		}
 	}()
 
-	initWriter()
-
-	if apiKey == "" {
-		log.Fatal("[polygon] api key is required")
-	}
-
-	api.SetAPIKey(apiKey)
-
-	start, err := time.Parse(format, from)
-	if err != nil {
-		log.Fatal("[polygon] failed to parse from timestamp (%v)", err)
-	}
-
-	end, err := time.Parse(format, to)
-	if err != nil {
-		log.Fatal("[polygon] failed to parse to timestamp (%v)", err)
-	}
-
 	var symbolList []string
-	log.Info("[polygon] listing symbols for pattern: %v", symbols)
-	pattern := glob.MustCompile(symbols)
-	resp, err := api.ListTickers()
-	if err != nil {
-		log.Fatal("[polygon] failed to list symbols (%v)", err)
-	}
-	log.Info("[polygon] %v symbols available", len(resp.Tickers))
-	symbolList = make([]string, 1)
-	for _, s := range resp.Tickers {
-		if pattern.Match(s.Ticker) {
+	if len(config.Symbols) > 0 {
+		symbolList = config.Symbols
+	} else {
+		log.Info("[polygon] fetching available symbols")
+		resp, err := api.ListTickers()
+		if err != nil {
+			log.Fatal("[polygon] failed to list symbols (%v)", err)
+		}
+
+		symbolList := make([]string, 1)
+		for _, s := range resp.Tickers {
 			symbolList = append(symbolList, s.Ticker)
 		}
 	}
 	log.Info("[polygon] selected %v symbols", len(symbolList))
 
-	var exchangeIDs []int
-	if exchanges != "*" {
-		for _, exchangeIDStr := range strings.Split(exchanges, ",") {
-			exchangeIDInt, err := strconv.Atoi(exchangeIDStr)
-			if err != nil {
-				log.Fatal("Invalid exchange ID: %v", exchangeIDStr)
+	if len(config.DataTypes) == 0 {
+		bars = true
+	} else {
+		for _, dt := range config.DataTypes {
+			switch dt {
+			case "bars":
+				bars = true
+			case "quotes":
+				quotes = true
+			case "trades":
+				trades = true
 			}
-
-			exchangeIDs = append(exchangeIDs, exchangeIDInt)
 		}
 	}
 
 	sem := make(chan struct{}, parallelism)
 
 	if bars {
-		log.Info("[polygon] backfilling bars from %v to %v", start, end)
+		log.Info("[polygon] backfilling bars from %v to %v", startTime.Format(format), endTime.Format(format))
 
 		for _, sym := range symbolList {
-			s := start
-			e := end
+			s := startTime
+			e := endTime
 
 			log.Info("[polygon] backfilling bars for %v", sym)
 
 			for e.After(s) {
 				if calendar.Nasdaq.IsMarketDay(s) {
-					log.Info("[polygon] backfilling bars for %v on %v", sym, s)
+					log.Info("[polygon] backfilling bars for %v on %v", sym, s.Format(format))
 
 					sem <- struct{}{}
 					go func(t time.Time) {
 						defer func() { <-sem }()
 
-						if len(exchangeIDs) == 0 {
-							if err = backfill.Bars(sym, t, t.Add(24*time.Hour)); err != nil {
-								log.Warn("[polygon] failed to backfill bars for %v (%v)", sym, err)
-							}
-						} else {
-							if err = backfill.BuildBarsFromTrades(sym, t, exchangeIDs, batchSize); err != nil {
-								log.Warn("[polygon] failed to backfill bars for %v @ %v (%v)", sym, t, err)
-							}
+						if err := backfill.Bars(sym, t, t.Add(24*time.Hour)); err != nil {
+							log.Warn("[polygon] failed to backfill bars for %v on %v (%v)", sym, t.Format(format), err)
 						}
 					}(s)
 				}
@@ -156,24 +125,24 @@ func main() {
 	}
 
 	if quotes {
-		log.Info("[polygon] backfilling quotes from %v to %v", start, end)
+		log.Info("[polygon] backfilling quotes from %v to %v", startTime.Format(format), endTime.Format(format))
 
 		for _, sym := range symbolList {
-			s := start
-			e := end
+			s := startTime
+			e := endTime
 
 			log.Info("[polygon] backfilling quotes for %v", sym)
 
 			for e.After(s) {
 				if calendar.Nasdaq.IsMarketDay(s) {
-					log.Info("[polygon] backfilling quotes for %v on %v", sym, s)
+					log.Info("[polygon] backfilling quotes for %v on %v", sym, s.Format(format))
 
 					sem <- struct{}{}
 					go func(t time.Time) {
 						defer func() { <-sem }()
 
-						if err = backfill.Quotes(sym, t, t.Add(24*time.Hour), batchSize); err != nil {
-							log.Warn("[polygon] failed to backfill quotes for %v (%v)", sym, err)
+						if err := backfill.Quotes(sym, t, t.Add(24*time.Hour), batchSize); err != nil {
+							log.Warn("[polygon] failed to backfill quotes for %v on %v (%v)", sym, t.Format(format), err)
 						}
 					}(s)
 				}
@@ -183,25 +152,25 @@ func main() {
 	}
 
 	if trades {
-		log.Info("[polygon] backfilling trades from %v to %v", start, end)
+		log.Info("[polygon] backfilling trades from %v to %v", startTime.Format(format), endTime.Format(format))
 
 		for _, sym := range symbolList {
-			s := start
-			e := end
+			s := startTime
+			e := endTime
 
 			log.Info("[polygon] backfilling trades for %v", sym)
 
 			for e.After(s) {
 				log.Info("Checking %v", s)
 				if calendar.Nasdaq.IsMarketDay(s) {
-					log.Info("[polygon] backfilling trades for %v on %v", sym, s)
+					log.Info("[polygon] backfilling trades for %v on %v", sym, s.Format(format))
 
 					sem <- struct{}{}
 					go func(t time.Time) {
 						defer func() { <-sem }()
 
-						if err = backfill.Trades(sym, t, batchSize); err != nil {
-							log.Warn("[polygon] failed to backfill trades for %v @ %v (%v)", sym, t, err)
+						if err := backfill.Trades(sym, t, batchSize); err != nil {
+							log.Warn("[polygon] failed to backfill trades for %v on %v (%v)", sym, t.Format(format), err)
 						}
 					}(e)
 				}
@@ -217,29 +186,70 @@ func main() {
 
 	log.Info("[polygon] backfilling complete")
 
-	log.Info("[polygon] waiting for 10 more seconds for ondiskagg triggers to complete")
-	time.Sleep(10 * time.Second)
+	if len(executor.ThisInstance.TriggerMatchers) > 0 {
+		log.Info("[polygon] waiting for 10 more seconds for ondiskagg triggers to complete")
+		time.Sleep(10 * time.Second)
+	}
+}
+
+func initConfig() {
+	// Attempt to read mkts.yml config file
+	data, err := ioutil.ReadFile(configFilePath)
+	if err != nil {
+		log.Fatal("failed to read configuration file error: %s", err.Error())
+		os.Exit(1)
+	}
+
+	// Attempt to set configuration
+	err = utils.InstanceConfig.Parse(data)
+	if err != nil {
+		log.Fatal("failed to parse configuration file error: %v", err.Error())
+		os.Exit(1)
+	}
+
+	// Attempt to set the polygon plugin config settings
+	foundPolygonConfig := false
+	for _, bgConfig := range utils.InstanceConfig.BgWorkers {
+		if bgConfig.Name == "Polygon" {
+			data, _ := json.Marshal(bgConfig.Config)
+			if err = json.Unmarshal(data, &config); err != nil {
+				log.Fatal("failed to parse configuration file error: %v", err.Error())
+				os.Exit(1)
+			}
+			foundPolygonConfig = true
+			break
+		}
+	}
+	if !foundPolygonConfig {
+		log.Fatal("polygon background worker is not configured in %s", configFilePath)
+		os.Exit(1)
+	}
+
+	if config.APIKey == "" {
+		log.Fatal("[polygon] api key is required")
+		os.Exit(1)
+	}
+	api.SetAPIKey(config.APIKey)
+
+	startTime, err = time.Parse(format, config.QueryStart)
+	if err != nil {
+		log.Fatal("[polygon] failed to parse from timestamp (%v)", err)
+		os.Exit(1)
+	}
+
+	t := time.Now()
+	endTime = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC).Round(time.Minute)
 }
 
 func initWriter() {
-	utils.InstanceConfig.Timezone = NY
-	utils.InstanceConfig.WALRotateInterval = 5
+	executor.NewInstanceSetup(utils.InstanceConfig.RootDirectory, true, true, true, true)
 
-	executor.NewInstanceSetup(
-		fmt.Sprintf("%v/mktsdb", dir),
-		true, true, true, true)
-
-	config := map[string]interface{}{
-		"filter":       "nasdaq",
-		"destinations": []string{"5Min", "15Min", "1H", "1D"},
-	}
-
-	trig, err := aggtrigger.NewTrigger(config)
-	if err != nil {
-		log.Fatal("[polygon] backfill failed to initialize writer (%v)", err)
-	}
-
-	executor.ThisInstance.TriggerMatchers = []*trigger.TriggerMatcher{
-		trigger.NewMatcher(trig, "*/1Min/OHLCV"),
+	// if configured, also load the 1Min ondiskagg trigger
+	for _, triggerSetting := range utils.InstanceConfig.Triggers {
+		if triggerSetting.Module == "ondiskagg.so" && triggerSetting.On == "*/1Min/OHLCV" {
+			tmatcher := start.NewTriggerMatcher(triggerSetting)
+			executor.ThisInstance.TriggerMatchers = append(executor.ThisInstance.TriggerMatchers, tmatcher)
+			break
+		}
 	}
 }

--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -73,9 +73,9 @@ func main() {
 			log.Fatal("[polygon] failed to list symbols (%v)", err)
 		}
 
-		symbolList := make([]string, 1)
-		for _, s := range resp.Tickers {
-			symbolList = append(symbolList, s.Ticker)
+		symbolList = make([]string, len(resp.Tickers))
+		for i, s := range resp.Tickers {
+			symbolList[i] = s.Ticker
 		}
 	}
 	log.Info("[polygon] selected %v symbols", len(symbolList))

--- a/contrib/polygon/polygon.go
+++ b/contrib/polygon/polygon.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/api"
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/backfill"
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/handlers"
+	"github.com/alpacahq/marketstore/v4/contrib/polygon/polygon_config"
 	"github.com/alpacahq/marketstore/v4/executor"
 	"github.com/alpacahq/marketstore/v4/planner"
 	"github.com/alpacahq/marketstore/v4/plugins/bgworker"
@@ -19,28 +20,8 @@ import (
 )
 
 type PolygonFetcher struct {
-	config FetcherConfig
+	config polygon_config.FetcherConfig
 	types  map[string]struct{} // Bars, Quotes, Trades
-}
-
-type FetcherConfig struct {
-	// AddTickCountToBars controls if TickCnt is added to the schema for Bars or not
-	AddTickCountToBars bool `json:"add_bar_tick_count,omitempty"`
-	// polygon API key for authenticating with their APIs
-	APIKey string `json:"api_key"`
-	// polygon API base URL in case it is being proxied
-	// (defaults to https://api.polygon.io/)
-	BaseURL string `json:"base_url"`
-	// websocket servers for Polygon, default is: "wss://socket.polygon.io"
-	WSServers string `json:"ws_servers"`
-	// list of data types to subscribe to (one of bars, quotes, trades)
-	DataTypes []string `json:"data_types"`
-	// list of symbols that are important
-	Symbols []string `json:"symbols"`
-	// time string when to start first time, in "YYYY-MM-DD HH:MM" format
-	// if it is restarting, the start is the last written data timestamp
-	// otherwise, it starts from the latest streamed bar
-	QueryStart string `json:"query_start"`
 }
 
 var (
@@ -51,7 +32,7 @@ var (
 // for more details about configuring PolygonFetcher.
 func NewBgWorker(conf map[string]interface{}) (w bgworker.BgWorker, err error) {
 	data, _ := json.Marshal(conf)
-	config := FetcherConfig{}
+	config := polygon_config.FetcherConfig{}
 	err = json.Unmarshal(data, &config)
 	if err != nil {
 		return

--- a/contrib/polygon/polygon_config/polygon_config.go
+++ b/contrib/polygon/polygon_config/polygon_config.go
@@ -1,0 +1,21 @@
+package polygon_config
+
+type FetcherConfig struct {
+	// AddTickCountToBars controls if TickCnt is added to the schema for Bars or not
+	AddTickCountToBars bool `json:"add_bar_tick_count,omitempty"`
+	// polygon API key for authenticating with their APIs
+	APIKey string `json:"api_key"`
+	// polygon API base URL in case it is being proxied
+	// (defaults to https://api.polygon.io/)
+	BaseURL string `json:"base_url"`
+	// websocket servers for Polygon, default is: "wss://socket.polygon.io"
+	WSServers string `json:"ws_servers"`
+	// list of data types to subscribe to (one of bars, quotes, trades)
+	DataTypes []string `json:"data_types"`
+	// list of symbols that are important
+	Symbols []string `json:"symbols"`
+	// time string when to start first time, in "YYYY-MM-DD HH:MM" format
+	// if it is restarting, the start is the last written data timestamp
+	// otherwise, it starts from the latest streamed bar
+	QueryStart string `json:"query_start"`
+}


### PR DESCRIPTION
This PR refactors the `polygon_backfiller` command to load settings from the user's configured `mkts.yml` file.

Settings are loaded for the `ondiskagg` trigger, as well as all of the polygon-specific settings (api key, symbols, bars/quotes/trades, query_start). If symbols is left unspecified, fetch all the things as before. (but, maybe it'd be better to only fetch all tradable-on-Alpaca symbols?)

Also, it may be preferable to instead make this a Cobra command? (eg `marketstore backfill ...`)