### PR TITLE
refactor: use WriteCSM instead of writer.WriteRecords

### DIFF
--- a/utils/io/metadata.go
+++ b/utils/io/metadata.go
@@ -37,6 +37,8 @@ func FileSize(tf time.Duration, year int, recordSize int) int64 {
 type TimeBucketInfo struct {
 	// Year, Path and IsRead are all set on catalog startup
 	Year   int16
+	// Path is the absolute path to the data binary file.
+	// (e.g. "/mkts/data/TEST/1Sec/Tick/2021.bin")
 	Path   string
 	IsRead bool
 


### PR DESCRIPTION
## WHAT
- Make all modules use WriteCSM instead of writer.WriteRecords.

## WHY
- improve refactorability 