### PR TITLE
refactor: stop using singleton config. catalogDir & WalWG

### DIFF
--- a/cmd/connect/session/client.go
+++ b/cmd/connect/session/client.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alpacahq/marketstore/v4/catalog"
 	"github.com/alpacahq/marketstore/v4/executor"
 	"github.com/alpacahq/marketstore/v4/frontend/client"
 	"github.com/alpacahq/marketstore/v4/sqlparser"
@@ -53,6 +54,8 @@ type Client struct {
 	disableVariableCompression bool
 	// enableLastKnown is an optimization to reduce the size of dara reading for query
 	enableLastKnown bool
+	// catalogDir is an in-memory cache for directory structure under the /data directory
+	catalogDir *catalog.Directory
 }
 
 // RPCClient is a marketstore API client interface.
@@ -65,10 +68,12 @@ func NewLocalClient(dir string, disableVariableCompression bool) (c *Client, err
 	// Configure db settings.
 	initCatalog, initWALCache, backgroundSync, WALBypass := true, true, false, true
 	walRotateInterval := 5
-	executor.NewInstanceSetup(dir,
+	instanceConfig, _ := executor.NewInstanceSetup(dir,
 		nil, walRotateInterval, initCatalog, initWALCache, backgroundSync, WALBypass,
 	)
-	return &Client{dir: dir, mode: local, disableVariableCompression: disableVariableCompression}, nil
+	return &Client{dir: dir, mode: local, disableVariableCompression: disableVariableCompression,
+		catalogDir: instanceConfig.CatalogDir,
+	}, nil
 }
 
 // NewRemoteClient generates a new client struct.

--- a/cmd/connect/session/show.go
+++ b/cmd/connect/session/show.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alpacahq/marketstore/v4/catalog"
 	"github.com/alpacahq/marketstore/v4/executor"
 	"github.com/alpacahq/marketstore/v4/frontend"
 	"github.com/alpacahq/marketstore/v4/planner"
@@ -35,7 +36,7 @@ func (c *Client) show(line string) {
 	)
 
 	if c.mode == local {
-		csm, err = processShowLocal(tbk, start, end, c.disableVariableCompression, c.enableLastKnown)
+		csm, err = processShowLocal(tbk, start, end, c.disableVariableCompression, c.enableLastKnown, c.catalogDir)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -77,8 +78,9 @@ func (c *Client) show(line string) {
 }
 
 func processShowLocal(tbk *io.TimeBucketKey, start, end *time.Time, disableVariableCompression, enableLastKnown bool,
+	catalogDir *catalog.Directory,
 ) (csm io.ColumnSeriesMap, err error) {
-	query := planner.NewQuery(executor.ThisInstance.CatalogDir)
+	query := planner.NewQuery(catalogDir)
 	query.AddTargetKey(tbk)
 
 	if start == nil && end == nil {

--- a/cmd/connect/session/trim.go
+++ b/cmd/connect/session/trim.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/alpacahq/marketstore/v4/executor"
 	"github.com/alpacahq/marketstore/v4/utils/io"
 	"github.com/alpacahq/marketstore/v4/utils/log"
 )
@@ -22,7 +21,7 @@ func (c *Client) trim(line string) {
 	if err != nil {
 		log.Error("Failed to parse trim date - Error: %v", trimDate)
 	}
-	fInfos := executor.ThisInstance.CatalogDir.GatherTimeBucketInfo()
+	fInfos := c.catalogDir.GatherTimeBucketInfo()
 	for _, info := range fInfos {
 		if info.Year == int16(trimDate.Year()) {
 			offset := io.TimeToOffset(trimDate, info.GetTimeframe(), info.GetRecordLength())

--- a/contrib/iex/backfill/backfill.go
+++ b/contrib/iex/backfill/backfill.go
@@ -239,9 +239,9 @@ func initWriter() {
 	utils.InstanceConfig.Timezone = NY
 	walRotateInterval := 5
 	instanceID := time.Now().UTC().UnixNano()
-
+	relRootDir := fmt.Sprintf("%v/mktsdb", dir)
 	instanceConfig, _ := executor.NewInstanceSetup(
-		fmt.Sprintf("%v/mktsdb", dir), nil,
+		relRootDir, nil,
 		walRotateInterval, true, true, true, true)
 
 	log.Info(

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -730,7 +731,7 @@ func (s *DestructiveWALTests) TestWALWrite(c *C) {
 	var err error
 	mockInstanceID := time.Now().UTC().UnixNano()
 	s.WALFile, err = executor.NewWALFile(s.Rootdir, mockInstanceID, nil, false,
-		false, s.shutdownPending,
+		false, s.shutdownPending, &sync.WaitGroup{},
 	)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
## WHAT
- stop using `executor.ThisInstance.CatalogDir` and `executor.ThisInstance.WALWg` and pass it as a function argument or struct parameter for each module

## WHY
- `executor.ThisInstance` is a singleton instance, and it makes it difficult to write unit tests of marketstore.