### PR TITLE
fix: index starts from 1 for 1day timeframe

### DIFF
--- a/executor/ticks_test.go
+++ b/executor/ticks_test.go
@@ -18,20 +18,13 @@ func (s *TickTests) SetUpSuite(c *C)    {}
 func (s *TickTests) TearDownSuite(c *C) {}
 
 func (s *TickTests) TestTimeToIntervals(c *C) {
-	t2 := time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
-	index := io.TimeToIndex(t2, time.Minute)
-	c.Assert(index == 1, Equals, true)
-	t2 = time.Date(2016, 12, 31, 23, 59, 0, 0, time.UTC)
-	index = io.TimeToIndex(t2, time.Minute)
-	c.Assert(index == 366*1440, Equals, true)
-
 	//20161230 21:59:20 383000
 	t1 := time.Date(2016, 12, 30, 21, 59, 20, 383000000, time.UTC)
 	fmt.Println("LAL t1 = ", t1)
 
 	// Check the 1Min interval
 	utils.InstanceConfig.Timezone = time.UTC
-	index = io.TimeToIndex(t1, time.Minute)
+	index := io.TimeToIndex(t1, time.Minute)
 
 	o_t1 := io.IndexToTime(index, time.Minute, 2016)
 	//fmt.Println("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())

--- a/tests/integ/tests/test_1day_timeframe.py
+++ b/tests/integ/tests/test_1day_timeframe.py
@@ -1,0 +1,67 @@
+"""
+Integration Test for 1Day timeframe
+"""
+import os
+
+import numpy as np
+import pandas as pd
+import pymarketstore as pymkts
+import pytest
+
+# Constants
+DATA_TYPE_TICK = [('Epoch', 'i8'), ('Bid', 'f4'), ('Ask', 'f4'), ('Nanoseconds', 'i4')]
+DATA_TYPE_CANDLE = [('Epoch', 'i8'), ('Open', 'f8'), ('High', 'f8'), ('Low', 'f8'), ('Close', 'f8'), ('Volume', 'f8')]
+MARKETSTORE_HOST = "localhost"
+MARKETSTORE_PORT = 5993
+
+client = pymkts.Client(f"http://127.0.0.1:{os.getenv('MARKETSTORE_PORT', 5993)}/rpc",
+                       grpc=(os.getenv("USE_GRPC", "false") == "true"))
+
+
+def timestamp(datestr):
+    return int(pd.Timestamp(datestr).value / 10 ** 9)
+
+
+@pytest.mark.parametrize('symbol, data', [
+    ('TEST_SIMPLE_TICK', [(timestamp('2019-01-01 00:00:00'), 1, 2, 0),  # epoch, ask, bid, nanosecond
+                          (timestamp('2019-01-01 12:00:00'), 3, 4, 0),
+                          (timestamp('2019-12-31 18:00:00'), 5, 6, 0)]),
+    ('TEST_MULTIPLE_TICK_IN_TIMEFRAME', [(timestamp('2019-01-01 06:00:00'), 1, 1, 0),
+                                         (timestamp('2019-01-01 06:00:00'), 2, 2, 0)]),
+    ('TEST_DUPLICATE_INDEX', [(timestamp('2019-01-01 00:00:00'), 1, 1, 0),
+                              (timestamp('2019-01-01 00:00:00'), 2, 2, 0)])
+])
+def test_1day_tf_tick(symbol, data):
+    # ---- given ----
+    tbk = "{}/1D/TICK".format(symbol)
+    client.destroy(tbk)  # setup
+
+    client.write(np.array(data, dtype=DATA_TYPE_TICK), tbk, isvariablelength=True)
+
+    # ---- when ----
+    reply = client.query(pymkts.Params(symbol, '1D', 'TICK', limit=10))
+
+    # ---- then ----
+    data_without_epochs = [record[1:] for record in data]
+    assert (reply.first().df().values == data_without_epochs).all()
+
+
+@pytest.mark.parametrize('symbol, data', [
+    ('TEST_SIMPLE_OHLCV',
+     [(timestamp('2019-01-01 00:00:00'), 1.0, 2.0, 3.0, 4.0, 5.0),  # epoch, Open, High, Low, Close, Volume
+      (timestamp('2019-01-02 00:00:00'), 1.0, 2.0, 3.0, 4.0, 5.0),
+      (timestamp('2019-12-31 00:00:00'), 6.0, 7.0, 8.0, 9.0, 10.0)]),
+])
+def test_1sec_tf_candle(symbol, data):
+    # ---- given ----
+    tbk = "{}/1D/OHLCV".format(symbol)
+    client.destroy(tbk)  # setup
+
+    print(client.write(np.array(data, dtype=DATA_TYPE_CANDLE), tbk, isvariablelength=False))
+
+    # ---- when ----
+    reply = client.query(pymkts.Params(symbol, '1D', 'OHLCV', limit=10))
+
+    # ---- then ----
+    data_without_epochs = [record[1:] for record in data]
+    assert (reply.first().df().values == data_without_epochs).all()

--- a/utils/io/all_test.go
+++ b/utils/io/all_test.go
@@ -300,7 +300,7 @@ func (s *TestSuite) TestIndexAndOffset(c *C) {
 	// Check the 1D interval
 	t2 := time.Date(2018, time.February, 5, 0, 0, 0, 0, loc)
 	index = TimeToIndex(t2, utils.Day)
-	c.Assert(index, Equals, int64(35))
+	c.Assert(index, Equals, int64(36))
 	o_t2 := IndexToTime(index, utils.Day, 2018)
 	c.Assert(o_t2, Equals, t2)
 
@@ -314,7 +314,7 @@ func (s *TestSuite) TestIndexAndOffset(c *C) {
 	// Check 1D at end of year
 	t3 := time.Date(2018, time.December, 31, 0, 0, 0, 0, loc)
 	index = TimeToIndex(t3, utils.Day)
-	c.Assert(index, Equals, int64(364))
+	c.Assert(index, Equals, int64(365))
 	o_t3 := IndexToTime(index, utils.Day, 2018)
 	c.Assert(o_t3, Equals, t3)
 

--- a/utils/io/timeindex.go
+++ b/utils/io/timeindex.go
@@ -14,9 +14,7 @@ func IndexToTime(index int64, tf time.Duration, year int16) time.Time {
 		time.January,
 		1, 0, 0, 0, 0,
 		utils.InstanceConfig.Timezone)
-	if tf == utils.Day {
-		return t0.AddDate(0, 0, int(index))
-	}
+
 	return t0.Add(tf * time.Duration(index-1))
 }
 
@@ -31,10 +29,7 @@ func ToSystemTimezone(t time.Time) time.Time {
 // MarketStore configuration file (or UTC by default),
 func TimeToIndex(t time.Time, tf time.Duration) int64 {
 	tLocal := ToSystemTimezone(t)
-	// special 1D case (maximum supported on-disk size)
-	if tf == utils.Day {
-		return int64(tLocal.YearDay() - 1)
-	}
+
 	return 1 + tLocal.Sub(
 		time.Date(
 			tLocal.Year(),

--- a/utils/io/timeindex_test.go
+++ b/utils/io/timeindex_test.go
@@ -1,6 +1,7 @@
 package io_test
 
 import (
+	"github.com/alpacahq/marketstore/v4/utils"
 	"github.com/alpacahq/marketstore/v4/utils/io"
 	"reflect"
 	"testing"
@@ -9,6 +10,8 @@ import (
 
 func TestIndexToTime(t *testing.T) {
 	t.Parallel()
+	utils.InstanceConfig.Timezone = time.UTC
+
 	tests := []struct {
 		name  string
 		index int64

--- a/utils/io/timeindex_test.go
+++ b/utils/io/timeindex_test.go
@@ -1,0 +1,66 @@
+package io_test
+
+import (
+	"github.com/alpacahq/marketstore/v4/utils/io"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestIndexToTime(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		index int64
+		tf    time.Duration
+		year  int16
+		want  time.Time
+	}{
+		{
+			name:  "tf=1Day, index=1, year=2020 -> 2020-01-01 00:00:00",
+			index: 1, tf: 24 * time.Hour, year: 2020,
+			want: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "tf=1Hour, index=1, year=2020 -> 2020-01-01 00:00:00",
+			index: 1, tf: 1 * time.Hour, year: 2020,
+			want: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:  "tf=1Sec, index=(3600*24*365), year=2019 -> 2019-12-31 23:59:59",
+			index: 3600 * 24 * 365, tf: 1 * time.Second, year: 2019,
+			want: time.Date(2019, 12, 31, 23, 59, 59, 0, time.UTC),
+		},
+		{
+			name:  "tf=1Sec, index=(3600*24*(365+1)), year=2020 -> 2020-12-31 23:59:59",
+			index: 3600 * 24 * (365 + 1), // +1 because 2020 is a leap year
+			tf:    1 * time.Second, year: 2020,
+			want: time.Date(2020, 12, 31, 23, 59, 59, 0, time.UTC),
+		},
+		{
+			name:  "tf=1Day, index=(24*365), year=2019 -> 2019-12-31 00:00:00",
+			index: 365,
+			tf:    24 * time.Hour,
+			year:  2019,
+			want:  time.Date(2019, 12, 31, 00, 00, 00, 0, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// convert to Time
+			gotTime := io.IndexToTime(tt.index, tt.tf, tt.year)
+			if !reflect.DeepEqual(gotTime, tt.want) {
+				t.Fatalf("IndexToTime() = %v, want %v", gotTime, tt.want)
+			}
+
+			// convert back to Index
+			gotIndex := io.TimeToIndex(gotTime, tt.tf)
+			if !reflect.DeepEqual(gotIndex, tt.index) {
+				t.Fatalf("TimeToIndex() = %v, want %v", gotIndex, tt.index)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## WHAT
- update the code to calculate index from time, and time from index so that the index starts from 1 for 1day timeframe.

## WHY
- If we allow index=0 as a valid record, it causes an issue when we query data stored on Jan.1st 00:00:00 (-> index=0. the epoch column binary is filled with 0) because marketstore can't distinguish them with empty data
