### PR TITLE
refactor(stop using singleton config): rootDir and TriggerSettings

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -74,11 +74,10 @@ func executeStart(cmd *cobra.Command, args []string) error {
 	log.Info("using %v for configuration", configFilePath)
 
 	// Attempt to set configuration.
-	err = utils.InstanceConfig.Parse(data)
+	config, err := utils.InstanceConfig.Parse(data)
 	if err != nil {
 		return fmt.Errorf("failed to parse configuration file error: %v", err.Error())
 	}
-	config := utils.InstanceConfig
 
 	// New grpc server for marketstore API.
 	grpcServer := grpc.NewServer(

--- a/utils/config.go
+++ b/utils/config.go
@@ -65,7 +65,7 @@ type MktsConfig struct {
 	BgWorkers                  []*BgWorkerSetting
 }
 
-func (m *MktsConfig) Parse(data []byte) error {
+func (m *MktsConfig) Parse(data []byte) (*MktsConfig, error) {
 	var (
 		err error
 		aux struct {
@@ -113,19 +113,19 @@ func (m *MktsConfig) Parse(data []byte) error {
 	)
 
 	if err := yaml.Unmarshal(data, &aux); err != nil {
-		return err
+		return nil, err
 	}
 
 	rootDir, err := filepath.Abs(filepath.Clean(aux.RootDirectory))
 	if aux.RootDirectory == "" || err != nil {
 		log.Fatal("Invalid root directory.")
-		return errors.New("Invalid root directory.")
+		return nil, errors.New("Invalid root directory.")
 	}
 	m.RootDirectory = rootDir
 
 	if aux.ListenPort == "" {
 		log.Fatal("Invalid listen port.")
-		return errors.New("Invalid listen port.")
+		return nil, errors.New("Invalid listen port.")
 	}
 
 	// GRPC is optional for now
@@ -151,7 +151,7 @@ func (m *MktsConfig) Parse(data []byte) error {
 	m.Timezone, err = time.LoadLocation(aux.Timezone)
 	if err != nil {
 		log.Fatal("Invalid timezone.")
-		return errors.New("Invalid timezone")
+		return nil, errors.New("Invalid timezone")
 	}
 
 	if aux.WALRotateInterval == 0 {
@@ -320,5 +320,5 @@ func (m *MktsConfig) Parse(data []byte) error {
 		m.BgWorkers = append(m.BgWorkers, bgWorkerSetting)
 	}
 
-	return err
+	return &InstanceConfig, err
 }


### PR DESCRIPTION
## WHAT
- stop using `executor.ThisInstance.RootDir/Triggers` and pass it as a function argument or struct parameter for each module

## WHY
- `executor.ThisInstance` is a singleton instance, and it makes it difficult to write unit tests of marketstore.