### PR TITLE
fix: suppress the panic of create command

### DIFF
--- a/cmd/connect/session/create.go
+++ b/cmd/connect/session/create.go
@@ -71,6 +71,12 @@ func (c *Client) create(line string) {
 	args := strings.Split(line, " ")
 	args = args[1:] // chop off the first word which should be "create"
 	// args[0]:tbk, args[1]:dataTypeStr, args[2]:"fixed" or "variable"
+	if len(args) < 3 {
+		fmt.Println(`Not enough arguments - need "\create [tbk] [dataTypeStr] [recordType('fixed' or 'variable')]"`)
+		fmt.Println(`example usage: "\create TEST/1Min/OHLCV:Symbol/Timeframe/AttributeGroup ` +
+			`Open,High,Low,Close/float32:Volume/int64 variable"`)
+		return
+	}
 
 	columnNames, columnTypes, err := toColumns(args[1])
 	if err != nil {


### PR DESCRIPTION
## WHAT
- add an error handling for \create command

## WHY
- A panic happens when not enough arguments are passed to \create command