### PR TITLE
chore: small refactor to prepare for Dependency Injection

### DIFF
--- a/cmd/connect/main.go
+++ b/cmd/connect/main.go
@@ -63,9 +63,6 @@ func validateArgs(cmd *cobra.Command, args []string) error {
 	if len(dir) == 0 && len(url) == 0 {
 		return errors.New("cannot connect to database, use a flag to set location")
 	}
-	if varCompOff {
-		utils.InstanceConfig.DisableVariableCompression = true
-	}
 	return nil
 }
 
@@ -89,6 +86,10 @@ func executeConnect(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if varCompOff {
+		utils.InstanceConfig.DisableVariableCompression = true
 	}
 
 	// Initialize connection.


### PR DESCRIPTION
## WHAT
- use config object instead of utils.InstanceConfig

## WHY
- In the future, we want to stop using InstanceConfig because it's a singleton object and hard to write unit tests