### PR TITLE
add: serialize/deserialize data shape

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/protobuf v1.4.0
+	github.com/google/go-cmp v0.5.2
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/gorilla/websocket v1.4.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 h1:zLTLjkaOFEFIOxY5BWLFLwh+cL8vOBW4XJ2aqLE/Tf0=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/utils/io/byteconversions.go
+++ b/utils/io/byteconversions.go
@@ -84,6 +84,9 @@ func ToFloat32(b []byte) float32 {
 func ToFloat64(b []byte) float64 {
 	return *(*float64)(unsafe.Pointer(&b[0]))
 }
+func ToString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}
 
 func SwapSliceData(src_slice interface{}, target_type interface{}) interface{} {
 	leftValue := reflect.ValueOf(src_slice)

--- a/utils/io/datashape_test.go
+++ b/utils/io/datashape_test.go
@@ -1,0 +1,50 @@
+package io_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/alpacahq/marketstore/v4/utils/io"
+)
+
+func TestDSVSerialize(t *testing.T) {
+	tests := []struct {
+		name        string
+		columnNames []string
+		elemTypes   []io.EnumElementType
+	}{
+		{
+			name:        "success",
+			columnNames: []string{"column1", "column2"},
+			elemTypes:   []io.EnumElementType{io.FLOAT32, io.UINT64},
+		},
+		{
+			name:        "success/empty DataShape",
+			columnNames: []string{},
+			elemTypes:   []io.EnumElementType{},
+		},
+		{
+			name:        "success/single column",
+			columnNames: []string{"column"},
+			elemTypes:   []io.EnumElementType{io.EPOCH},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			dsv := io.NewDataShapeVector(tt.columnNames, tt.elemTypes)
+
+			serialized, err := io.DSVToBytes(dsv)
+			if err != nil {
+				t.Fatalf("failed to serialize DSV: " + err.Error())
+			}
+
+			deserialized := io.DSVFromBytes(serialized)
+			if diff := cmp.Diff(dsv, deserialized); diff != "" {
+				t.Errorf("Original DSV/Serialized->Deserialized DSV mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## [WHAT]
- Add functionality to Serialize/Deserialize DataShape.

## [WHY]
- In order to implement replication feature using WAL binary, DataShape information for each bucket should be added to WAL, because replica instances need to create buckets from WAL but it's impossible without the DataShape information(=column names and their data types)
