### PR TITLE
fix: remove walWG from instance config

### DIFF
--- a/cmd/connect/session/local_api_client.go
+++ b/cmd/connect/session/local_api_client.go
@@ -18,7 +18,7 @@ func NewLocalAPIClient(dir string, disableVariableCompression bool) (lc *LocalAP
 	// Configure db settings.
 	initCatalog, initWALCache, backgroundSync, WALBypass := true, true, false, true
 	walRotateInterval := 5
-	instanceConfig, _ := executor.NewInstanceSetup(dir,
+	instanceConfig, _, _ := executor.NewInstanceSetup(dir,
 		nil, walRotateInterval, initCatalog, initWALCache, backgroundSync, WALBypass,
 	)
 	return &LocalAPIClient{dir: dir, disableVariableCompression: disableVariableCompression,

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -130,7 +130,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 
 	start := time.Now()
 
-	instanceConfig, shutdownPending := executor.NewInstanceSetup(
+	instanceConfig, shutdownPending, walWG := executor.NewInstanceSetup(
 		config.RootDirectory,
 		rs,
 		config.WALRotateInterval,
@@ -224,7 +224,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 				atomic.StoreUint32(&frontend.Queryable, uint32(0))
 				log.Info("waiting a grace period of %v to shutdown...", config.StopGracePeriod)
 				time.Sleep(config.StopGracePeriod)
-				shutdown(shutdownPending, instanceConfig.WALWg)
+				shutdown(shutdownPending, walWG)
 			}
 		}
 	}()

--- a/contrib/alpaca/handlers/handlers_test.go
+++ b/contrib/alpaca/handlers/handlers_test.go
@@ -22,7 +22,7 @@ type HandlersTestSuite struct {
 
 func (s *HandlersTestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
-	metadata, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
+	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDirectory = metadata.CatalogDir
 	s.WALFile = metadata.WALFile
 }

--- a/contrib/candler/candlecandler/all_test.go
+++ b/contrib/candler/candlecandler/all_test.go
@@ -32,7 +32,7 @@ type TestSuite struct {
 func (s *TestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyStockDir(s.Rootdir, true, false)
-	metadata, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true,
+	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true,
 	) // WAL Bypass
 	s.DataDirectory = metadata.CatalogDir
 	s.WALFile = metadata.WALFile

--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -33,7 +33,7 @@ type TestSuite struct {
 func (s *TestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyCurrencyDir(s.Rootdir, false, false)
-	instanceConfig, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
+	instanceConfig, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDirectory = instanceConfig.CatalogDir
 	s.WALFile = instanceConfig.WALFile
 	s.TXNPipe = instanceConfig.TXNPipe

--- a/contrib/ice/cmd/reorg/show.go
+++ b/contrib/ice/cmd/reorg/show.go
@@ -30,7 +30,7 @@ var ShowRecordsCmd = &cobra.Command{
 		}
 		cusip := args[1]
 		dataDir := args[0]
-		metadata, _ := executor.NewInstanceSetup(dataDir, nil, 5, true, true, true, true)
+		metadata, _, _ := executor.NewInstanceSetup(dataDir, nil, 5, true, true, true, true)
 		showRecords(cusip, metadata.CatalogDir)
 		return nil
 	},

--- a/contrib/iex/backfill/backfill.go
+++ b/contrib/iex/backfill/backfill.go
@@ -240,7 +240,7 @@ func initWriter() {
 	walRotateInterval := 5
 	instanceID := time.Now().UTC().UnixNano()
 	relRootDir := fmt.Sprintf("%v/mktsdb", dir)
-	instanceConfig, _ := executor.NewInstanceSetup(
+	instanceConfig, _, _ := executor.NewInstanceSetup(
 		relRootDir, nil,
 		walRotateInterval, true, true, true, true)
 

--- a/contrib/polygon/handlers/handlers_test.go
+++ b/contrib/polygon/handlers/handlers_test.go
@@ -25,7 +25,7 @@ type HandlersTestSuite struct {
 
 func (s *HandlersTestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
-	metadata, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
+	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDirectory = metadata.CatalogDir
 	s.WALFile = metadata.WALFile
 }

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -62,7 +62,7 @@ type DestructiveWALTest2 struct {
 func (s *TestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyCurrencyDir(s.Rootdir, true, false)
-	metadata, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
+	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
 	s.DataDirectory = metadata.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 }
@@ -715,7 +715,7 @@ func (s *TestSuite) TestWriter(c *C) {
 func (s *DestructiveWALTests) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyCurrencyDir(s.Rootdir, true, false)
-	instanceConfig, shutdownPending := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
+	instanceConfig, shutdownPending, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
 	s.DataDirectory = instanceConfig.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 	s.shutdownPending = shutdownPending
@@ -855,7 +855,7 @@ func (s *DestructiveWALTests) TestBrokenWAL(c *C) {
 func (s *DestructiveWALTest2) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyCurrencyDir(s.Rootdir, true, false)
-	instanceConfig, shutdownPending := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
+	instanceConfig, shutdownPending, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
 	s.DataDirectory = instanceConfig.CatalogDir
 	s.WALFile = executor.ThisInstance.WALFile
 	s.shutdownPending = shutdownPending

--- a/frontend/server_test.go
+++ b/frontend/server_test.go
@@ -26,7 +26,7 @@ func (s *ServerTestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	//s.Rootdir = "/tmp/LALtemp"
 	test.MakeDummyCurrencyDir(s.Rootdir, true, false)
-	metadata, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, false)
+	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, false)
 	s.root = metadata.CatalogDir
 	atomic.StoreUint32(&Queryable, uint32(1))
 }

--- a/sqlparser/all_test.go
+++ b/sqlparser/all_test.go
@@ -33,7 +33,7 @@ type TestSuite struct {
 func (s *TestSuite) SetUpSuite(c *C) {
 	s.Rootdir = c.MkDir()
 	s.ItemsWritten = MakeDummyStockDir(s.Rootdir, true, false)
-	metadata, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
+	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false)
 	s.DataDirectory = metadata.CatalogDir
 	s.WALFile = metadata.WALFile
 }

--- a/uda/adjust/adjust_test.go
+++ b/uda/adjust/adjust_test.go
@@ -24,7 +24,7 @@ type TestSuiteAdjust struct {
 
 func (s *TestSuiteAdjust) SetupSuite(c *C) {
 	s.Rootdir = c.MkDir()
-	metadata, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
+	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDir = metadata.CatalogDir
 }
 

--- a/uda/adjust/caloader_test.go
+++ b/uda/adjust/caloader_test.go
@@ -22,7 +22,7 @@ type TestCALoaderSuite struct {
 
 func (s *TestCALoaderSuite) SetupSuite(c *C) {
 	s.Rootdir = c.MkDir()
-	metadata, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
+	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, 5, true, true, false, true) // WAL Bypass
 	s.DataDir = metadata.CatalogDir
 }
 


### PR DESCRIPTION
to fix the panic issue when shutting down marketstore by Ctrl+C
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x407e8e6]

goroutine 38 [running]:
sync.(*WaitGroup).state(...)
        /usr/local/Cellar/go/1.15.2/libexec/src/sync/waitgroup.go:33
sync.(*WaitGroup).Wait(0x0)
        /usr/local/Cellar/go/1.15.2/libexec/src/sync/waitgroup.go:104 +0x26
github.com/alpacahq/marketstore/v4/cmd/start.shutdown(0xc0002312f0, 0x0)
        /Users/dakimura/projects/go/src/github.com/alpacahq/marketstore/cmd/start/main.go:244 +0x38
github.com/alpacahq/marketstore/v4/cmd/start.executeStart.func2(0xc00004e0c0, 0xc00016c000, 0xc000208470, 0xc0002581a0, 0x552f2c0, 0xc0002312f0, 0xc00021c780)
        /Users/dakimura/projects/go/src/github.com/alpacahq/marketstore/cmd/start/main.go:227 +0x22f
created by github.com/alpacahq/marketstore/v4/cmd/start.executeStart
        /Users/dakimura/projects/go/src/github.com/alpacahq/marketstore/cmd/start/main.go:206 +0x998
```