### PR TITLE
chore: remove CandleAttribute from row

### DIFF
--- a/contrib/candler/candler.go
+++ b/contrib/candler/candler.go
@@ -202,8 +202,6 @@ func (ca *Candler) Output() *io.ColumnSeries {
 	}
 
 	rows := io.NewRows(dataShapes, dataBuf)
-	catt := io.CandleAttributes(io.OHLC)
-	rows.SetCandleAttributes(&catt)
 	return rows.ToColumnSeries()
 }
 

--- a/contrib/ondiskagg/aggtrigger/aggtrigger.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger.go
@@ -156,7 +156,6 @@ func (s *OnDiskAggTrigger) Fire(keyPath string, records []trigger.Record) {
 
 		cs := trigger.RecordsToColumnSeries(
 			*tbk, c.cs.GetDataShapes(),
-			c.cs.GetCandleAttributes(),
 			tf.Duration, int16(year), records)
 
 		cs = io.ColumnSeriesUnion(cs, &c.cs)

--- a/executor/scanner.go
+++ b/executor/scanner.go
@@ -215,12 +215,10 @@ func (r *Reader) Read() (csm ColumnSeriesMap, err error) {
 	// down to several parts of small query and each one's Range.Start follow the last's
 	// Range.End with same other conditions.
 	csm = NewColumnSeriesMap()
-	catMap := r.pr.GetCandleAttributes()
 	rtMap := r.pr.GetRecordType()
 	dsMap := r.pr.GetDataShapes()
 	rlMap := r.pr.GetRowLen()
 	for key, iop := range r.IOPMap {
-		cat := catMap[key]
 		rt := rtMap[key]
 		rlen := rlMap[key]
 		buffer, err := r.read(iop)
@@ -231,7 +229,7 @@ func (r *Reader) Read() (csm ColumnSeriesMap, err error) {
 			buffer = trimResultsToRange(r.pr.Range, rlen, buffer)
 			buffer = trimResultsToLimit(r.pr.Limit, rlen, buffer)
 		}
-		rs := NewRowSeries(key, buffer, dsMap[key], rlen, cat, rt)
+		rs := NewRowSeries(key, buffer, dsMap[key], rlen, rt)
 		key, cs := rs.ToColumnSeries()
 		csm[key] = cs
 	}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -81,28 +81,6 @@ func (pr *ParseResult) GetRecordType() (rt map[TimeBucketKey]EnumRecordType) {
 	return rt
 }
 
-func (pr *ParseResult) GetCandleAttributes() (cat map[TimeBucketKey]*CandleAttributes) {
-	/*
-		The test uses the types and length of the elements in the record to determine if it matches a known type
-	*/
-	OHLCNames := []string{"Open", "High", "Low", "Close"}
-	OHLCVNames := []string{"Open", "High", "Low", "Close", "Volume"}
-
-	cat = make(map[TimeBucketKey]*CandleAttributes, len(pr.QualifiedFiles))
-	for _, qf := range pr.QualifiedFiles {
-		elNames := qf.File.GetElementNames()
-		cat[qf.Key] = new(CandleAttributes)
-		if NamesMatch(elNames, OHLCVNames) {
-			*cat[qf.Key] = OHLCV
-		} else if NamesMatch(elNames, OHLCNames) {
-			*cat[qf.Key] = OHLC
-		} else {
-			*cat[qf.Key] = None
-		}
-	}
-	return cat
-}
-
 func (pr *ParseResult) GetDataShapes() (dsv map[TimeBucketKey][]DataShape) {
 	dsv = make(map[TimeBucketKey][]DataShape)
 	for _, qf := range pr.QualifiedFiles {

--- a/plugins/trigger/trigger.go
+++ b/plugins/trigger/trigger.go
@@ -85,7 +85,6 @@ func (r *Record) Payload() []byte {
 func RecordsToColumnSeries(
 	tbk io.TimeBucketKey,
 	ds []io.DataShape,
-	ca *io.CandleAttributes,
 	tf time.Duration,
 	year int16,
 	records []Record) *io.ColumnSeries {

--- a/plugins/trigger/trigger_test.go
+++ b/plugins/trigger/trigger_test.go
@@ -85,7 +85,6 @@ func (s *TestSuite) TestRecordsToColumnSeries(c *C) {
 
 	testCS := RecordsToColumnSeries(
 		*tbk, cs.GetDataShapes(),
-		cs.GetCandleAttributes(),
 		time.Minute, int16(2017),
 		records)
 

--- a/utils/io/columnseries.go
+++ b/utils/io/columnseries.go
@@ -33,14 +33,12 @@ type ColumnSeries struct {
 
 	columns          map[string]interface{}
 	orderedNames     []string
-	candleAttributes *CandleAttributes
 	nameIncrement    map[string]int
 }
 
 func NewColumnSeries() *ColumnSeries {
 	cs := new(ColumnSeries)
 	cs.columns = make(map[string]interface{})
-	cs.candleAttributes = new(CandleAttributes)
 	cs.nameIncrement = make(map[string]int)
 	return cs
 }
@@ -92,14 +90,6 @@ func (cs *ColumnSeries) GetTime() ([]time.Time, error) {
 
 func (cs *ColumnSeries) GetColumnNames() (columnNames []string) {
 	return cs.orderedNames
-}
-
-func (cs *ColumnSeries) GetCandleAttributes() (cat *CandleAttributes) {
-	return cs.candleAttributes
-}
-
-func (cs *ColumnSeries) SetCandleAttributes(cat *CandleAttributes) {
-	cs.candleAttributes = cat
 }
 
 func (cs *ColumnSeries) GetColumns() map[string]interface{} {
@@ -240,7 +230,7 @@ func (cs *ColumnSeries) GetEpoch() []int64 {
 func (cs *ColumnSeries) ToRowSeries(itemKey TimeBucketKey, alignData bool) (rs *RowSeries) {
 	dsv := cs.GetDataShapes()
 	data, recordLen := SerializeColumnsToRows(cs, dsv, alignData)
-	rs = NewRowSeries(itemKey, data, dsv, recordLen, cs.GetCandleAttributes(), NOTYPE)
+	rs = NewRowSeries(itemKey, data, dsv, recordLen, NOTYPE)
 	return rs
 }
 
@@ -256,7 +246,6 @@ func (cs *ColumnSeries) ApplyTimeQual(tq func(epoch int64) bool) *ColumnSeries {
 
 	out := &ColumnSeries{
 		orderedNames:     cs.orderedNames,
-		candleAttributes: cs.candleAttributes,
 		nameIncrement:    cs.nameIncrement,
 		columns:          map[string]interface{}{},
 	}
@@ -289,7 +278,6 @@ func (cs *ColumnSeries) ApplyTimeQual(tq func(epoch int64) bool) *ColumnSeries {
 func SliceColumnSeriesByEpoch(cs ColumnSeries, start, end *int64) (slc ColumnSeries, err error) {
 	slc = ColumnSeries{
 		orderedNames:     cs.orderedNames,
-		candleAttributes: cs.candleAttributes,
 		nameIncrement:    cs.nameIncrement,
 		columns:          map[string]interface{}{},
 	}
@@ -342,7 +330,6 @@ func max(x, y int) int {
 func ColumnSeriesUnion(left, right *ColumnSeries) *ColumnSeries {
 	out := NewColumnSeries()
 
-	out.candleAttributes = left.candleAttributes
 	out.orderedNames = left.orderedNames
 	out.nameIncrement = make(map[string]int, len(left.nameIncrement))
 	for k, v := range left.nameIncrement {

--- a/utils/io/datatypes.go
+++ b/utils/io/datatypes.go
@@ -175,51 +175,6 @@ func GetElementType(datum interface{}) EnumElementType {
 	return NONE
 }
 
-type CandleAttributes uint8
-
-/*
-- if None, then there are no candle attributes - not a candle
-- if both HASFLOAT32 and HASFLOAT64 are set, the 64-bit versions of OHLC are named using a "64" after the column name
-- if only one of HASFLOAT32 and HASFLOAT64 are set, the OHLC have names: "open", "high", etc
-*/
-const (
-	None       CandleAttributes = 0x0       // Default - not a candle
-	ISCANDLE                    = 1 << iota // Is a candle - continuum data representation (not a tick)
-	OHLC                                    // Has "Open, High, Low, Close" data in the candle
-	OHLCV                                   // Has "Open, High, Low, Close" and "Volume" data in the candle
-	HASFLOAT32                              // 32-bit version available
-	HASFLOAT64                              // 64-bit version available
-)
-
-func (cat *CandleAttributes) AddOption(option CandleAttributes) {
-	*cat |= option
-}
-func (cat *CandleAttributes) DelOption(option CandleAttributes) {
-	*cat &= ^option
-}
-func (cat *CandleAttributes) IsSet(checkOption ...CandleAttributes) bool {
-	/*
-		Returns true if all supplied options are set
-	*/
-	for _, co := range checkOption {
-		if (*cat)&co != co {
-			return false
-		}
-	}
-	return true
-}
-func (cat *CandleAttributes) AnySet(checkOption ...CandleAttributes) bool {
-	/*
-		Returns true if any of the supplied options are set
-	*/
-	for _, co := range checkOption {
-		if (*cat)&co == co {
-			return true
-		}
-	}
-	return false
-}
-
 type DirectionEnum uint8
 
 const (

--- a/utils/io/rowseries.go
+++ b/utils/io/rowseries.go
@@ -5,8 +5,6 @@ import (
 )
 
 type RowsInterface interface {
-	SetCandleAttributes(*CandleAttributes)
-	GetCandleAttributes() *CandleAttributes
 	GetRow(i int) []byte // Position to the i-th record
 	GetData() []byte     // Pointer to the beginning of the data
 	GetNumRows() int
@@ -21,15 +19,13 @@ type RowSeriesInterface interface {
 type Rows struct {
 	ColumnInterface
 	RowsInterface
-	dataShape        []DataShape
-	data             []byte
-	rowLen           int               // We allow for a rowLen that might differ from the sum of dataShape for alignment, etc
-	candleAttributes *CandleAttributes // Attributes of the rows, are they discrete (ticks) or continuous (candles)
+	dataShape []DataShape
+	data      []byte
+	rowLen    int // We allow for a rowLen that might differ from the sum of dataShape for alignment, etc
 }
 
 func NewRows(dataShape []DataShape, data []byte) *Rows {
-	ca := CandleAttributes(0)
-	return &Rows{dataShape: dataShape, data: data, rowLen: 0, candleAttributes: &ca}
+	return &Rows{dataShape: dataShape, data: data, rowLen: 0}
 }
 
 func (rows *Rows) GetColumn(colname string) (col interface{}) {
@@ -90,14 +86,6 @@ func (rows *Rows) GetTime() ([]time.Time, error) {
 	return ts, nil
 }
 
-func (rows *Rows) SetCandleAttributes(ca *CandleAttributes) {
-	rows.candleAttributes = ca
-}
-
-func (rows *Rows) GetCandleAttributes() *CandleAttributes {
-	return rows.candleAttributes
-}
-
 func (rows *Rows) SetRowLen(rowLen int) {
 	/*
 		Call this to set a custom row length for this group of rows. This is needed when padding for alignment.
@@ -143,7 +131,6 @@ func (rows *Rows) ToColumnSeries() *ColumnSeries {
 		}
 		cs.AddColumn(ds.Name, rows.GetColumn(ds.Name))
 	}
-	cs.SetCandleAttributes(rows.GetCandleAttributes())
 	return cs
 }
 
@@ -159,7 +146,7 @@ func NewRowSeries(
 	key TimeBucketKey,
 	data []byte,
 	dataShape []DataShape,
-	rowLen int, cat *CandleAttributes,
+	rowLen int,
 	rowType EnumRecordType,
 ) *RowSeries {
 	/*
@@ -170,7 +157,6 @@ func NewRowSeries(
 		dataShape = append(dataShape, DataShape{"Nanoseconds", INT32})
 	}
 	rows := NewRows(dataShape, data)
-	rows.SetCandleAttributes(cat)
 	rows.SetRowLen(rowLen)
 	return &RowSeries{
 		metadataKey: key,
@@ -182,12 +168,6 @@ func (rs *RowSeries) GetMetadataKey() TimeBucketKey {
 	return rs.metadataKey
 }
 
-func (rs *RowSeries) SetCandleAttributes(ca *CandleAttributes) {
-	rs.rows.SetCandleAttributes(ca)
-}
-func (rs *RowSeries) GetCandleAttributes() *CandleAttributes {
-	return rs.rows.GetCandleAttributes()
-}
 func (rs *RowSeries) GetRow(i int) []byte {
 	return rs.rows.GetRow(i)
 }
@@ -230,6 +210,5 @@ func (rs *RowSeries) ToColumnSeries() (key TimeBucketKey, cs *ColumnSeries) {
 		}
 		cs.AddColumn(ds.Name, rs.GetColumn(ds.Name))
 	}
-	cs.SetCandleAttributes(rs.GetCandleAttributes())
 	return key, cs
 }


### PR DESCRIPTION
I found that `CandleAttributes` type is defined and set to many structs but never be used in marketstore...

I don't know if there are any plans to use this, but let me remove this for now...