### PR TITLE
refactor(stop using singleton config): utils.InstanceConfig.WalBypass

### DIFF
--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -726,7 +726,7 @@ func (s *DestructiveWALTests) TearDownSuite(c *C) {
 func (s *DestructiveWALTests) TestWALWrite(c *C) {
 	var err error
 	mockInstanceID := time.Now().UTC().UnixNano()
-	s.WALFile, err = executor.NewWALFile(s.Rootdir, mockInstanceID, nil, false)
+	s.WALFile, err = executor.NewWALFile(s.Rootdir, mockInstanceID, nil, false, false)
 	if err != nil {
 		fmt.Println(err)
 		c.Fail()

--- a/executor/instance.go
+++ b/executor/instance.go
@@ -67,18 +67,18 @@ func NewInstanceSetup(relRootDir string, rs ReplicationSender, walRotateInterval
 	if initCatalog {
 		ThisInstance.CatalogDir = catalog.NewDirectory(rootDir)
 	}
-	ThisInstance.WALBypass = WALBypass
+
 	if initWALCache {
 		// Allocate a new WALFile and cache
 		if WALBypass {
 			ThisInstance.TXNPipe = NewTransactionPipe()
-			ThisInstance.WALFile, err = NewWALFile(ThisInstance.RootDir, instanceID, nil, false)
+			ThisInstance.WALFile, err = NewWALFile(ThisInstance.RootDir, instanceID, nil, false, WALBypass)
 			if err != nil {
 				log.Fatal("Unable to create WAL")
 			}
 		} else {
 			ThisInstance.TXNPipe, ThisInstance.WALFile, err = StartupCacheAndWAL(ThisInstance.RootDir, instanceID, rs,
-				false,
+				false, WALBypass,
 			)
 
 			if err != nil {


### PR DESCRIPTION
## WHAT
- stop using `utils.InstanceConfig.WalBypass` and pass it as a function argument or struct parameter for each module

## WHY
- `executor.ThisInstance` is a singleton instance, and it makes it difficult to write unit tests of marketstore.