### PR TITLE
refactor(stop using singleton config): executor.ThisInstance.WALRotateInterval

### DIFF
--- a/cmd/connect/session/client.go
+++ b/cmd/connect/session/client.go
@@ -21,7 +21,6 @@ import (
 	"github.com/alpacahq/marketstore/v4/executor"
 	"github.com/alpacahq/marketstore/v4/frontend/client"
 	"github.com/alpacahq/marketstore/v4/sqlparser"
-	"github.com/alpacahq/marketstore/v4/utils"
 	dbio "github.com/alpacahq/marketstore/v4/utils/io"
 	"github.com/chzyer/readline"
 )
@@ -63,9 +62,9 @@ type RPCClient interface {
 func NewLocalClient(dir string, disableVariableCompression bool) (c *Client, err error) {
 	// Configure db settings.
 	initCatalog, initWALCache, backgroundSync, WALBypass := true, true, false, true
-	utils.InstanceConfig.WALRotateInterval = 5
+	walRotateInterval := 5
 	executor.NewInstanceSetup(dir,
-		nil, initCatalog, initWALCache, backgroundSync, WALBypass,
+		nil, walRotateInterval, initCatalog, initWALCache, backgroundSync, WALBypass,
 	)
 	return &Client{dir: dir, mode: local, disableVariableCompression: disableVariableCompression}, nil
 }

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -139,6 +139,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 	executor.NewInstanceSetup(
 		config.RootDirectory,
 		rs,
+		config.WALRotateInterval,
 		config.InitCatalog,
 		config.InitWALCache,
 		config.BackgroundSync,

--- a/contrib/alpaca/handlers/handlers_test.go
+++ b/contrib/alpaca/handlers/handlers_test.go
@@ -22,7 +22,7 @@ type HandlersTestSuite struct {
 
 func (s *HandlersTestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
-	executor.NewInstanceSetup(s.Rootdir, nil, true, true, false, true) // WAL Bypass
+	executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDirectory = executor.ThisInstance.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 }

--- a/contrib/candler/candlecandler/all_test.go
+++ b/contrib/candler/candlecandler/all_test.go
@@ -32,7 +32,7 @@ type TestSuite struct {
 func (s *TestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyStockDir(s.Rootdir, true, false)
-	executor.NewInstanceSetup(s.Rootdir, nil, true, true, false, true) // WAL Bypass
+	executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDirectory = executor.ThisInstance.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 }

--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -32,7 +32,7 @@ type TestSuite struct {
 func (s *TestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyCurrencyDir(s.Rootdir, false, false)
-	executor.NewInstanceSetup(s.Rootdir, nil, true, true, false, true) // WAL Bypass
+	executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDirectory = executor.ThisInstance.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 }

--- a/contrib/ice/cmd/reorg/import.go
+++ b/contrib/ice/cmd/reorg/import.go
@@ -37,7 +37,7 @@ var ImportCmd = &cobra.Command{
 		}
 		dataDir := args[0]
 		reorgDir := args[1]
-		executor.NewInstanceSetup(dataDir, nil, true, true, true, true)
+		executor.NewInstanceSetup(dataDir, nil, 5, true, true, true, true)
 		reorg.Import(reorgDir, reimport, storeWithoutSymbols)
 		return nil
 	},

--- a/contrib/ice/cmd/reorg/show.go
+++ b/contrib/ice/cmd/reorg/show.go
@@ -29,7 +29,7 @@ var ShowRecordsCmd = &cobra.Command{
 		}
 		cusip := args[1]
 		dataDir := args[0]
-		executor.NewInstanceSetup(dataDir, nil, true, true, true, true)
+		executor.NewInstanceSetup(dataDir, nil, 5, true, true, true, true)
 		showRecords(cusip)
 		return nil
 	},

--- a/contrib/iex/backfill/backfill.go
+++ b/contrib/iex/backfill/backfill.go
@@ -237,12 +237,12 @@ func nextBatch(bars []*consolidator.Bar, index int) ([]*consolidator.Bar, int) {
 
 func initWriter() {
 	utils.InstanceConfig.Timezone = NY
-	utils.InstanceConfig.WALRotateInterval = 5
+	walRotateInterval := 5
 	instanceID := time.Now().UTC().UnixNano()
 
 	executor.NewInstanceSetup(
 		fmt.Sprintf("%v/mktsdb", dir), nil,
-		true, true, true, true)
+		walRotateInterval, true, true, true, true)
 
 	log.Info(
 		"Initialized writer with InstanceID: %v - RootDir: %v\n",

--- a/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
@@ -109,7 +109,7 @@ func (t *TestSuite) TestFireBars(c *C) {
 	os.MkdirAll(rootDir, 0777)
 	executor.NewInstanceSetup(
 		rootDir, nil,
-		true, true, false, false)
+		5, true, true, false, false)
 
 	ts := utils.TriggerSetting{
 		Module: "ondiskagg.so",

--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -71,8 +71,8 @@ func init() {
 }
 
 func main() {
-	rootDir, triggers := initConfig()
-	initWriter(rootDir, triggers)
+	rootDir, triggers, walRotateInterval := initConfig()
+	initWriter(rootDir, triggers, walRotateInterval)
 
 	// free memory in the background every 1 minute for long running backfills with very high parallelism
 	go func() {
@@ -243,7 +243,7 @@ func main() {
 	log.Info("[polygon] backfilling complete %s", time.Now().Sub(startTime))
 }
 
-func initConfig() (rootDir string, triggers []*utils.TriggerSetting) {
+func initConfig() (rootDir string, triggers []*utils.TriggerSetting, walRotateInterval int) {
 	data, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
 		log.Fatal("failed to read configuration file error: %s", err.Error())
@@ -256,11 +256,11 @@ func initConfig() (rootDir string, triggers []*utils.TriggerSetting) {
 		os.Exit(1)
 	}
 
-	return config.RootDirectory, config.Triggers
+	return config.RootDirectory, config.Triggers, config.WALRotateInterval
 }
 
-func initWriter(rootDir string, triggers []*utils.TriggerSetting) {
-	executor.NewInstanceSetup(rootDir, nil, true, true, true, true)
+func initWriter(rootDir string, triggers []*utils.TriggerSetting, walRotateInterval int) {
+	executor.NewInstanceSetup(rootDir, nil, walRotateInterval, true, true, true, true)
 	// if configured, also load the ondiskagg triggers
 	for _, triggerSetting := range triggers {
 		if triggerSetting.Module == "ondiskagg.so" {

--- a/contrib/polygon/handlers/handlers_test.go
+++ b/contrib/polygon/handlers/handlers_test.go
@@ -25,7 +25,7 @@ type HandlersTestSuite struct {
 
 func (s *HandlersTestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
-	executor.NewInstanceSetup(s.Rootdir, nil, true, true, false, true) // WAL Bypass
+	executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDirectory = executor.ThisInstance.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 }

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -59,7 +59,7 @@ type DestructiveWALTest2 struct {
 func (s *TestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyCurrencyDir(s.Rootdir, true, false)
-	executor.NewInstanceSetup(s.Rootdir, nil, true, true, false)
+	executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
 	s.DataDirectory = executor.ThisInstance.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 }
@@ -714,7 +714,7 @@ func (s *TestSuite) TestWriter(c *C) {
 func (s *DestructiveWALTests) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyCurrencyDir(s.Rootdir, true, false)
-	executor.NewInstanceSetup(s.Rootdir, nil, true, true, false)
+	executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
 	s.DataDirectory = executor.ThisInstance.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 }
@@ -851,7 +851,7 @@ func (s *DestructiveWALTests) TestBrokenWAL(c *C) {
 func (s *DestructiveWALTest2) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyCurrencyDir(s.Rootdir, true, false)
-	executor.NewInstanceSetup(s.Rootdir, nil, true, true, false)
+	executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
 	s.DataDirectory = executor.ThisInstance.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 }

--- a/executor/instance.go
+++ b/executor/instance.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/alpacahq/marketstore/v4/catalog"
 	"github.com/alpacahq/marketstore/v4/plugins/trigger"
-	"github.com/alpacahq/marketstore/v4/utils"
 	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
@@ -25,7 +24,7 @@ type InstanceMetadata struct {
 	TriggerMatchers []*trigger.TriggerMatcher
 }
 
-func NewInstanceSetup(relRootDir string, rs ReplicationSender, options ...bool) {
+func NewInstanceSetup(relRootDir string, rs ReplicationSender, walRotateInterval int, options ...bool) {
 	/*
 		Defaults
 	*/
@@ -88,7 +87,7 @@ func NewInstanceSetup(relRootDir string, rs ReplicationSender, options ...bool) 
 		}
 		if backgroundSync {
 			// Startup the WAL and Primary cache flushers
-			go ThisInstance.WALFile.SyncWAL(500*time.Millisecond, 5*time.Minute, utils.InstanceConfig.WALRotateInterval)
+			go ThisInstance.WALFile.SyncWAL(500*time.Millisecond, 5*time.Minute, walRotateInterval)
 			ThisInstance.WALWg.Add(1)
 		}
 	}

--- a/frontend/server_test.go
+++ b/frontend/server_test.go
@@ -26,7 +26,7 @@ func (s *ServerTestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	//s.Rootdir = "/tmp/LALtemp"
 	test.MakeDummyCurrencyDir(s.Rootdir, true, false)
-	executor.NewInstanceSetup(s.Rootdir, nil,true, true, false, false)
+	executor.NewInstanceSetup(s.Rootdir, nil,5, true, true, false, false)
 	atomic.StoreUint32(&Queryable, uint32(1))
 }
 

--- a/frontend/stream/stream_test.go
+++ b/frontend/stream/stream_test.go
@@ -24,7 +24,7 @@ var _ = Suite(&StreamTestSuite{})
 
 func (s *StreamTestSuite) SetUpSuite(c *C) {
 	root := c.MkDir()
-	executor.NewInstanceSetup(root, nil, true, true, false, false)
+	executor.NewInstanceSetup(root, nil, 5, true, true, false, false)
 
 	Initialize()
 }

--- a/sqlparser/all_test.go
+++ b/sqlparser/all_test.go
@@ -33,7 +33,7 @@ type TestSuite struct {
 func (s *TestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyStockDir(s.Rootdir, true, false)
-	executor.NewInstanceSetup(s.Rootdir, nil, true, true, false)
+	executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
 	s.DataDirectory = executor.ThisInstance.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 }


### PR DESCRIPTION
## WHAT
- stop using `executor.ThisInstance.WALRotateInterval` and pass it as a function argument or struct parameter for each module

## WHY
- `executor.ThisInstance` is a singleton instance, and it makes it difficult to write unit tests of marketstore.