### PR TITLE
fix: a step to stop using "ThisInstance" singleton instance

### DIFF
--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -133,7 +133,7 @@ func createTickBucket(symbol, rootDir string, catalogDir *Directory, txnPipe *ex
 	/*
 		Write some data
 	*/
-	w, err := executor.NewWriter(tbinfo, txnPipe, catalogDir)
+	w, err := executor.NewWriter(tbinfo, txnPipe, catalogDir, wf)
 	if err != nil {
 		panic(err)
 	}

--- a/executor/writer.go
+++ b/executor/writer.go
@@ -27,14 +27,15 @@ type Writer struct {
 	tbi  *io.TimeBucketInfo
 }
 
-func NewWriter(tbi *io.TimeBucketInfo, tgc *TransactionPipe, rootCatDir *catalog.Directory) (*Writer, error) {
+func NewWriter(tbi *io.TimeBucketInfo, tgc *TransactionPipe, rootCatDir *catalog.Directory, walFile *WALFileType,
+) (*Writer, error) {
 	/*
 		A writer is produced that complies with the parsed query results, including a possible date
 		range restriction.  If there is a date range restriction, the write() routine should produce
 		an error when an out-of-bounds write is tried.
 	*/
 	// Check to ensure there is a valid WALFile for this instance before writing
-	if ThisInstance.WALFile == nil {
+	if walFile == nil {
 		err := fmt.Errorf("there is not an active WALFile for this instance, so cannot write")
 		log.Error("NewWriter: %v", err)
 		return nil, err
@@ -365,7 +366,7 @@ func WriteCSMInner(csm io.ColumnSeriesMap, isVariableLength bool) (err error) {
 		/*
 			Create a writer for this TimeBucket
 		*/
-		w, err := NewWriter(tbi, ThisInstance.TXNPipe, cDir)
+		w, err := NewWriter(tbi, ThisInstance.TXNPipe, cDir, ThisInstance.WALFile)
 		if err != nil {
 			return err
 		}

--- a/sqlparser/insertintostatement.go
+++ b/sqlparser/insertintostatement.go
@@ -112,7 +112,7 @@ func (is *InsertIntoStatement) Materialize() (outputColumnSeries *io.ColumnSerie
 	if err != nil {
 		return nil, err
 	}
-	writer, err := executor.NewWriter(tbi, tgc, catDir)
+	writer, err := executor.NewWriter(tbi, tgc, catDir, wal)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/config.go
+++ b/utils/config.go
@@ -42,6 +42,7 @@ type BgWorkerSetting struct {
 }
 
 type MktsConfig struct {
+	// RootDirectory is the absolute path to the data directory
 	RootDirectory              string
 	ListenURL                  string
 	GRPCListenURL              string
@@ -71,6 +72,7 @@ func (m *MktsConfig) Parse(data []byte) (*MktsConfig, error) {
 	var (
 		err error
 		aux struct {
+			// RootDirectory can be either a relative or absolute path
 			RootDirectory              string `yaml:"root_directory"`
 			ListenHost                 string `yaml:"listen_host"`
 			ListenPort                 string `yaml:"listen_port"`
@@ -120,12 +122,12 @@ func (m *MktsConfig) Parse(data []byte) (*MktsConfig, error) {
 		return nil, err
 	}
 
-	rootDir, err := filepath.Abs(filepath.Clean(aux.RootDirectory))
+	absoluteRootDir, err := filepath.Abs(filepath.Clean(aux.RootDirectory))
 	if aux.RootDirectory == "" || err != nil {
 		log.Fatal("Invalid root directory.")
 		return nil, errors.New("Invalid root directory.")
 	}
-	m.RootDirectory = rootDir
+	m.RootDirectory = absoluteRootDir
 
 	if aux.ListenPort == "" {
 		log.Fatal("Invalid listen port.")


### PR DESCRIPTION
## WHAT
- stop using `executor.ThisInstance.WALFile` from `NewWriter` function

## WHY
- singleton instances make unit test difficult