### PR TITLE
feat(sql): nanosec support

### DIFF
--- a/sqlparser/executablestatement.go
+++ b/sqlparser/executablestatement.go
@@ -657,6 +657,9 @@ func CoerceToNumeric(literal *Literal) (err error) {
 		// Strip off the single quotes
 		value = value[1 : len(value)-1]
 		formats := []string{
+			// the fractional second is of the specified width. Please always include the trailing zeros.
+			// ref: https://golang.org/pkg/time/#example_Time_Format
+			"2006-01-02-15:04:05.00000000",
 			"2006-01-02-15:04:05 MST",
 			"2006-01-02-15:04:05",
 			"2006-01-02-15:04",
@@ -674,7 +677,7 @@ func CoerceToNumeric(literal *Literal) (err error) {
 			return fmt.Errorf("Unable to convert string to date: %s",
 				value)
 		}
-		literal.Value = t.Unix()
+		literal.Value = t.UnixNano()
 		literal.Type = INTEGER_LITERAL
 	case NULL_LITERAL:
 		return fmt.Errorf("Unable to convert NULL to a numeric")


### PR DESCRIPTION
## WHAT
- support Nanosec precision predicate for SELECT SQL query.

## Example Usage
```
if __name__ == "__main__":
    # --- given ---
    cli = pymkts.Client()

    tbk = "TEST/1Sec/OHLCV"
    dtype = [('Epoch', 'i8'), ('Bid', 'f4'), ('Ask', 'f4'), ('Nanoseconds', 'i4')]

    cli.destroy(tbk)

    data = [
        np.array([(pd.Timestamp('2019-01-01 00:00:00').value / 10 ** 9, 1, 2, 100000000)], dtype=dtype),
        np.array([(pd.Timestamp('2019-01-01 00:00:00').value / 10 ** 9, 3, 4, 200000000)], dtype=dtype),
        np.array([(pd.Timestamp('2019-01-01 00:00:00').value / 10 ** 9, 5, 6, 300000000)], dtype=dtype),
        np.array([(pd.Timestamp('2019-01-01 00:00:00').value / 10 ** 9, 7, 8, 400000000)], dtype=dtype)
    ]
    for record in data:
        cli.write(record, tbk, isvariablelength=True)

    # --- when (datetime string)---
    sql = "SELECT * FROM `TEST/1Sec/OHLCV` WHERE Epoch BETWEEN '2019-01-01-00:00:00.15' AND '2019-01-01-00:00:00.35';"
    resp = cli.sql(sql)

    # --- then ---
    print(resp.first().df())

    # --- when (epoch nanosecond)---
    sql = "SELECT * FROM `TEST/1Sec/OHLCV` WHERE Epoch < 1546300800300000000;" # 1546300800300000000 = '2019-01-01-00:00:00.3'
    resp = cli.sql(sql)

    # --- then ---
    print(resp.first().df())

    # --- tear down
    cli.destroy(tbk)
```

->

```
                           Bid  Ask  Nanoseconds
Epoch                                           
2019-01-01 00:00:00+00:00  3.0  4.0    200000000
2019-01-01 00:00:00+00:00  5.0  6.0    300000000
                           Bid  Ask  Nanoseconds
Epoch                                           
2019-01-01 00:00:00+00:00  1.0  2.0    100000000
2019-01-01 00:00:00+00:00  3.0  4.0    200000000
```


## WHY
- Nanosec precision should be considered in case of variable-length query