### PR TITLE
add: include DataShape in WAL message

### DIFF
--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -149,7 +149,7 @@ func createTickBucket(symbol string) {
 		ts = ts.Add(time.Second)
 		row.Epoch = ts.Unix()
 		buffer, _ := io.Serialize([]byte{}, row)
-		w.WriteRecords([]time.Time{ts}, buffer)
+		w.WriteRecords([]time.Time{ts}, buffer, dsv)
 	}
 	wf.RequestFlush()
 }

--- a/executor/cache.go
+++ b/executor/cache.go
@@ -21,6 +21,7 @@ type WriteCommand struct {
 	VarRecLen     int32
 	Offset, Index int64
 	Data          []byte
+	DataShapes    []io.DataShape
 }
 
 // Convert WriteCommand to string for debuging/presentation

--- a/executor/writer.go
+++ b/executor/writer.go
@@ -55,7 +55,7 @@ func (w *Writer) AddNewYearFile(year int16) (err error) {
 // The caller should assume that by calling WriteRecords directly, the data will be written
 // to the file regardless if it satisfies the on-disk data shape, possible corrupting
 // the data files. It is recommended to call WriteCSM() for any writes as it is safer.
-func (w *Writer) WriteRecords(ts []time.Time, data []byte) {
+func (w *Writer) WriteRecords(ts []time.Time, data []byte, ds []DataShape) {
 	/*
 		[]data contains a number of records, each including the epoch in the first 8 bytes
 	*/
@@ -114,7 +114,9 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte) {
 				VarRecLen:  vrl,
 				Offset:     offset,
 				Index:      index,
-				Data:       nil}
+				Data:       nil,
+				DataShapes: ds,
+			}
 		}
 		// Because index is relative time from the beginning of the year
 		// To confirm that the next data is a different data, both index and year should be checked.
@@ -140,7 +142,9 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte) {
 				VarRecLen:  w.tbi.GetVariableRecordLength(),
 				Offset:     offset,
 				Index:      index,
-				Data:       outBuf}
+				Data:       outBuf,
+				DataShapes: ds,
+			}
 		}
 		if i == (numRows - 1) {
 			/*
@@ -340,7 +344,7 @@ func WriteCSM(csm io.ColumnSeriesMap, isVariableLength bool) (err error) {
 			return err
 		}
 
-		w.WriteRecords(times, rowdata)
+		w.WriteRecords(times, rowdata, dbDSV)
 	}
 	wal := ThisInstance.WALFile
 	wal.RequestFlush()

--- a/sqlparser/insertintostatement.go
+++ b/sqlparser/insertintostatement.go
@@ -121,7 +121,7 @@ func (is *InsertIntoStatement) Materialize() (outputColumnSeries *io.ColumnSerie
 		return nil, fmt.Errorf("Unable to pre-process data for insertion")
 	}
 
-	writer.WriteRecords(indexTime, data)
+	writer.WriteRecords(indexTime, data, targetDSV)
 	wal.RequestFlush()
 
 	outputColumnSeries = io.NewColumnSeries()

--- a/utils/io/datashape.go
+++ b/utils/io/datashape.go
@@ -101,9 +101,10 @@ func dsFromBytes(buf []byte) (DataShape, int) {
 }
 
 // DSVFromBytes deserializes bytes into an array of datashape (=Data Shape Vector)
-func DSVFromBytes(buf []byte) []DataShape {
+// and return it with its byte length
+func DSVFromBytes(buf []byte) ([]DataShape, int) {
 	if buf == nil {
-		return nil
+		return nil, 0
 	}
 
 	cursor := 0
@@ -117,7 +118,7 @@ func DSVFromBytes(buf []byte) []DataShape {
 		ret[i] = ds
 		cursor += l
 	}
-	return ret
+	return ret, cursor
 }
 
 // DSVToBytes serializes an array of DataShape (=Data Shape Vector) into []byte

--- a/utils/io/datashape_test.go
+++ b/utils/io/datashape_test.go
@@ -41,7 +41,7 @@ func TestDSVSerialize(t *testing.T) {
 				t.Fatalf("failed to serialize DSV: " + err.Error())
 			}
 
-			deserialized := io.DSVFromBytes(serialized)
+			deserialized, _ := io.DSVFromBytes(serialized)
 			if diff := cmp.Diff(dsv, deserialized); diff != "" {
 				t.Errorf("Original DSV/Serialized->Deserialized DSV mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
## WHAT
- include DataShape information in WAL message

## WHY
- to implement replication using WAL, DataShape information is necessary because replica instances need to create bucket files from WAL.