### PR TITLE
refactor: move OffsetIndexBuffer and WTSet to another file

### DIFF
--- a/executor/cache.go
+++ b/executor/cache.go
@@ -18,7 +18,7 @@ const WriteChannelCommandDepth = 1000000
 type WriteCommand struct {
 	RecordType    io.EnumRecordType
 	WALKeyPath    string
-	VarRecLen     int32
+	VarRecLen     int
 	Offset, Index int64
 	Data          []byte
 	DataShapes    []io.DataShape

--- a/executor/wal/oib.go
+++ b/executor/wal/oib.go
@@ -1,0 +1,21 @@
+package wal
+
+import "github.com/alpacahq/marketstore/v4/utils/io"
+
+type OffsetIndexBuffer []byte
+
+func (b OffsetIndexBuffer) Offset() int64 {
+	return io.ToInt64(b[:8])
+}
+
+func (b OffsetIndexBuffer) Index() int64 {
+	return io.ToInt64(b[8:16])
+}
+
+func (b OffsetIndexBuffer) IndexAndPayload() []byte {
+	return b[8:]
+}
+
+func (b OffsetIndexBuffer) Payload() []byte {
+	return b[16:]
+}

--- a/executor/wal/wt.go
+++ b/executor/wal/wt.go
@@ -1,0 +1,32 @@
+package wal
+
+import "github.com/alpacahq/marketstore/v4/utils/io"
+
+type WTSet struct {
+	// Direct or Indirect IO (for variable or fixed length records)
+	RecordType int8
+	// FilePath is an absolute path of the WAL file. The string is ASCII encoded without a trailing null
+	FilePath string
+	// Length of each data element in this set in bytes, excluding the index
+	DataLen int
+	// Used only in case of variable recordType.
+	// (The sum of field lengths in elementTypes) + 4 bytes(for intervalTicks)
+	VarRecLen int
+	// Data bytes
+	Buffer OffsetIndexBuffer
+	// Data Shape without Epoch Column
+	DataShapes []io.DataShape
+}
+
+func NewWTSet(
+	recordType int8, filePath string, dataLen, varRecLen int, data OffsetIndexBuffer, dataShapes []io.DataShape,
+) WTSet {
+	return WTSet{
+		RecordType: recordType,
+		FilePath:   filePath,
+		DataLen:    dataLen,
+		VarRecLen:  varRecLen,
+		Buffer:     data,
+		DataShapes: dataShapes,
+	}
+}

--- a/executor/written_test.go
+++ b/executor/written_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	. "gopkg.in/check.v1"
 
+	"github.com/alpacahq/marketstore/v4/executor/wal"
 	"github.com/alpacahq/marketstore/v4/plugins/trigger"
 	"github.com/alpacahq/marketstore/v4/utils/io"
 )
@@ -46,8 +47,8 @@ func (s *WrittenIndexesTests) TestWrittenIndexes(c *C) {
 	s.SetTrigger(t, "AAPL/1Min/OHLCV")
 
 	buffer := io.SwapSliceData([]int64{0, 5}, byte(0)).([]byte)
-	appendRecord("AAPL/1Min/OHLCV/2017.bin", offsetIndexBuffer(buffer).IndexAndPayload())
-	appendRecord("TSLA/1Min/OHLCV/2017.bin", offsetIndexBuffer(buffer).IndexAndPayload())
+	appendRecord("AAPL/1Min/OHLCV/2017.bin", wal.OffsetIndexBuffer(buffer).IndexAndPayload())
+	appendRecord("TSLA/1Min/OHLCV/2017.bin", wal.OffsetIndexBuffer(buffer).IndexAndPayload())
 	dispatchRecords()
 
 	<-t.fireC


### PR DESCRIPTION
## WHAT
move OffsetIndexBuffer and WTSet structs to wal package

## WHY
to make wal.go simpler for visibility