### PR TITLE
refactor: pass config to plugins

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -167,8 +167,8 @@ func executeStart(cmd *cobra.Command, args []string) error {
 	http.Handle("/metrics", promhttp.Handler())
 
 	// Initialize any provided plugins.
-	InitializeTriggers()
-	RunBgWorkers()
+	InitializeTriggers(config)
+	RunBgWorkers(config)
 
 	if config.UtilitiesURL != "" {
 		// Start utility endpoints.

--- a/cmd/start/plugins.go
+++ b/cmd/start/plugins.go
@@ -9,9 +9,8 @@ import (
 	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
-func InitializeTriggers() {
+func InitializeTriggers(config *utils.MktsConfig) {
 	log.Info("InitializeTriggers")
-	config := utils.InstanceConfig
 	theInstance := executor.ThisInstance
 	for _, triggerSetting := range config.Triggers {
 		log.Info("triggerSetting = %v", triggerSetting)
@@ -38,9 +37,8 @@ func NewTriggerMatcher(ts *utils.TriggerSetting) *trigger.TriggerMatcher {
 	return trigger.NewMatcher(trig, ts.On)
 }
 
-func RunBgWorkers() {
+func RunBgWorkers(config *utils.MktsConfig) {
 	log.Info("InitializeBgWorkers")
-	config := utils.InstanceConfig
 	for _, bgWorkerSetting := range config.BgWorkers {
 		// bgWorkerSetting may contain sensitive data such as a password or token.
 		log.Debug("bgWorkerSetting = %v", bgWorkerSetting)


### PR DESCRIPTION
## WHAT
- pass MktsConfig to marketstore plugins
## WHY
- to stop using the singleton config `utils.InstanceConfig` in the near future