### PR TITLE
refactor(stop using singleton config): executor.ThisInstance.ShutdownPending&WALBypass 

### DIFF
--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -33,7 +33,7 @@ type TestSuite struct {
 func (s *TestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyCurrencyDir(s.Rootdir, false, false)
-	instanceConfig := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
+	instanceConfig, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDirectory = instanceConfig.CatalogDir
 	s.WALFile = instanceConfig.WALFile
 	s.TXNPipe = instanceConfig.TXNPipe

--- a/contrib/iex/backfill/backfill.go
+++ b/contrib/iex/backfill/backfill.go
@@ -240,7 +240,7 @@ func initWriter() {
 	walRotateInterval := 5
 	instanceID := time.Now().UTC().UnixNano()
 
-	instanceConfig := executor.NewInstanceSetup(
+	instanceConfig, _ := executor.NewInstanceSetup(
 		fmt.Sprintf("%v/mktsdb", dir), nil,
 		walRotateInterval, true, true, true, true)
 

--- a/frontend/server_test.go
+++ b/frontend/server_test.go
@@ -26,7 +26,7 @@ func (s *ServerTestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	//s.Rootdir = "/tmp/LALtemp"
 	test.MakeDummyCurrencyDir(s.Rootdir, true, false)
-	executor.NewInstanceSetup(s.Rootdir, nil,5, true, true, false, false)
+	executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, false)
 	atomic.StoreUint32(&Queryable, uint32(1))
 }
 


### PR DESCRIPTION
## WHAT
- stop using `executor.ThisInstance.ShutdownPending` and `executor.ThisInstance.WALBypass` and pass it as a function argument or struct parameter for each module

## WHY
- `executor.ThisInstance` is a singleton instance, and it makes it difficult to write unit tests of marketstore.