### PR TITLE
refactor(stop using singleton config): utils.InstanceConfig.startTime

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -175,7 +175,8 @@ func executeStart(cmd *cobra.Command, args []string) error {
 	if config.UtilitiesURL != "" {
 		// Start utility endpoints.
 		log.Info("launching utility service...")
-		go frontend.Utilities(config.UtilitiesURL)
+		uah := frontend.NewUtilityAPIHandlers(config.StartTime)
+		go uah.Handle(config.UtilitiesURL)
 	}
 
 	log.Info("enabling query access...")

--- a/frontend/utilities.go
+++ b/frontend/utilities.go
@@ -24,9 +24,17 @@ func init() {
 	Queryable = uint32(0)
 }
 
-func Utilities(url string) {
+func NewUtilityAPIHandlers(startTime time.Time) *utilityAPIHandlers{
+	return &utilityAPIHandlers{startTime: startTime}
+}
+
+type utilityAPIHandlers struct{
+	startTime time.Time
+}
+
+func (uah *utilityAPIHandlers) Handle(url string) {
 	// heartbeat
-	http.HandleFunc("/heartbeat", heartbeat)
+	http.HandleFunc("/heartbeat", uah.heartbeat)
 
 	// profiling
 	http.HandleFunc("/pprof/", pprof.Index)
@@ -42,8 +50,8 @@ func Utilities(url string) {
 	http.ListenAndServe(url, nil)
 }
 
-func heartbeat(rw http.ResponseWriter, r *http.Request) {
-	uptime := time.Since(utils.InstanceConfig.StartTime).String()
+func (uah *utilityAPIHandlers) heartbeat(rw http.ResponseWriter, r *http.Request) {
+	uptime := time.Since(uah.startTime).String()
 	queryable := atomic.LoadUint32(&Queryable)
 	if queryable > 0 {
 		// queryable

--- a/frontend/utilities_test.go
+++ b/frontend/utilities_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
+	"time"
 
 	"github.com/alpacahq/marketstore/v4/utils"
 	. "gopkg.in/check.v1"
@@ -16,6 +17,7 @@ type HeartbeatTestSuite struct{}
 var _ = Suite(&HeartbeatTestSuite{})
 
 func (s *HeartbeatTestSuite) TestHandler(c *C) {
+	startTime := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	utils.Tag = "dev"
 	var TestValues = map[string]struct {
 		Recorder        *httptest.ResponseRecorder
@@ -38,7 +40,7 @@ func (s *HeartbeatTestSuite) TestHandler(c *C) {
 		switch key {
 		case "Success":
 			atomic.StoreUint32(&Queryable, uint32(1))
-			heartbeat(val.Recorder, nil)
+			NewUtilityAPIHandlers(startTime).heartbeat(val.Recorder, nil)
 			hm := HeartbeatMessage{}
 			err := json.NewDecoder(val.Recorder.Body).Decode(&hm)
 			if err != nil {
@@ -51,7 +53,7 @@ func (s *HeartbeatTestSuite) TestHandler(c *C) {
 			c.Assert(val.Recorder.Code, Equals, http.StatusOK)
 		case "Failure":
 			atomic.StoreUint32(&Queryable, uint32(0))
-			heartbeat(val.Recorder, nil)
+			NewUtilityAPIHandlers(startTime).heartbeat(val.Recorder, nil)
 			hm := HeartbeatMessage{}
 			err := json.NewDecoder(val.Recorder.Body).Decode(&hm)
 			if err != nil {


### PR DESCRIPTION
## WHAT
- stop using `utils.InstanceConfig.startTime` and pass it as a function argument or struct parameter for each module

## WHY
- `executor.ThisInstance` is a singleton instance, and it makes it difficult to write unit tests of marketstore.