### PR TITLE
fix: remove escapes by using back quotes

### DIFF
--- a/cmd/connect/session/client.go
+++ b/cmd/connect/session/client.go
@@ -140,33 +140,33 @@ EVAL:
 		// Evaulate.
 		switch {
 		// Flip timing flag.
-		case strings.HasPrefix(line, "\\o"):
+		case strings.HasPrefix(line, `\o`):
 			args := strings.Split(line, " ")
 			if len(args) > 1 {
 				c.target = args[1]
 			} else {
 				c.target = ""
 			}
-		case strings.HasPrefix(line, "\\timing"):
+		case strings.HasPrefix(line, `\timing`):
 			c.timing = !c.timing
-		case strings.HasPrefix(line, "\\show"):
+		case strings.HasPrefix(line, `\show`):
 			c.show(line)
-		case strings.HasPrefix(line, "\\trim"):
+		case strings.HasPrefix(line, `\trim`):
 			c.trim(line)
-		case strings.HasPrefix(line, "\\load"):
+		case strings.HasPrefix(line, `\load`):
 			c.load(line)
-		case strings.HasPrefix(line, "\\create"):
+		case strings.HasPrefix(line, `\create`):
 			c.create(line)
-		case strings.HasPrefix(line, "\\destroy"):
+		case strings.HasPrefix(line, `\destroy`):
 			c.destroy(line)
-		case strings.HasPrefix(line, "\\getinfo"):
+		case strings.HasPrefix(line, `\getinfo`):
 			c.getinfo(line)
-		case strings.HasPrefix(line, "\\help") || strings.HasPrefix(line, "\\?"):
+		case strings.HasPrefix(line, `\help`) || strings.HasPrefix(line, `\?`):
 			c.functionHelp(line)
 		case line == "help":
-			c.functionHelp("\\help")
+			c.functionHelp(`\help`)
 		// Quit.
-		case line == "\\stop", line == "\\quit", line == "\\q", line == "exit":
+		case line == `\stop`, line == `\quit`, line == `\q`, line == `exit`:
 			break EVAL
 			// Nothing to do.
 		case line == "":
@@ -190,16 +190,16 @@ func newReader() (*readline.Instance, error) {
 
 	// Register commands with autocompletion.
 	autoComplete := readline.NewPrefixCompleter(
-		readline.PcItem("\\show"),
-		readline.PcItem("\\load"),
-		readline.PcItem("\\create"),
-		readline.PcItem("\\trim"),
-		readline.PcItem("\\help"),
-		readline.PcItem("\\exit"),
-		readline.PcItem("\\quit"),
-		readline.PcItem("\\q"),
-		readline.PcItem("\\?"),
-		readline.PcItem("\\stop"),
+		readline.PcItem(`\show`),
+		readline.PcItem(`\load`),
+		readline.PcItem(`\create`),
+		readline.PcItem(`\trim`),
+		readline.PcItem(`\help`),
+		readline.PcItem(`\exit`),
+		readline.PcItem(`\quit`),
+		readline.PcItem(`\q`),
+		readline.PcItem(`\?`),
+		readline.PcItem(`\stop`),
 	)
 
 	// Build config.

--- a/cmd/connect/session/load.go
+++ b/cmd/connect/session/load.go
@@ -137,11 +137,11 @@ func writeNumpy(c *Client, npm *io.NumpyMultiDataset, isVariable bool) (err erro
 
 func parseLoadArgs(args []string) (mk *io.TimeBucketKey, inputFD, controlFD *os.File, err error) {
 	if len(args) < 2 {
-		return nil, nil, nil, errors.New("Not enough arguments, see \"\\help load\"")
+		return nil, nil, nil, errors.New(`not enough arguments, see "\help load"`)
 	}
 	mk = io.NewTimeBucketKey(args[0])
 	if mk == nil {
-		return nil, nil, nil, errors.New("Key is not in proper format, see \"\\help load\"")
+		return nil, nil, nil, errors.New(`key is not in proper format, see "\help load"`)
 	}
 	/*
 		We need to read two file names that open successfully

--- a/cmd/connect/session/show.go
+++ b/cmd/connect/session/show.go
@@ -23,7 +23,7 @@ func (c *Client) show(line string) {
 	}
 	tbk, start, end := c.parseQueryArgs(args)
 	if tbk == nil {
-		fmt.Println("Could not parse arguments, see \"\\help show\" ")
+		fmt.Println(`Could not parse arguments, see "\help show" `)
 		return
 	}
 
@@ -141,7 +141,7 @@ func (c *Client) processShowRemote(tbk *io.TimeBucketKey, start, end *time.Time)
 func (c *Client) parseQueryArgs(args []string) (tbk *io.TimeBucketKey, start, end *time.Time) {
 	tbk = io.NewTimeBucketKey(args[0])
 	if tbk == nil {
-		fmt.Println("Key is not in proper format, see \"\\help show\" ")
+		fmt.Println(`Key is not in proper format, see "\help show" `)
 		return
 	}
 	parsedTime := false


### PR DESCRIPTION
## WHAT
remove escapes by using back quotes because a string encoded in back quotes is a raw literal string and doesn’t honor any kind of escaping in Golang.

## WHY
small refactor