### PR TITLE
bugfix: pass MktsConfig to plugins

### DIFF
--- a/contrib/binancefeeder/binancefeeder.go
+++ b/contrib/binancefeeder/binancefeeder.go
@@ -185,7 +185,7 @@ func findLastTimestamp(tbk *io.TimeBucketKey) time.Time {
 	if err != nil {
 		return time.Time{}
 	}
-	reader, err := executor.NewReader(parsed, false)
+	reader, err := executor.NewReader(parsed, utils.InstanceConfig.DisableVariableCompression)
 	csm, err := reader.Read()
 	cs := csm[*tbk]
 	if cs == nil || cs.Len() == 0 {

--- a/contrib/bitmexfeeder/bitmexfeeder.go
+++ b/contrib/bitmexfeeder/bitmexfeeder.go
@@ -101,7 +101,7 @@ func findLastTimestamp(tbk *io.TimeBucketKey) time.Time {
 	if err != nil {
 		return time.Time{}
 	}
-	reader, err := executor.NewReader(parsed, false)
+	reader, err := executor.NewReader(parsed, utils.InstanceConfig.DisableVariableCompression)
 	csm, err := reader.Read()
 	cs := csm[*tbk]
 	if cs == nil || cs.Len() == 0 {

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -126,7 +126,7 @@ func findLastTimestamp(tbk *io.TimeBucketKey) time.Time {
 	if err != nil {
 		return time.Time{}
 	}
-	reader, err := executor.NewReader(parsed, false)
+	reader, err := executor.NewReader(parsed, utils.InstanceConfig.DisableVariableCompression)
 	csm, err := reader.Read()
 	cs := csm[*tbk]
 	if cs == nil || cs.Len() == 0 {

--- a/contrib/ondiskagg/aggtrigger/aggtrigger.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger.go
@@ -384,7 +384,7 @@ func (s *OnDiskAggTrigger) query(
 		return nil, err
 	}
 
-	scanner, err := executor.NewReader(parsed, false)
+	scanner, err := executor.NewReader(parsed, utils.InstanceConfig.DisableVariableCompression)
 	if err != nil {
 		return nil, err
 	}

--- a/contrib/polygon/polygon.go
+++ b/contrib/polygon/polygon.go
@@ -7,15 +7,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alpacahq/marketstore/v4/contrib/polygon/worker"
-
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/api"
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/backfill"
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/handlers"
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/polygon_config"
+	"github.com/alpacahq/marketstore/v4/contrib/polygon/worker"
 	"github.com/alpacahq/marketstore/v4/executor"
 	"github.com/alpacahq/marketstore/v4/planner"
 	"github.com/alpacahq/marketstore/v4/plugins/bgworker"
+	"github.com/alpacahq/marketstore/v4/utils"
 	"github.com/alpacahq/marketstore/v4/utils/io"
 	"github.com/alpacahq/marketstore/v4/utils/log"
 )
@@ -147,7 +147,7 @@ func (pf *PolygonFetcher) backfillBars(symbol string, end time.Time, writerWP *w
 			return
 		}
 
-		scanner, err := executor.NewReader(parsed, false)
+		scanner, err := executor.NewReader(parsed, utils.InstanceConfig.DisableVariableCompression)
 		if err != nil {
 			log.Error("[polygon] new scanner failure (%v)", err)
 			return

--- a/contrib/stream/streamtrigger/streamtrigger.go
+++ b/contrib/stream/streamtrigger/streamtrigger.go
@@ -96,7 +96,7 @@ func (s *StreamTrigger) Fire(keyPath string, records []trigger.Record) {
 		return
 	}
 
-	scanner, err := executor.NewReader(parsed, false)
+	scanner, err := executor.NewReader(parsed, utils.InstanceConfig.DisableVariableCompression)
 	if err != nil {
 		log.Error("[streamtrigger] new scanner failure (%v)", err)
 		return


### PR DESCRIPTION
## WHAT
- pass MktsConfig.DisableVariableCompression config to plugins

## WHY
- tried to stop using the singleton config `utils.InstanceConfig.DisableVariableCompression` but currently there is no way to inject the config without using the singleton config