### PR TITLE
feat: retry logic for replication feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/timpalpant/go-iex v0.0.0-20181027174710-0b8a5fdd2ec1
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	go.uber.org/zap v1.15.0
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064
 	gonum.org/v1/gonum v0.0.0-20190618015908-5dc218f86579
 	google.golang.org/grpc v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alpacahq/marketstore v1.0.2 h1:0Z/LUQVN0QU0v6UOAamK+CiGARJ6UQRlzU42Y+ajZaQ=
-github.com/alpacahq/marketstore v2.3.8+incompatible h1:m2+YHe7Yx4J+gAG2GuTeLQcO0QQKGYZ97Bl0NdqXMIc=
 github.com/alpacahq/rpc v1.3.0 h1:lB7T3oTSq0b4pFsntmAq4Be0ngJDrJcbD1KtGIc9P1s=
 github.com/alpacahq/rpc v1.3.0/go.mod h1:UfzqdExg1VFMZA6aiQTyBhgBxHBpWzCi5OknSby/wmQ=
 github.com/antlr/antlr4 v0.0.0-20181031000400-73836edf1f84 h1:c4ZppOrw9VXa9s4i6cnxC7YQUEZ5RbmVKfEY5g4yAow=
@@ -266,7 +264,6 @@ golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0 h1:wBouT66WTYFXdxfVdz9sVWARVd/2vfGcmI45D2gj45M=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -276,6 +273,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -310,14 +308,12 @@ golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064 h1:BmCFkEH4nJrYcAc2L08yX5RhYGD4j58PTMkEUDkpz2I=
 golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/replication/receiver.go
