### PR TITLE
refactor: remove Instance ID from Instance Config

### DIFF
--- a/contrib/iex/backfill/backfill.go
+++ b/contrib/iex/backfill/backfill.go
@@ -238,6 +238,7 @@ func nextBatch(bars []*consolidator.Bar, index int) ([]*consolidator.Bar, int) {
 func initWriter() {
 	utils.InstanceConfig.Timezone = NY
 	utils.InstanceConfig.WALRotateInterval = 5
+	instanceID := time.Now().UTC().UnixNano()
 
 	executor.NewInstanceSetup(
 		fmt.Sprintf("%v/mktsdb", dir),
@@ -245,7 +246,7 @@ func initWriter() {
 
 	log.Info(
 		"Initialized writer with InstanceID: %v - RootDir: %v\n",
-		executor.ThisInstance.InstanceID,
+		instanceID,
 		executor.ThisInstance.RootDir,
 	)
 

--- a/executor/errors.go
+++ b/executor/errors.go
@@ -62,12 +62,6 @@ func (msg WALWriteError) Error() string {
 	return errReport("%s: Error Writing to WAL", string(msg))
 }
 
-type ShortReadError string
-
-func (msg ShortReadError) Error() string {
-	return errReport("%s: Unexpectedly short read", string(msg))
-}
-
 func errReport(base string, msg string) string {
 	base = io.GetCallerFileContext(2) + ":" + base
 	log.Error(base, msg)

--- a/executor/messages.go
+++ b/executor/messages.go
@@ -27,19 +27,4 @@ const (
 	COMMITCOMPLETE
 )
 
-type FileStatusEnum int8
 
-const (
-	Invalid FileStatusEnum = iota
-	OPEN
-	CLOSED
-)
-
-type ReplayStateEnum int8
-
-const (
-	Invalid2 ReplayStateEnum = iota
-	NOTREPLAYED
-	REPLAYED
-	REPLAYINPROCESS
-)

--- a/executor/wal/errors.go
+++ b/executor/wal/errors.go
@@ -1,0 +1,19 @@
+package wal
+
+import (
+	"fmt"
+	"github.com/alpacahq/marketstore/v4/utils/io"
+	"github.com/alpacahq/marketstore/v4/utils/log"
+)
+
+type ShortReadError string
+
+func (msg ShortReadError) Error() string {
+	return errReport("%s: Unexpectedly short read", string(msg))
+}
+
+func errReport(base string, msg string) string {
+	base = io.GetCallerFileContext(2) + ":" + base
+	log.Error(base, msg)
+	return fmt.Sprintf(base, msg)
+}

--- a/executor/wal/file.go
+++ b/executor/wal/file.go
@@ -1,0 +1,56 @@
+package wal
+
+import (
+	"fmt"
+	"github.com/alpacahq/marketstore/v4/utils/io"
+	"github.com/alpacahq/marketstore/v4/utils/log"
+	"os"
+)
+
+type FileStatusEnum int8
+
+const (
+	Invalid FileStatusEnum = iota
+	OPEN
+	CLOSED
+)
+
+type ReplayStateEnum int8
+
+const (
+	Invalid2 ReplayStateEnum = iota
+	NOTREPLAYED
+	REPLAYED
+	REPLAYINPROCESS
+)
+
+func ReadStatus(filePtr *os.File) (fileStatus FileStatusEnum, replayStatus ReplayStateEnum, OwningInstanceID int64, err error) {
+	var buffer [10]byte
+	buf, _, err := Read(filePtr, -1, buffer[:])
+	return FileStatusEnum(buf[0]), ReplayStateEnum(buf[1]), io.ToInt64(buf[2:]), err
+}
+
+func Read(fp *os.File, targetOffset int64, buffer []byte) (result []byte, newOffset int64, err error) {
+	/*
+		Read from the WAL file
+			targetOffset: -1 will read from current position
+	*/
+	offset, err := fp.Seek(0, os.SEEK_CUR)
+	if err != nil {
+		log.Fatal(io.GetCallerFileContext(0) + ": Unable to seek in WALFile")
+	}
+	if targetOffset != -1 {
+		if offset != targetOffset {
+			fp.Seek(targetOffset, os.SEEK_SET)
+		}
+	}
+	numToRead := len(buffer)
+	n, err := fp.Read(buffer)
+	if n != numToRead {
+		msg := fmt.Sprintf("Read: Expected: %d Got: %d", numToRead, n)
+		err = ShortReadError(msg)
+	} else if err != nil {
+		log.Fatal(io.GetCallerFileContext(0) + ": Unable to read WALFile")
+	}
+	return buffer, offset + int64(n), err
+}


### PR DESCRIPTION
## WHAT
- remove InstanceID(= a kind of process ID) from Instance Config and embed it in the WAL file
## WHY
- InstanceMetaData is a singleton and it makes unit-test difficult
- WAL is the only user of the Instance ID