### PR TITLE
refactor(stop using singleton config): executor.ThisInstance.RootDir

### DIFF
--- a/cmd/connect/session/create.go
+++ b/cmd/connect/session/create.go
@@ -108,7 +108,7 @@ func (c *Client) create(line string) (ok bool) {
 	responses := &frontend.MultiServerResponse{}
 
 	if c.mode == local {
-		ds := frontend.NewDataService(c.disableVariableCompression, c.enableLastKnown)
+		ds := frontend.NewDataService(c.disableVariableCompression, c.enableLastKnown, c.dir)
 		err = ds.Create(nil, reqs, responses)
 	} else {
 		var respI interface{}
@@ -167,7 +167,7 @@ func (c *Client) destroy(line string) {
 	responses := &frontend.MultiServerResponse{}
 	var err error
 	if c.mode == local {
-		ds := frontend.NewDataService(c.disableVariableCompression, c.enableLastKnown)
+		ds := frontend.NewDataService(c.disableVariableCompression, c.enableLastKnown, c.dir)
 		err = ds.Destroy(nil, reqs, responses)
 	} else {
 		var respI interface{}
@@ -198,7 +198,7 @@ func (c *Client) GetBucketInfo(key io.TimeBucketKey) (resp *frontend.GetInfoResp
 	responses := &frontend.MultiGetInfoResponse{}
 
 	if c.mode == local {
-		ds := frontend.NewDataService(c.disableVariableCompression, c.enableLastKnown)
+		ds := frontend.NewDataService(c.disableVariableCompression, c.enableLastKnown, c.dir)
 		err = ds.GetInfo(nil, reqs, responses)
 	} else {
 		var respI interface{}

--- a/cmd/connect/session/load.go
+++ b/cmd/connect/session/load.go
@@ -122,7 +122,7 @@ func writeNumpy(c *Client, npm *io.NumpyMultiDataset, isVariable bool) (err erro
 	responses := &frontend.MultiServerResponse{}
 
 	if c.mode == local {
-		ds := frontend.NewDataService(c.disableVariableCompression, c.enableLastKnown)
+		ds := frontend.NewDataService(c.disableVariableCompression, c.enableLastKnown, c.dir)
 		err = ds.Write(nil, reqs, responses)
 	} else {
 		var respI interface{}

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -85,7 +85,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 		grpc.MaxRecvMsgSize(config.GRPCMaxRecvMsgSize),
 	)
 	pb.RegisterMarketstoreServer(grpcServer,
-		frontend.NewGRPCService(config.DisableVariableCompression, config.EnableLastKnown),
+		frontend.NewGRPCService(config.DisableVariableCompression, config.EnableLastKnown, config.RootDirectory),
 	)
 
 	// New gRPC stream server for replication.
@@ -153,7 +153,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 	log.Info("startup time: %s", startupTime)
 
 	// New server.
-	server, _ := frontend.NewServer(config.DisableVariableCompression, config.EnableLastKnown)
+	server, _ := frontend.NewServer(config.DisableVariableCompression, config.EnableLastKnown, config.RootDirectory)
 
 	// Set rpc handler.
 	log.Info("launching rpc data server...")

--- a/contrib/iex/backfill/backfill.go
+++ b/contrib/iex/backfill/backfill.go
@@ -240,14 +240,14 @@ func initWriter() {
 	walRotateInterval := 5
 	instanceID := time.Now().UTC().UnixNano()
 
-	executor.NewInstanceSetup(
+	instanceConfig := executor.NewInstanceSetup(
 		fmt.Sprintf("%v/mktsdb", dir), nil,
 		walRotateInterval, true, true, true, true)
 
 	log.Info(
 		"Initialized writer with InstanceID: %v - RootDir: %v\n",
 		instanceID,
-		executor.ThisInstance.RootDir,
+		instanceConfig.RootDir,
 	)
 
 	config := map[string]interface{}{
@@ -260,7 +260,7 @@ func initWriter() {
 		log.Fatal(err.Error())
 	}
 
-	executor.ThisInstance.TriggerMatchers = []*trigger.TriggerMatcher{
+	instanceConfig.TriggerMatchers = []*trigger.TriggerMatcher{
 		trigger.NewMatcher(trig, "*/1Min/OHLCV"),
 	}
 }

--- a/executor/instance.go
+++ b/executor/instance.go
@@ -14,6 +14,7 @@ import (
 var ThisInstance *InstanceMetadata
 
 type InstanceMetadata struct {
+	// RootDir is the absolute path to the data directory
 	RootDir         string
 	CatalogDir      *catalog.Directory
 	TXNPipe         *TransactionPipe
@@ -24,7 +25,8 @@ type InstanceMetadata struct {
 	TriggerMatchers []*trigger.TriggerMatcher
 }
 
-func NewInstanceSetup(relRootDir string, rs ReplicationSender, walRotateInterval int, options ...bool) {
+func NewInstanceSetup(relRootDir string, rs ReplicationSender, walRotateInterval int, options ...bool,
+) *InstanceMetadata {
 	/*
 		Defaults
 	*/
@@ -72,12 +74,12 @@ func NewInstanceSetup(relRootDir string, rs ReplicationSender, walRotateInterval
 		// Allocate a new WALFile and cache
 		if WALBypass {
 			ThisInstance.TXNPipe = NewTransactionPipe()
-			ThisInstance.WALFile, err = NewWALFile(ThisInstance.RootDir, instanceID, nil, false, WALBypass)
+			ThisInstance.WALFile, err = NewWALFile(rootDir, instanceID, nil, false, WALBypass)
 			if err != nil {
 				log.Fatal("Unable to create WAL")
 			}
 		} else {
-			ThisInstance.TXNPipe, ThisInstance.WALFile, err = StartupCacheAndWAL(ThisInstance.RootDir, instanceID, rs,
+			ThisInstance.TXNPipe, ThisInstance.WALFile, err = StartupCacheAndWAL(rootDir, instanceID, rs,
 				false, WALBypass,
 			)
 
@@ -91,4 +93,5 @@ func NewInstanceSetup(relRootDir string, rs ReplicationSender, walRotateInterval
 			ThisInstance.WALWg.Add(1)
 		}
 	}
+	return ThisInstance
 }

--- a/frontend/grpc.go
+++ b/frontend/grpc.go
@@ -53,12 +53,14 @@ func toProtoDataType(elemType io.EnumElementType) proto.DataType {
 type GRPCService struct {
 	disableVariableCompression bool
 	enableLastKnown            bool
+	rootDir string
 }
 
-func NewGRPCService(disableVariableCompression, enableLastKnown bool) *GRPCService {
+func NewGRPCService(disableVariableCompression, enableLastKnown bool, rootDir string) *GRPCService {
 	return &GRPCService{
 		disableVariableCompression: disableVariableCompression,
 		enableLastKnown:            enableLastKnown,
+		rootDir: rootDir,
 	}
 }
 
@@ -330,7 +332,7 @@ func (s GRPCService) Create(ctx context.Context, req *proto.MultiCreateRequest) 
 		if err != nil {
 			appendResponse(&response, err)
 		}
-		dir := tbk.GetPathToYearFiles(executor.ThisInstance.RootDir)
+		dir := tbk.GetPathToYearFiles(s.rootDir)
 		year := int16(time.Now().Year())
 		rt := io.EnumRecordTypeByName(req.RowType)
 		dsv, err := NewDataShapeVector(req.DataShapes)

--- a/frontend/query_test.go
+++ b/frontend/query_test.go
@@ -15,7 +15,7 @@ import (
 
 func (s *ServerTestSuite) _TestQueryCustomTimeframes(c *C) {
 	//TODO: Support custom timeframes
-	service := NewDataService(false, false)
+	service := NewDataService(false, false, s.Rootdir)
 	service.Init()
 
 	args := &MultiQueryRequest{
@@ -73,7 +73,7 @@ func (s *ServerTestSuite) _TestQueryCustomTimeframes(c *C) {
 }
 
 func (s *ServerTestSuite) TestQuery(c *C) {
-	service := NewDataService(false, false)
+	service := NewDataService(false, false, s.Rootdir)
 	service.Init()
 
 	args := &MultiQueryRequest{
@@ -106,7 +106,7 @@ func (s *ServerTestSuite) TestQuery(c *C) {
 }
 
 func (s *ServerTestSuite) TestQueryFirstN(c *C) {
-	service := NewDataService(false, false)
+	service := NewDataService(false, false, s.Rootdir)
 	service.Init()
 
 	args := &MultiQueryRequest{
@@ -137,7 +137,7 @@ func (s *ServerTestSuite) TestQueryFirstN(c *C) {
 }
 
 func (s *ServerTestSuite) TestQueryRange(c *C) {
-	service := NewDataService(false, false)
+	service := NewDataService(false, false, s.Rootdir)
 	service.Init()
 	{
 		args := &MultiQueryRequest{
@@ -184,7 +184,7 @@ func (s *ServerTestSuite) TestQueryRange(c *C) {
 }
 
 func (s *ServerTestSuite) TestQueryNpyMulti(c *C) {
-	service := NewDataService(false, false)
+	service := NewDataService(false, false, s.Rootdir)
 	service.Init()
 
 	args := &MultiQueryRequest{
@@ -214,7 +214,7 @@ func (s *ServerTestSuite) TestQueryNpyMulti(c *C) {
 }
 
 func (s *ServerTestSuite) TestQueryMulti(c *C) {
-	service := NewDataService(false, false)
+	service := NewDataService(false, false, s.Rootdir)
 	service.Init()
 
 	args := &MultiQueryRequest{
@@ -255,7 +255,7 @@ func (s *ServerTestSuite) TestQueryMulti(c *C) {
 }
 
 func (s *ServerTestSuite) TestListSymbols(c *C) {
-	service := NewDataService(false, false)
+	service := NewDataService(false, false, s.Rootdir)
 	service.Init()
 
 	var response ListSymbolsResponse
@@ -288,7 +288,7 @@ func (s *ServerTestSuite) TestListSymbols(c *C) {
 }
 
 func (s *ServerTestSuite) TestFunctions(c *C) {
-	service := NewDataService(false, false)
+	service := NewDataService(false, false, s.Rootdir)
 	service.Init()
 
 	call := "candlecandler('1Min',Open,High,Low,Close,Sum::Volume)"

--- a/frontend/server.go
+++ b/frontend/server.go
@@ -19,16 +19,18 @@ var (
 	argsNilError   = errors.New("Arguments are nil, can not query using nil arguments")
 )
 
-func NewDataService(disableVariableCompression, enableLastKnown bool) *DataService {
+func NewDataService(disableVariableCompression, enableLastKnown bool, rootDir string) *DataService {
 	return &DataService{
 		disableVariableCompression: disableVariableCompression,
 		enableLastKnown:            enableLastKnown,
+		rootDir:                    rootDir,
 	}
 }
 
 type DataService struct {
 	disableVariableCompression bool
 	enableLastKnown            bool
+	rootDir                    string
 }
 
 func (s *DataService) Init() {}
@@ -44,7 +46,7 @@ func (s *RpcServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	metrics.RPCTotalRequestDuration.Observe(time.Since(start).Seconds())
 }
 
-func NewServer(disableVariableCompression, enableLastKnown bool) (*RpcServer, *DataService) {
+func NewServer(disableVariableCompression, enableLastKnown bool, rootDir string) (*RpcServer, *DataService) {
 	s := &RpcServer{
 		Server: rpc.NewServer(),
 	}
@@ -53,7 +55,7 @@ func NewServer(disableVariableCompression, enableLastKnown bool) (*RpcServer, *D
 	s.RegisterCodec(msgpack2.NewCodec(), "application/x-msgpack")
 	s.RegisterInterceptFunc(intercept)
 	s.RegisterAfterFunc(after)
-	service := NewDataService(disableVariableCompression, enableLastKnown)
+	service := NewDataService(disableVariableCompression, enableLastKnown, rootDir)
 	service.Init()
 	err := s.RegisterService(service, "")
 	if err != nil {

--- a/frontend/server_test.go
+++ b/frontend/server_test.go
@@ -35,6 +35,6 @@ func (s *ServerTestSuite) TearDownSuite(c *C) {
 }
 
 func (s *ServerTestSuite) TestNewServer(c *C) {
-	serv, _ := NewServer(false, false)
+	serv, _ := NewServer(false, false, s.Rootdir)
 	c.Check(serv.HasMethod("DataService.Query"), Equals, true)
 }

--- a/frontend/write.go
+++ b/frontend/write.go
@@ -86,7 +86,6 @@ func (s *DataService) Create(r *http.Request, reqs *MultiCreateRequest, response
 		}
 
 		// --- Timeframe
-		rootDir := executor.ThisInstance.RootDir
 		year := int16(time.Now().Year())
 		tf, err := tbk.GetTimeFrame()
 		if err != nil {
@@ -114,7 +113,7 @@ func (s *DataService) Create(r *http.Request, reqs *MultiCreateRequest, response
 			dsv[i] = io.DataShape{Name: name, Type: t}
 		}
 
-		tbinfo := io.NewTimeBucketInfo(*tf, tbk.GetPathToYearFiles(rootDir), "Default", year, dsv, recordType)
+		tbinfo := io.NewTimeBucketInfo(*tf, tbk.GetPathToYearFiles(s.rootDir), "Default", year, dsv, recordType)
 
 		err = executor.ThisInstance.CatalogDir.AddTimeBucket(tbk, tbinfo)
 		if err != nil {

--- a/frontend/write_test.go
+++ b/frontend/write_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *ServerTestSuite) TestWrite(c *C) {
-	service := NewDataService(false, false)
+	service := NewDataService(false, false, s.Rootdir)
 	service.Init()
 
 	qargs := &MultiQueryRequest{


### PR DESCRIPTION
## WHAT
- stop using `executor.ThisInstance.RootDir` and pass it as a function argument or struct parameter for each module

## WHY
- `executor.ThisInstance` is a singleton instance, and it makes it difficult to write unit tests of marketstore.