+++ b/replication/receiver.go
@@ -3,9 +3,9 @@ package replication
 import (
 	"context"
 	"fmt"
-	"github.com/alpacahq/marketstore/v4/utils/log"
-	"github.com/pkg/errors"
 	"io"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 type Receiver struct {
@@ -33,32 +33,29 @@ func NewReceiver(grpcClient GRPCClient, replayer Replayer) *Receiver {
 func (r *Receiver) Run(ctx context.Context) error {
 	err := r.gRPCClient.Connect(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to master instance")
+		return RetryableError("failed to connect to master instance:" + err.Error())
 	}
+	log.Info("connected to the master instance.")
 
-	go func() {
-		for {
-			log.Debug("waiting for replication messages from master...")
-			// block until receive a new replication message
-			transactionGroup, err := r.gRPCClient.Recv()
-			if err == io.EOF {
-				log.Info("received EOF from master server")
-				return
-			}
-			if err != nil {
-				log.Error(fmt.Sprintf("an error occurred while receiving a replication message from master instance."+
-					"There will be data inconsistency between master and replica:%s", err.Error()))
-				return
-			}
-
-			err = r.replayer.Replay(transactionGroup)
-			if err != nil {
-				log.Error(fmt.Sprintf("an error occurred while replaying. "+
-					"There will be data inconsistency between master and replica:%s", err.Error()))
-				return
-			}
+	for {
+		log.Debug("waiting for replication messages from master...")
+		// block until receive a new replication message
+		transactionGroup, err := r.gRPCClient.Recv()
+		if err == io.EOF {
+			return fmt.Errorf("received EOF from master server")
 		}
-	}()
+		if err != nil {
+			log.Error(fmt.Sprintf("an error occurred while receiving a replication message"+
+				" from master instance. Will be retried soon...:%s", err.Error()))
+			// This might be a temporary network issue. We retry it.
+			return RetryableError(err.Error())
+		}
 
-	return err
+		err = r.replayer.Replay(transactionGroup)
+		if err != nil {
+			// this might be a bug in the replay logic. We won't retry it.
+			return fmt.Errorf("an error occurred while replaying. "+
+				"There will be data inconsistency between master and replica:%w", err)
+		}
+	}
 }

--- a/replication/receiver_test.go
+++ b/replication/receiver_test.go
@@ -55,14 +55,6 @@ func TestReceiver_Run(t *testing.T) {
 		wantReplayCalled bool
 	}{
 		{
-			name:             "success",
-			mockConnectFunc:  func(ctx context.Context) error { return nil },
-			mockRecvFunc:     func() ([]byte, error) { return nil, nil },
-			mockReplayFunc:   func(transactionGroup []byte) error { return nil },
-			wantErr:          false,
-			wantReplayCalled: true,
-		},
-		{
 			name:             "gRPC connect error/ an error occurs and Run() fails",
 			mockConnectFunc:  func(ctx context.Context) error { return errors.New("some error") },
 			mockRecvFunc:     func() ([]byte, error) { return nil, nil },
@@ -75,7 +67,7 @@ func TestReceiver_Run(t *testing.T) {
 			mockConnectFunc:  func(ctx context.Context) error { return nil },
 			mockRecvFunc:     func() ([]byte, error) { return nil, io.EOF },
 			mockReplayFunc:   func(transactionGroup []byte) error { return nil },
-			wantErr:          false,
+			wantErr:          true,
 			wantReplayCalled: false,
 		},
 		{
@@ -83,7 +75,7 @@ func TestReceiver_Run(t *testing.T) {
 			mockConnectFunc:  func(ctx context.Context) error { return nil },
 			mockRecvFunc:     func() ([]byte, error) { return nil, errors.New("some error") },
 			mockReplayFunc:   func(transactionGroup []byte) error { return nil },
-			wantErr:          false,
+			wantErr:          true,
 			wantReplayCalled: false,
 		},
 		{
@@ -91,7 +83,7 @@ func TestReceiver_Run(t *testing.T) {
 			mockConnectFunc:  func(ctx context.Context) error { return nil },
 			mockRecvFunc:     func() ([]byte, error) { return nil, nil },
 			mockReplayFunc:   func(transactionGroup []byte) error { return errors.New("some error") },
-			wantErr:          false,
+			wantErr:          true,
 			wantReplayCalled: true,
 		},
 	}
@@ -111,7 +103,6 @@ func TestReceiver_Run(t *testing.T) {
 
 			// --- when ---
 			err := r.Run(context.Background())
-			time.Sleep(1 * time.Second) // wait 1 second to ensure that the goroutine started
 
 			// --- then ---
 			if (err != nil) != tt.wantErr {

--- a/replication/retry.go
+++ b/replication/retry.go
@@ -1,0 +1,72 @@
+package replication
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
+	"github.com/pkg/errors"
+)
+
+// RetryableError is a custom error to retry the logic when returned
+type RetryableError string
+
+func (re RetryableError) Error() string {
+	return string(re)
+}
+func (re RetryableError) Is(err error) bool {
+	return err == RetryableError("")
+}
+
+type retryer struct {
+	retryFunc    func(ctx context.Context) error
+	interval     time.Duration
+	backoffCoeff int
+}
+
+func NewRetryer(retryFunc func(ctx context.Context) error, interval time.Duration, backoffCoeff int) *retryer {
+	return &retryer{
+		retryFunc:    retryFunc,
+		interval:     interval,
+		backoffCoeff: backoffCoeff,
+	}
+}
+
+// Run tries the retryer until it succeeds, it returns unretriable error, or the context is canceled.
+func (r *retryer) Run(ctx context.Context) error {
+	cnt := -1
+	for {
+		cnt++
+		select {
+		case <-ctx.Done():
+			return errors.New("context canceled")
+		default:
+			err := r.retryFunc(ctx)
+			// success
+			if err == nil {
+				return nil
+			}
+
+			if errors.Is(err, RetryableError("")) {
+				// retryable error. continue
+				interval := retryInterval(r.interval, r.backoffCoeff, cnt)
+				log.Warn("caught a retryable error. It will be retried after an interval:" +
+					strconv.FormatInt(interval.Milliseconds(), 10) + "[ms], err=" + err.Error())
+				time.Sleep(interval)
+				continue
+			} else {
+				// not retryable error, give up.
+				log.Warn("caught a non-retryable error:" + err.Error())
+				return err
+			}
+		}
+	}
+}
+
+func retryInterval(interval time.Duration, backoffCoeff, retryCount int) time.Duration {
+	coeff := math.Pow(float64(backoffCoeff), float64(retryCount))
+	intervalMilliSec := float64(interval.Milliseconds())
+	return time.Duration(intervalMilliSec*coeff) * time.Millisecond
+}

--- a/replication/retry_test.go
+++ b/replication/retry_test.go
@@ -1,0 +1,91 @@
+package replication_test
+
+import (
+	"context"
+	"errors"
+	"github.com/alpacahq/marketstore/v4/replication"
+	"testing"
+	"time"
+)
+
+// retryer succeeds at a certain trial
+type retryer struct {
+	Count     int
+	SucceedAt int
+}
+
+func (r *retryer) try(_ context.Context) error {
+	r.Count++
+	if r.Count == r.SucceedAt {
+		return nil
+	}
+	return replication.RetryableError("error")
+}
+
+func TestRetryer_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		retryFunc func(ctx context.Context) error
+		interval  time.Duration
+		context   context.Context
+		wantErr   bool
+	}{
+		{
+			name:      "success",
+			retryFunc: func(ctx context.Context) error { return nil },
+			context:   context.Background(),
+			wantErr:   false,
+		},
+		{
+			name:      "not retryable error",
+			retryFunc: func(ctx context.Context) error { return errors.New("some error") },
+			context:   context.Background(),
+			wantErr:   true,
+		},
+		{
+			name:      "retryable error",
+			retryFunc: func(ctx context.Context) error { return replication.RetryableError("some retryable error") },
+			context:   context.Background(),
+			wantErr:   true,
+		},
+		{
+			name: "succeed at the 3rd try",
+			retryFunc: func() func(ctx context.Context) error {
+				r := retryer{SucceedAt: 3}
+				return r.try
+			}(),
+			context: context.Background(),
+			wantErr: false,
+		},
+		{
+			name: "don't retry if context is canceled",
+			retryFunc: func(ctx context.Context) error {
+				return replication.RetryableError("some retryable error")
+			},
+			context: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx // already canceled context is passed
+			}(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// --- given ---
+			r := replication.NewRetryer(tt.retryFunc, 10*time.Millisecond, 2)
+
+			// --- when ---
+			err := r.Run(tt.context)
+
+			// --- then ---
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## WHAT
- add a retry feature for the replication feature.
When replication fails, it retries after an interval that can be configured by mkts.yml.

## WHY
- sometimes a replica instance loses the connection to the master instance.