### PR TITLE
info log when CSV is imported using local mode

### DIFF
--- a/cmd/connect/loader/utils.go
+++ b/cmd/connect/loader/utils.go
@@ -45,7 +45,7 @@ func CSVtoNumpyMulti(csvReader *csv.Reader, tbk io.TimeBucketKey, cvm *CSVMetada
 	if len(csvChunk) == 0 {
 		return nil, true, nil
 	}
-	fmt.Printf("Read next %d lines from CSV file...", linesRead)
+	fmt.Printf("Read next %d lines from CSV file...\n", linesRead)
 
 	csm, err := convertCSVtoCSM(tbk, cvm, csvChunk)
 	if err != nil {

--- a/cmd/connect/session/load.go
+++ b/cmd/connect/session/load.go
@@ -102,6 +102,15 @@ func (c *Client) load(line string) {
 		}
 	}
 
+	// because a marketstore process has cache of the data directory structure (executor.ThisInstance.CatalogDir)
+	// and it can't be updated by the CSV import using the local mode,
+	// the imported data is not returned to query responses until restart marketstore,
+	// the data is correctly written to the data file though.
+	if c.mode == local {
+		fmt.Println("Note: The imported data won't be returned to query responses until restart marketstore" +
+			" due to the cache of the marketstore process.")
+	}
+
 	return
 }
 


### PR DESCRIPTION
## WHAT
- print log when a CSV file is imported using the local mode

## WHY
- Without the log, it's confusing that the data is not updated until restart marketstore.