### PR TITLE
refactor: remove unused AstBuilder struct

### DIFF
--- a/cmd/connect/session/local_api_client.go
+++ b/cmd/connect/session/local_api_client.go
@@ -108,11 +108,11 @@ func (lc *LocalAPIClient) GetBucketInfo(reqs *frontend.MultiKeyRequest, response
 }
 
 func (lc *LocalAPIClient) SQL(line string) (cs *io.ColumnSeries, err error){
-	ast, err := sqlparser.NewAstBuilder(line)
+	queryTree, err := sqlparser.BuildQueryTree(line)
 	if err != nil {
 		return nil, err
 	}
-	es, err := sqlparser.NewExecutableStatement(lc.catalogDir, ast.Mtree)
+	es, err := sqlparser.NewExecutableStatement(lc.catalogDir, queryTree)
 	if err != nil {
 		return nil, err
 	}

--- a/frontend/grpc.go
+++ b/frontend/grpc.go
@@ -70,11 +70,11 @@ func (s GRPCService) Query(ctx context.Context, reqs *proto.MultiQueryRequest) (
 	for _, req := range reqs.Requests {
 		switch req.IsSqlStatement {
 		case true:
-			ast, err := sqlparser.NewAstBuilder(req.SqlStatement)
+			queryTree, err := sqlparser.BuildQueryTree(req.SqlStatement)
 			if err != nil {
 				return nil, err
 			}
-			es, err := sqlparser.NewExecutableStatement(s.catalogDir, ast.Mtree)
+			es, err := sqlparser.NewExecutableStatement(s.catalogDir, queryTree)
 			if err != nil {
 				return nil, err
 			}

--- a/frontend/query.go
+++ b/frontend/query.go
@@ -116,11 +116,11 @@ func (s *DataService) Query(r *http.Request, reqs *MultiQueryRequest, response *
 }
 
 func (s *DataService) executeSQL(sqlStatement string) (*QueryResponse, error) {
-	ast, err := sqlparser.NewAstBuilder(sqlStatement)
+	queryTree, err := sqlparser.BuildQueryTree(sqlStatement)
 	if err != nil {
 		return nil, err
 	}
-	es, err := sqlparser.NewExecutableStatement(s.catalogDir, ast.Mtree)
+	es, err := sqlparser.NewExecutableStatement(s.catalogDir, queryTree)
 	if err != nil {
 		return nil, err
 	}

--- a/sqlparser/datatypes.go
+++ b/sqlparser/datatypes.go
@@ -9,11 +9,6 @@ type Relation interface {
 	Materialize() (cs *io.ColumnSeries, err error)
 }
 
-type QueryTree struct {
-	Relation
-	MSTree
-}
-
 /*
 Utility Functions
 */

--- a/sqlparser/executablestatement.go
+++ b/sqlparser/executablestatement.go
@@ -11,11 +11,10 @@ import (
 )
 
 type ExecutableStatement struct {
-	QueryTree
+	MSTree
 	BaseSQLQueryTreeVisitor
 	nodeCursor                 *ExecutableStatement
 	pendingSP                  *StaticPredicate
-	IsExplain                  bool
 	CatalogDirectory           *catalog.Directory
 }
 

--- a/sqlparser/interpreter.go
+++ b/sqlparser/interpreter.go
@@ -7,21 +7,10 @@ import (
 	. "github.com/antlr/antlr4/runtime/Go/antlr"
 )
 
-type AstBuilder struct {
-	BaseSQLBaseListener
 
-	statementSource string
-
-	QTRoot, QTCurrent *QueryTree
-	numberOfRelations int
-
-	Mtree IMSTree // The query tree, built from the parse tree
-}
-
-func NewAstBuilder(sourceString string) (ast *AstBuilder, err error) {
-	ast = &AstBuilder{statementSource: sourceString}
-
-	input := NewInputStream(ast.statementSource)
+// BuildQueryTree returns the query tree built from the parse tree
+func BuildQueryTree(sourceString string) (tree IMSTree, err error) {
+	input := NewInputStream(sourceString)
 	lexer := NewSQLBaseLexer(input)
 	lexErr := new(DescriptiveErrorListener)
 	lexer.RemoveErrorListeners()
@@ -42,15 +31,15 @@ func NewAstBuilder(sourceString string) (ast *AstBuilder, err error) {
 	//	fmt.Println(ast.statementSource)
 	//	fmt.Println(parser.Statements().ToStringTree([]string{"\n"}, parser))
 
-	ast.Mtree = NewStatementsParse(parser.Statements(), sourceString)
-	if ast.Mtree == nil {
+	tree = NewStatementsParse(parser.Statements(), sourceString)
+	if tree == nil {
 		return nil, fmt.Errorf("Unable to create query tree from parse tree")
 	}
 	if parseErr.err != nil {
 		fmt.Println(parseErr.err.Error())
 		return nil, parseErr.err
 	}
-	return ast, nil
+	return tree, nil
 }
 
 /*


### PR DESCRIPTION
Only `ast.Mtree`(=query tree) is necessary, we can remove AstBuilder struct