### PR TITLE
refactor: use testing.T and t.Parallel() as much as possible

### DIFF
--- a/cmd/connect/loader/all_test.go
+++ b/cmd/connect/loader/all_test.go
@@ -1,48 +1,41 @@
 package loader
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
-
-	. "gopkg.in/check.v1"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
+func TestParseTime(t *testing.T) {
+	t.Parallel()
 
-type LoaderTests struct{}
-
-var _ = Suite(&LoaderTests{})
-
-func (s *LoaderTests) SetUpSuite(c *C)    {}
-func (s *LoaderTests) TearDownSuite(c *C) {}
-
-func (s *LoaderTests) TestParseTime(c *C) {
 	tt := time.Date(2016, 12, 30, 21, 59, 20, 383000000, time.UTC)
 	var fAdj int
 	timeFormat := "20060102 15:04:05"
 	dateTime := "20161230 21:59:20 383000"
 	tzLoc := time.UTC
 	tTest, err := parseTime(timeFormat, dateTime, tzLoc, fAdj)
-	c.Assert(err != nil, Equals, true)
+	assert.Equal(t, err != nil, true)
 	formatAdj := len(dateTime) - len(timeFormat)
 	tTest, err = parseTime(timeFormat, dateTime, tzLoc, formatAdj)
-	c.Assert(tt == tTest, Equals, true)
+	assert.Equal(t, tt == tTest, true)
 }
 
-func (s *LoaderTests) TestParseTimestamp(c *C) {
+func TestParseTimestamp(t *testing.T) {
+	t.Parallel()
+
 	tt := time.Date(2017, 11, 07, 07, 8, 23, 383000000, time.UTC)
 	var fAdj int
 	timeFormat := "timestamp"
 	dateTime := "1510038503.383"
 	tzLoc := time.UTC
 	tTest, err := parseTime(timeFormat, dateTime, tzLoc, fAdj)
-	c.Assert(err == nil, Equals, true)
-	c.Assert(tt == tTest, Equals, true)
+	assert.Equal(t, err == nil, true)
+	assert.Equal(t, tt == tTest, true)
 
 	tt1 := time.Date(2017, 11, 07, 07, 8, 23, 0, time.UTC)
 	dateTime = "1510038503"
 	tTest, err = parseTime(timeFormat, dateTime, tzLoc, fAdj)
-	c.Assert(err == nil, Equals, true)
-	c.Assert(tt1 == tTest, Equals, true)
+	assert.Equal(t, err == nil, true)
+	assert.Equal(t, tt1 == tTest, true)
 }

--- a/cmd/connect/session/client_test.go
+++ b/cmd/connect/session/client_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestPrintResult(t *testing.T) {
+	t.Parallel()
+	
 	// --- given ---
 	cs := io.NewColumnSeries()
 	cs.AddColumn("Epoch", []int64{1483228800, 1483315200, 1483401600}) //2017-01-01,02,03

--- a/contrib/alpaca/config/config_test.go
+++ b/contrib/alpaca/config/config_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAsCanonical(t *testing.T) {
+	t.Parallel()
 	aggToMinute := string(enums.AggToMinute)
 	q := string(enums.Quote)
 	tr := string(enums.Trade)
@@ -59,6 +60,7 @@ func TestAsCanonical(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		got := tt.sub.AsCanonical()
 		assert.ElementsMatchf(
 			t,
@@ -73,6 +75,7 @@ func TestAsCanonical(t *testing.T) {
 }
 
 func TestFlatten(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		lists    [][]string
 		expected []string
@@ -86,6 +89,7 @@ func TestFlatten(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		got := flatten(tt.lists...)
 		assert.ElementsMatchf(
 			t,
@@ -100,6 +104,7 @@ func TestFlatten(t *testing.T) {
 }
 
 func TestPrefixStrings(t *testing.T) {
+	t.Parallel()
 	aggToMinute := string(enums.AggToMinute)
 	var tests = []struct {
 		list     []string
@@ -115,6 +120,7 @@ func TestPrefixStrings(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		got := prefixStrings(tt.list, string(tt.prefix))
 		assert.ElementsMatchf(
 			t,
@@ -130,6 +136,7 @@ func TestPrefixStrings(t *testing.T) {
 }
 
 func TestNormalizeSubscriptions(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		list     []string
 		expected []string
@@ -142,6 +149,7 @@ func TestNormalizeSubscriptions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		got := normalizeSubscriptions(tt.list)
 		assert.ElementsMatchf(
 			t,
@@ -156,6 +164,7 @@ func TestNormalizeSubscriptions(t *testing.T) {
 }
 
 func TestContainsWildcard(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		list     []string
 		expected bool
@@ -169,6 +178,7 @@ func TestContainsWildcard(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		got := containsWildcard(tt.list)
 		assert.Equalf(
 			t,

--- a/contrib/binancefeeder/binancefeeder_test.go
+++ b/contrib/binancefeeder/binancefeeder_test.go
@@ -4,22 +4,18 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/alpacahq/marketstore/v4/plugins/bgworker"
-	. "gopkg.in/check.v1"
 )
-
-func Test(t *testing.T) { TestingT(t) }
-
-var _ = Suite(&TestSuite{})
-
-type TestSuite struct{}
 
 func getConfig(data string) (ret map[string]interface{}) {
 	json.Unmarshal([]byte(data), &ret)
 	return
 }
 
-func (t *TestSuite) TestNew(c *C) {
+func TestNew(t *testing.T) {
+	t.Parallel()
 	var config = getConfig(`{
 		"symbols": ["ETH"],
 		"base_currencies": ["USDT", "BTC"]
@@ -29,12 +25,12 @@ func (t *TestSuite) TestNew(c *C) {
 	var err error
 	ret, err = NewBgWorker(config)
 	worker = ret.(*BinanceFetcher)
-	c.Assert(len(worker.symbols), Equals, 1)
-	c.Assert(worker.symbols[0], Equals, "ETH")
-	c.Assert(len(worker.baseCurrencies), Equals, 2)
-	c.Assert(worker.baseCurrencies[0], Equals, "USDT")
-	c.Assert(worker.baseCurrencies[1], Equals, "BTC")
-	c.Assert(err, IsNil)
+	assert.Len(t, worker.symbols, 1)
+	assert.Equal(t, worker.symbols[0], "ETH")
+	assert.Len(t, worker.baseCurrencies, 2)
+	assert.Equal(t, worker.baseCurrencies[0], "USDT")
+	assert.Equal(t, worker.baseCurrencies[1], "BTC")
+	assert.Nil(t, err)
 
 	//The symbols from the biannce API can very well change so
 	//if this test fails, consider that the API might of changed with more symbols
@@ -50,6 +46,6 @@ func (t *TestSuite) TestNew(c *C) {
         }`)
 	ret, err = NewBgWorker(config)
 	worker = ret.(*BinanceFetcher)
-	c.Assert(err, IsNil)
-	c.Assert(worker.queryStart.IsZero(), Equals, false)
+	assert.Nil(t, err)
+	assert.False(t, worker.queryStart.IsZero())
 }

--- a/contrib/bitmexfeeder/bitmexfeeder_test.go
+++ b/contrib/bitmexfeeder/bitmexfeeder_test.go
@@ -5,23 +5,19 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	bitmex "github.com/alpacahq/marketstore/v4/contrib/bitmexfeeder/api"
 	"github.com/alpacahq/marketstore/v4/plugins/bgworker"
-	. "gopkg.in/check.v1"
 )
-
-func Test(t *testing.T) { TestingT(t) }
-
-var _ = Suite(&TestSuite{})
-
-type TestSuite struct{}
 
 func getConfig(data string) (ret map[string]interface{}) {
 	json.Unmarshal([]byte(data), &ret)
 	return
 }
 
-func (t *TestSuite) TestNew(c *C) {
+func TestNew(t *testing.T) {
+	t.Parallel()
 	var config = getConfig(`{
         "symbols": ["XBTUSD"]
         }`)
@@ -30,18 +26,18 @@ func (t *TestSuite) TestNew(c *C) {
 	var err error
 	ret, err = NewBgWorker(config)
 	worker = ret.(*BitmexFetcher)
-	c.Assert(len(worker.symbols), Equals, 1)
-	c.Assert(worker.symbols[0], Equals, "XBTUSD")
-	c.Assert(err, IsNil)
+	assert.Equal(t, len(worker.symbols), 1)
+	assert.Equal(t, worker.symbols[0], "XBTUSD")
+	assert.Nil(t, err)
 
 	config = getConfig(``)
 	ret, err = NewBgWorker(config)
 	worker = ret.(*BitmexFetcher)
-	c.Assert(err, IsNil)
+	assert.Nil(t, err)
 	client := bitmex.Init()
 	symbols, err := client.GetInstruments()
-	c.Assert(err, IsNil)
-	c.Assert(len(worker.symbols), Equals, len(symbols))
+	assert.Nil(t, err)
+	assert.Equal(t, len(worker.symbols), len(symbols))
 
 	config = getConfig(`{
 	    "query_start": "2017-01-02 00:00"
@@ -52,6 +48,6 @@ func (t *TestSuite) TestNew(c *C) {
 	}
 	worker = ret.(*BitmexFetcher)
 	fmt.Printf("%v", worker)
-	c.Assert(err, IsNil)
-	c.Assert(worker.queryStart.IsZero(), Equals, false)
+	assert.Nil(t, err)
+	assert.Equal(t, worker.queryStart.IsZero(), false)
 }

--- a/contrib/calendar/calendar_test.go
+++ b/contrib/calendar/calendar_test.go
@@ -4,50 +4,45 @@ import (
 	"testing"
 	"time"
 
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
 )
-
-func Test(t *testing.T) { TestingT(t) }
 
 var NY, _ = time.LoadLocation("America/New_York")
 
-type CalendarTestSuite struct{}
-
-var _ = Suite(&CalendarTestSuite{})
-
-func (s *CalendarTestSuite) TestCalendar(c *C) {
+func TestCalendar(t *testing.T) {
+	t.Parallel()
 	// Weekend
 	weekend := time.Date(2017, 1, 1, 11, 0, 0, 0, NY)
-	c.Assert(Nasdaq.IsMarketOpen(weekend), Equals, false)
-	c.Assert(Nasdaq.IsMarketDay(weekend), Equals, false)
+	assert.Equal(t, Nasdaq.IsMarketOpen(weekend), false)
+	assert.Equal(t, Nasdaq.IsMarketDay(weekend), false)
 
 	// MLK day 2018
 	mlk := time.Date(2018, 1, 15, 11, 0, 0, 0, NY)
-	c.Assert(Nasdaq.IsMarketOpen(mlk), Equals, false)
-	c.Assert(Nasdaq.IsMarketDay(mlk), Equals, false)
+	assert.Equal(t, Nasdaq.IsMarketOpen(mlk), false)
+	assert.Equal(t, Nasdaq.IsMarketDay(mlk), false)
 
 	// July 3rd 2019 (early close)
 	julThirdAM := time.Date(2018, 7, 3, 11, 0, 0, 0, NY)
 	julThirdPM := time.Date(2018, 7, 3, 15, 0, 0, 0, NY)
-	c.Assert(Nasdaq.IsMarketOpen(julThirdAM), Equals, true)
-	c.Assert(Nasdaq.EpochIsMarketOpen(julThirdAM.Unix()), Equals, true)
-	c.Assert(Nasdaq.IsMarketDay(julThirdAM), Equals, true)
+	assert.True(t, Nasdaq.IsMarketOpen(julThirdAM))
+	assert.True(t, Nasdaq.EpochIsMarketOpen(julThirdAM.Unix()))
+	assert.True(t, Nasdaq.IsMarketDay(julThirdAM))
 
-	c.Assert(Nasdaq.IsMarketOpen(julThirdPM), Equals, false)
-	c.Assert(Nasdaq.IsMarketDay(julThirdPM), Equals, true)
+	assert.False(t, Nasdaq.IsMarketOpen(julThirdPM))
+	assert.True(t, Nasdaq.IsMarketDay(julThirdPM))
 
 	// normal day
 	bestDayMid := time.Date(2021, 8, 31, 11, 0, 0, 0, NY)
 	bestDayEarly := time.Date(2021, 8, 31, 7, 0, 0, 0, NY)
 	bestDayLate := time.Date(2021, 8, 31, 19, 0, 0, 0, NY)
-	c.Assert(Nasdaq.IsMarketOpen(bestDayMid), Equals, true)
-	c.Assert(Nasdaq.IsMarketDay(bestDayMid), Equals, true)
+	assert.True(t, Nasdaq.IsMarketOpen(bestDayMid))
+	assert.True(t, Nasdaq.IsMarketDay(bestDayMid))
 
-	c.Assert(Nasdaq.IsMarketOpen(bestDayEarly), Equals, false)
-	c.Assert(Nasdaq.IsMarketDay(bestDayEarly), Equals, true)
+	assert.False(t, Nasdaq.IsMarketOpen(bestDayEarly))
+	assert.True(t, Nasdaq.IsMarketDay(bestDayEarly))
 
-	c.Assert(Nasdaq.IsMarketOpen(bestDayLate), Equals, false)
-	c.Assert(Nasdaq.IsMarketDay(bestDayLate), Equals, true)
+	assert.False(t, Nasdaq.IsMarketOpen(bestDayLate))
+	assert.True(t, Nasdaq.IsMarketDay(bestDayLate))
 
-	c.Assert(Nasdaq.Tz().String(), Equals, "America/New_York")
+	assert.Equal(t, Nasdaq.Tz().String(), "America/New_York")
 }

--- a/contrib/gdaxfeeder/gdaxfeeder_test.go
+++ b/contrib/gdaxfeeder/gdaxfeeder_test.go
@@ -4,22 +4,18 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/alpacahq/marketstore/v4/plugins/bgworker"
-	. "gopkg.in/check.v1"
 )
-
-func Test(t *testing.T) { TestingT(t) }
-
-var _ = Suite(&TestSuite{})
-
-type TestSuite struct{}
 
 func getConfig(data string) (ret map[string]interface{}) {
 	json.Unmarshal([]byte(data), &ret)
 	return
 }
 
-func (t *TestSuite) TestNew(c *C) {
+func TestNew(t *testing.T) {
+	t.Parallel()
 	var config = getConfig(`{
         "symbols": ["BTC-USD"]
         }`)
@@ -28,23 +24,23 @@ func (t *TestSuite) TestNew(c *C) {
 	var err error
 	ret, err = NewBgWorker(config)
 	worker = ret.(*GdaxFetcher)
-	c.Assert(len(worker.symbols), Equals, 1)
-	c.Assert(worker.symbols[0], Equals, "BTC-USD")
-	c.Assert(err, IsNil)
+	assert.Len(t, worker.symbols, 1)
+	assert.Equal(t, worker.symbols[0], "BTC-USD")
+	assert.Nil(t, err)
 
 	config = getConfig(`{
         "symbols": ["BTC-USD", "ETH-USD", "LTC-BTC"]
         }`)
 	ret, err = NewBgWorker(config)
-	c.Assert(err, IsNil)
+	assert.Nil(t, err)
 	worker = ret.(*GdaxFetcher)
-	c.Assert(len(worker.symbols), Equals, 3)
+	assert.Len(t, worker.symbols, 3)
 
 	config = getConfig(`{
         "query_start": "2017-01-02 00:00"
         }`)
 	ret, err = NewBgWorker(config)
 	worker = ret.(*GdaxFetcher)
-	c.Assert(err, IsNil)
-	c.Assert(worker.queryStart.IsZero(), Equals, false)
+	assert.Nil(t, err)
+	assert.False(t, worker.queryStart.IsZero())
 }

--- a/contrib/ice/reorg/record_test.go
+++ b/contrib/ice/reorg/record_test.go
@@ -5,23 +5,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/alpacahq/marketstore/v4/contrib/ice/enum"
-
-	. "gopkg.in/check.v1"
 )
-
-func TestAnnouncement(t *testing.T) { TestingT(t) }
-
-type TestAnnouncementSuite struct {
-}
-
-var _ = Suite(&TestAnnouncementSuite{})
 
 func date(year int, month time.Month, day int) time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 }
 
-func (t *TestAnnouncementSuite) TestReadRecord(c *C) {
+func TestReadRecord(t *testing.T) {
+	t.Parallel()
 	input := `........................................................... ENT:01/24/20:(2020) 
 DEAL#: 1: TEXT#:2052662: REMARKS:STOCK SPLIT :   IND:7N  C: EFF:99/99/99:(9999) 
 TARGET:928534106: :VIVIC CORP: INIT:999999999: :9999999999: EXP:01/27/20:(2020) 
@@ -40,36 +34,37 @@ DUE BILL REDEMPTION DATE:  /  /  :                                  **
 	a := Announcement{}
 	readRecord(lines, &a)
 
-	c.Assert(a.EntryDate, DeepEquals, date(2020, time.January, 24))
-	c.Assert(a.DealNumber, Equals, "1")
-	c.Assert(a.TextNumber, Equals, 2052662)
-	c.Assert(a.Remarks, Equals, "STOCK SPLIT")
-	c.Assert(a.NotificationType, Equals, enum.StockSplit)
-	c.Assert(a.Status, Equals, enum.NewAnnouncement)
-	c.Assert(a.UpdatedNotificationType, Equals, enum.UnsetNotification)
-	c.Assert(a.NrOfOptions, Equals, "")
-	c.Assert(a.SecurityType, Equals, enum.CommonStock)
-	c.Assert(a.EffectiveDate, Equals, time.Time{})
-	c.Assert(a.TargetCusip, Equals, "928534106")
-	c.Assert(a.TargetDescription, Equals, "VIVIC CORP")
-	c.Assert(a.InitiatingCusip, Equals, "999999999")
-	c.Assert(a.InitiatingDescription, Equals, "9999999999")
-	c.Assert(a.ExpirationDate, Equals, date(2020, time.January, 27))
-	c.Assert(a.Cash, Equals, 0.0)
-	c.Assert(a.CashCode, Equals, "")
-	c.Assert(a.StateCode, Equals, "")
-	c.Assert(a.RecordDate, Equals, date(2020, time.January, 20))
-	c.Assert(a.Rate, Equals, 4.0)
-	c.Assert(a.RateCode, Equals, "")
-	c.Assert(a.VoluntaryMandatoryCode, Equals, enum.MandatoryAction)
-	c.Assert(a.UpdateTextNumber, Equals, 0)
-	c.Assert(a.DeleteTextNumber, Equals, 0)
-	c.Assert(a.NewRate, Equals, 4.0)
-	c.Assert(a.OldRate, Equals, 1.0)
-	c.Assert(a.DueRedemptionDate, Equals, time.Time{})
+	assert.Equal(t, a.EntryDate, date(2020, time.January, 24))
+	assert.Equal(t, a.DealNumber, "1")
+	assert.Equal(t, a.TextNumber, 2052662)
+	assert.Equal(t, a.Remarks, "STOCK SPLIT")
+	assert.Equal(t, a.NotificationType, enum.StockSplit)
+	assert.Equal(t, a.Status, enum.NewAnnouncement)
+	assert.Equal(t, a.UpdatedNotificationType, enum.UnsetNotification)
+	assert.Equal(t, a.NrOfOptions, "")
+	assert.Equal(t, a.SecurityType, enum.CommonStock)
+	assert.Equal(t, a.EffectiveDate, time.Time{})
+	assert.Equal(t, a.TargetCusip, "928534106")
+	assert.Equal(t, a.TargetDescription, "VIVIC CORP")
+	assert.Equal(t, a.InitiatingCusip, "999999999")
+	assert.Equal(t, a.InitiatingDescription, "9999999999")
+	assert.Equal(t, a.ExpirationDate, date(2020, time.January, 27))
+	assert.Equal(t, a.Cash, 0.0)
+	assert.Equal(t, a.CashCode, "")
+	assert.Equal(t, a.StateCode, "")
+	assert.Equal(t, a.RecordDate, date(2020, time.January, 20))
+	assert.Equal(t, a.Rate, 4.0)
+	assert.Equal(t, a.RateCode, "")
+	assert.Equal(t, a.VoluntaryMandatoryCode, enum.MandatoryAction)
+	assert.Equal(t, a.UpdateTextNumber, 0)
+	assert.Equal(t, a.DeleteTextNumber, 0)
+	assert.Equal(t, a.NewRate, 4.0)
+	assert.Equal(t, a.OldRate, 1.0)
+	assert.Equal(t, a.DueRedemptionDate, time.Time{})
 }
 
-func (t *TestAnnouncementSuite) TestReadRecords(c *C) {
+func TestReadRecords(t *testing.T) {
+	t.Parallel()
 	input := `........................................................... ENT:01/24/20:(2020) 
 DEAL#: 1: TEXT#:2052815: REMARKS:EXPIRATION  :   IND:@UT1C: EFF:99/99/99:(9999) 
 TARGET:26153M200: :DREAM UNLI: INIT:999999999: :DREAM UNLI: EXP:01/22/20:(2020) 
@@ -125,13 +120,13 @@ TEL: 800 680-0661
 	var announcements = []Announcement{}
 	readRecords(input, &announcements)
 
-	c.Assert(len(announcements), Equals, 2)
+	assert.Equal(t, len(announcements), 2)
 	first := announcements[0]
 	second := announcements[1]
-	c.Assert(first.TextNumber, Equals, 2052815)
-	c.Assert(first.TargetCusip, Equals, "26153M200")
-	c.Assert(first.UpdateTextNumber, Equals, 2035174)
-	c.Assert(second.TextNumber, Equals, 2052817)
-	c.Assert(second.TargetCusip, Equals, "11144V105")
-	c.Assert(second.UpdateTextNumber, Equals, 1984589)
+	assert.Equal(t, first.TextNumber, 2052815)
+	assert.Equal(t, first.TargetCusip, "26153M200")
+	assert.Equal(t, first.UpdateTextNumber, 2035174)
+	assert.Equal(t, second.TextNumber, 2052817)
+	assert.Equal(t, second.TargetCusip, "11144V105")
+	assert.Equal(t, second.UpdateTextNumber, 1984589)
 }

--- a/contrib/polygon/backfill/backfill_test.go
+++ b/contrib/polygon/backfill/backfill_test.go
@@ -1,27 +1,19 @@
 package backfill
 
 import (
-	"github.com/alpacahq/marketstore/v4/models/enum"
 	"testing"
 	"time"
+
+	"github.com/alpacahq/marketstore/v4/models/enum"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/api"
 	"github.com/alpacahq/marketstore/v4/models"
 	"github.com/alpacahq/marketstore/v4/utils/io"
-
-	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-var _ = Suite(&BackfillTests{})
-
-type BackfillTests struct{}
-
-func (s *BackfillTests) SetUpSuite(c *C)    {}
-func (s *BackfillTests) TearDownSuite(c *C) {}
-
-func (s *BackfillTests) TestTicksToBars(c *C) {
+func TestTicksToBars(t *testing.T) {
+	t.Parallel()
 	NY, _ := time.LoadLocation("America/New_York")
 
 	// Without any condition
@@ -59,16 +51,16 @@ func (s *BackfillTests) TestTicksToBars(c *C) {
 
 		// Then the returned ColumnSeriesMarks should contain data from the two
 		// specified exchanges, accumulated to minutes
-		c.Assert(csm, NotNil)
-		t, _ := csm[*key].GetTime()
-		c.Assert(t, DeepEquals, []time.Time{
+		assert.NotNil(t, csm)
+		ti, _ := csm[*key].GetTime()
+		assert.Equal(t, ti, []time.Time{
 			time.Date(2020, 1, 21, 9, 30, 0, 0, NY).In(time.UTC),
 		})
-		c.Assert(csm[*key].GetColumn("Open").([]enum.Price), DeepEquals, []enum.Price{300})
-		c.Assert(csm[*key].GetColumn("High").([]enum.Price), DeepEquals, []enum.Price{300.1})
-		c.Assert(csm[*key].GetColumn("Low").([]enum.Price), DeepEquals, []enum.Price{300})
-		c.Assert(csm[*key].GetColumn("Close").([]enum.Price), DeepEquals, []enum.Price{300.1})
-		c.Assert(csm[*key].GetColumn("Volume").([]enum.Size), DeepEquals, []enum.Size{180})
+		assert.Equal(t, csm[*key].GetColumn("Open").([]enum.Price), []enum.Price{300})
+		assert.Equal(t, csm[*key].GetColumn("High").([]enum.Price), []enum.Price{300.1})
+		assert.Equal(t, csm[*key].GetColumn("Low").([]enum.Price), []enum.Price{300})
+		assert.Equal(t, csm[*key].GetColumn("Close").([]enum.Price), []enum.Price{300.1})
+		assert.Equal(t, csm[*key].GetColumn("Volume").([]enum.Size), []enum.Size{180})
 
 		model = models.NewBar(symbol, "1Min", 1440)
 		// And when we call tradesToBars with different set of exchanges
@@ -78,16 +70,16 @@ func (s *BackfillTests) TestTicksToBars(c *C) {
 
 		// Then the returned ColumnSeriesMarks should contain data from the two new
 		// specified exchanges, accumulated in minutes
-		c.Assert(csm, NotNil)
-		t, _ = csm[*key].GetTime()
-		c.Assert(t, DeepEquals, []time.Time{
+		assert.NotNil(t, csm)
+		ti, _ = csm[*key].GetTime()
+		assert.Equal(t, ti, []time.Time{
 			time.Date(2020, 1, 21, 9, 30, 0, 0, NY).In(time.UTC),
 		})
-		c.Assert(csm[*key].GetColumn("Open").([]enum.Price), DeepEquals, []enum.Price{300})
-		c.Assert(csm[*key].GetColumn("High").([]enum.Price), DeepEquals, []enum.Price{300})
-		c.Assert(csm[*key].GetColumn("Low").([]enum.Price), DeepEquals, []enum.Price{299.9})
-		c.Assert(csm[*key].GetColumn("Close").([]enum.Price), DeepEquals, []enum.Price{299.9})
-		c.Assert(csm[*key].GetColumn("Volume").([]enum.Size), DeepEquals, []enum.Size{150})
+		assert.Equal(t, csm[*key].GetColumn("Open").([]enum.Price), []enum.Price{300})
+		assert.Equal(t, csm[*key].GetColumn("High").([]enum.Price), []enum.Price{300})
+		assert.Equal(t, csm[*key].GetColumn("Low").([]enum.Price), []enum.Price{299.9})
+		assert.Equal(t, csm[*key].GetColumn("Close").([]enum.Price), []enum.Price{299.9})
+		assert.Equal(t, csm[*key].GetColumn("Volume").([]enum.Size), []enum.Size{150})
 	}
 
 	// With one condition: No update on High/Low, Volume & Close
@@ -112,12 +104,12 @@ func (s *BackfillTests) TestTicksToBars(c *C) {
 
 		csm := *model.BuildCsm()
 
-		c.Assert(csm, NotNil)
-		c.Assert(csm[*key].GetColumn("Open").([]enum.Price), DeepEquals, []enum.Price{})
-		c.Assert(csm[*key].GetColumn("High").([]enum.Price), DeepEquals, []enum.Price{})
-		c.Assert(csm[*key].GetColumn("Low").([]enum.Price), DeepEquals, []enum.Price{})
-		c.Assert(csm[*key].GetColumn("Close").([]enum.Price), DeepEquals, []enum.Price{})
-		c.Assert(csm[*key].GetColumn("Volume").([]enum.Size), DeepEquals, []enum.Size{})
+		assert.NotNil(t, csm)
+		assert.Equal(t, csm[*key].GetColumn("Open").([]enum.Price), []enum.Price{})
+		assert.Equal(t, csm[*key].GetColumn("High").([]enum.Price), []enum.Price{})
+		assert.Equal(t, csm[*key].GetColumn("Low").([]enum.Price), []enum.Price{})
+		assert.Equal(t, csm[*key].GetColumn("Close").([]enum.Price), []enum.Price{})
+		assert.Equal(t, csm[*key].GetColumn("Volume").([]enum.Size), []enum.Size{})
 	}
 
 	// With conditions: Normal trade + No update on High/Low, Volume & Close
@@ -149,12 +141,12 @@ func (s *BackfillTests) TestTicksToBars(c *C) {
 
 		csm := *model.BuildCsm()
 
-		c.Assert(csm, NotNil)
-		c.Assert(csm[*key].GetColumn("Open").([]enum.Price), DeepEquals, []enum.Price{300})
-		c.Assert(csm[*key].GetColumn("High").([]enum.Price), DeepEquals, []enum.Price{300})
-		c.Assert(csm[*key].GetColumn("Low").([]enum.Price), DeepEquals, []enum.Price{300})
-		c.Assert(csm[*key].GetColumn("Close").([]enum.Price), DeepEquals, []enum.Price{300})
-		c.Assert(csm[*key].GetColumn("Volume").([]enum.Size), DeepEquals, []enum.Size{100})
+		assert.NotNil(t, csm)
+		assert.Equal(t, csm[*key].GetColumn("Open").([]enum.Price), []enum.Price{300})
+		assert.Equal(t, csm[*key].GetColumn("High").([]enum.Price), []enum.Price{300})
+		assert.Equal(t, csm[*key].GetColumn("Low").([]enum.Price), []enum.Price{300})
+		assert.Equal(t, csm[*key].GetColumn("Close").([]enum.Price), []enum.Price{300})
+		assert.Equal(t, csm[*key].GetColumn("Volume").([]enum.Size), []enum.Size{100})
 	}
 
 	// With condition: Form-T, odd-lot and normal
@@ -205,12 +197,11 @@ func (s *BackfillTests) TestTicksToBars(c *C) {
 		tradesToBars(ticks, model, exchangeIDs)
 
 		csm := *model.BuildCsm()
-		c.Assert(csm, NotNil)
-		c.Assert(csm[*key].GetColumn("Open").([]enum.Price), DeepEquals, []enum.Price{300, 305.2})
-		c.Assert(csm[*key].GetColumn("High").([]enum.Price), DeepEquals, []enum.Price{300, 315.2})
-		c.Assert(csm[*key].GetColumn("Low").([]enum.Price), DeepEquals, []enum.Price{299, 305.2})
-		c.Assert(csm[*key].GetColumn("Close").([]enum.Price), DeepEquals, []enum.Price{299, 315.2})
-		c.Assert(csm[*key].GetColumn("Volume").([]enum.Size), DeepEquals, []enum.Size{276, 27})
-
+		assert.NotNil(t, csm)
+		assert.Equal(t, csm[*key].GetColumn("Open").([]enum.Price), []enum.Price{300, 305.2})
+		assert.Equal(t, csm[*key].GetColumn("High").([]enum.Price), []enum.Price{300, 315.2})
+		assert.Equal(t, csm[*key].GetColumn("Low").([]enum.Price), []enum.Price{299, 305.2})
+		assert.Equal(t, csm[*key].GetColumn("Close").([]enum.Price), []enum.Price{299, 315.2})
+		assert.Equal(t, csm[*key].GetColumn("Volume").([]enum.Size), []enum.Size{276, 27})
 	}
 }

--- a/contrib/polyiex/orderbook/orderbook_test.go
+++ b/contrib/polyiex/orderbook/orderbook_test.go
@@ -3,22 +3,17 @@ package orderbook
 import (
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-type OrderBookTestSuite struct{}
-
-var _ = Suite(&OrderBookTestSuite{})
-
-func (s *OrderBookTestSuite) TestOrderBook(c *C) {
+func TestOrderBook(t *testing.T) {
+	t.Parallel()
 	ob := NewOrderBook()
 
 	{
 		b, a := ob.BBO()
-		c.Assert(float32(0.0), Equals, b.Price)
-		c.Assert(float32(0.0), Equals, a.Price)
+		assert.Equal(t, float32(0.0), b.Price)
+		assert.Equal(t, float32(0.0), a.Price)
 	}
 
 	bids0 := []Entry{
@@ -34,8 +29,8 @@ func (s *OrderBookTestSuite) TestOrderBook(c *C) {
 
 	{
 		b, a := ob.BBO()
-		c.Assert(float32(153.72), Equals, b.Price)
-		c.Assert(float32(0.0), Equals, a.Price)
+		assert.Equal(t, float32(153.72), b.Price)
+		assert.Equal(t, float32(0.0), a.Price)
 	}
 
 	asks0 := []Entry{
@@ -50,10 +45,10 @@ func (s *OrderBookTestSuite) TestOrderBook(c *C) {
 
 	{
 		b, a := ob.BBO()
-		c.Assert(float32(153.72), Equals, b.Price)
-		c.Assert(int32(100), Equals, b.Size)
-		c.Assert(float32(154.04), Equals, a.Price)
-		c.Assert(int32(100), Equals, a.Size)
+		assert.Equal(t, float32(153.72), b.Price)
+		assert.Equal(t, int32(100), b.Size)
+		assert.Equal(t, float32(154.04), a.Price)
+		assert.Equal(t, int32(100), a.Size)
 	}
 
 	asks1 := []Entry{
@@ -66,8 +61,8 @@ func (s *OrderBookTestSuite) TestOrderBook(c *C) {
 
 	{
 		_, a := ob.BBO()
-		c.Assert(float32(154.05), Equals, a.Price)
-		c.Assert(int32(200), Equals, a.Size)
+		assert.Equal(t, float32(154.05), a.Price)
+		assert.Equal(t, int32(200), a.Size)
 	}
 
 }

--- a/contrib/stream/shelf/shelf_test.go
+++ b/contrib/stream/shelf/shelf_test.go
@@ -4,17 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/alpacahq/marketstore/v4/utils/io"
-	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-type ShelfTestSuite struct{}
-
-var _ = Suite(&ShelfTestSuite{})
-
-func (s *ShelfTestSuite) TestShelf(c *C) {
+func TestShelf(t *testing.T) {
+	t.Parallel()
 	// normal expiration
 	{
 		expC := make(chan struct{}, 1)
@@ -34,7 +30,7 @@ func (s *ShelfTestSuite) TestShelf(c *C) {
 
 		<-expC
 
-		c.Assert(expired, Equals, true)
+		assert.True(t, expired)
 	}
 	// replacement with same deadline, then expiration
 	{
@@ -60,7 +56,7 @@ func (s *ShelfTestSuite) TestShelf(c *C) {
 
 		<-expC
 
-		c.Assert(expireCount, Equals, 1)
+		assert.Equal(t, expireCount, 1)
 	}
 	// replacement with new deadline, then expiration
 	{
@@ -89,11 +85,11 @@ func (s *ShelfTestSuite) TestShelf(c *C) {
 
 		<-expC
 
-		c.Assert(expireCount, Equals, 1)
+		assert.Equal(t, expireCount, 1)
 
 		<-expC
 
-		c.Assert(expireCount, Equals, 2)
+		assert.Equal(t, expireCount, 2)
 	}
 	// attempted replacement w/ same deadline - make sure
 	// things get properly cleaned up
@@ -114,7 +110,7 @@ func (s *ShelfTestSuite) TestShelf(c *C) {
 		// attempt replace
 		shelf.Store(tbk, genColumns(), &deadline)
 
-		c.Assert(len(shelf.m), Equals, 1)
+		assert.Len(t, shelf.m, 1)
 	}
 }
 

--- a/contrib/xignitefeeder/api/client_test.go
+++ b/contrib/xignitefeeder/api/client_test.go
@@ -48,6 +48,7 @@ func NewMockClient(t *testing.T, expectedResponse interface{}) *http.Client {
 }
 
 func TestDefaultAPIClient_GetRealTimeQuotes_Success(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultClient{
 		// return "Outcome: Success" response body
@@ -67,6 +68,7 @@ func TestDefaultAPIClient_GetRealTimeQuotes_Success(t *testing.T) {
 }
 
 func TestDefaultAPIClient_ListSymbols_Success(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultClient{
 		// return "Outcome: Success" response body
@@ -86,6 +88,7 @@ func TestDefaultAPIClient_ListSymbols_Success(t *testing.T) {
 }
 
 func TestDefaultAPIClient_GetQuotesRange_Success(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultClient{
 		// return "Outcome: Success" response body
@@ -106,6 +109,7 @@ func TestDefaultAPIClient_GetQuotesRange_Success(t *testing.T) {
 
 // When Xignite returns Outcome:"SystemError", throw an error
 func TestDefaultAPIClient_ListSymbols_Error(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultClient{
 		// return "Outcome: SystemError" response body
@@ -123,6 +127,7 @@ func TestDefaultAPIClient_ListSymbols_Error(t *testing.T) {
 
 // When Xignite returns Outcome:"SystemError" to ListIndexSymbols API, throw an error
 func TestDefaultAPIClient_ListIndexSymbols_Error(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultClient{
 		// return "Outcome: SystemError" response body
@@ -139,6 +144,7 @@ func TestDefaultAPIClient_ListIndexSymbols_Error(t *testing.T) {
 }
 
 func TestDefaultAPIClient_GetRealTimeBars_Success(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultClient{
 		// return "Outcome: Success" response body
@@ -158,6 +164,7 @@ func TestDefaultAPIClient_GetRealTimeBars_Success(t *testing.T) {
 }
 
 func TestDefaultAPIClient_GetIndexBars_Success(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultClient{
 		// return "Outcome: Success" response body
@@ -178,6 +185,7 @@ func TestDefaultAPIClient_GetIndexBars_Success(t *testing.T) {
 
 // When Xignite returns Outcome:"SystemError", throw an error
 func TestDefaultAPIClient_GetQuotesRange_Error(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultClient{
 		// return "Outcome: SystemError" response body

--- a/contrib/xignitefeeder/feed/backfill_test.go
+++ b/contrib/xignitefeeder/feed/backfill_test.go
@@ -54,6 +54,7 @@ func (mqrw *MockQuotesRangeWriter) WriteIndex(quotesRange api.GetIndexQuotesRang
 
 // 3 writes should be successfully done with the 3 identifiers
 func TestBackfill_Update(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	var rw writer.QuotesRangeWriter = &MockQuotesRangeWriter{WriteCount: 0}
 	var w writer.QuotesWriter = &MockQuotesWriter{WriteCount: 0}
@@ -89,6 +90,7 @@ func TestBackfill_Update(t *testing.T) {
 
 // Even if Xignite returns Outcome:"RequestError" to an identifier, Backfill writes data for the other identifiers
 func TestBackfill_Update_RequestErrorIdentifier(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	var rw writer.QuotesRangeWriter = &MockQuotesRangeWriter{WriteCount: 0}
 	var w writer.QuotesWriter = &MockQuotesWriter{WriteCount: 0}

--- a/contrib/xignitefeeder/feed/recent_backfill_test.go
+++ b/contrib/xignitefeeder/feed/recent_backfill_test.go
@@ -41,6 +41,7 @@ func (mbw *MockBarWriter) Write(symbol string, bars []api.Bar, isIndexSymbol boo
 
 // 3 writes should be successfully done with the 3 identifiers
 func TestRecentBackfill_Update(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	var w writer.BarWriter = &MockBarWriter{WriteCount: 0}
 
@@ -67,6 +68,7 @@ func TestRecentBackfill_Update(t *testing.T) {
 
 // Even if Xignite returns Outcome:"RequestError" to an identifier, Backfill writes data for the other identifiers
 func TestRecentBackfill_Update_RequestErrorIdentifier(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	var w writer.BarWriter = &MockBarWriter{WriteCount: 0}
 

--- a/contrib/xignitefeeder/feed/time_checker_test.go
+++ b/contrib/xignitefeeder/feed/time_checker_test.go
@@ -26,6 +26,7 @@ type testCase struct {
 }
 
 func TestDefaultMarketTimeChecker_isOpen(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultMarketTimeChecker{
 		ClosedDaysOfTheWeek,
@@ -54,7 +55,9 @@ func TestDefaultMarketTimeChecker_isOpen(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// --- when ---
 			got := SUT.IsOpen(tt.arg)
 
@@ -75,6 +78,7 @@ type subTestCase struct {
 }
 
 func TestDefaultMarketTimeChecker_Sub(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := &DefaultMarketTimeChecker{
 		ClosedDaysOfTheWeek,
@@ -105,7 +109,9 @@ func TestDefaultMarketTimeChecker_Sub(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// --- when ---
 			got, err := SUT.Sub(tt.currentTime, tt.businessDays)
 

--- a/contrib/xignitefeeder/feed/worker_test.go
+++ b/contrib/xignitefeeder/feed/worker_test.go
@@ -33,6 +33,7 @@ func (m *MockQuotesWriter) Write(resp api.GetQuotesResponse) error {
 }
 
 func TestWorker_try_normal(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	w := &MockQuotesWriter{WriteCount: 0}
 	SUT := Worker{

--- a/contrib/xignitefeeder/symbols/manager_test.go
+++ b/contrib/xignitefeeder/symbols/manager_test.go
@@ -37,6 +37,7 @@ func (mac *MockListSymbolsAPIClient) ListSymbols(exchange string) (api.ListSymbo
 }
 
 func TestManagerImpl_UpdateSymbols(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	SUT := ManagerImpl{
 		APIClient:       &MockListSymbolsAPIClient{},

--- a/contrib/xignitefeeder/timer/timer_test.go
+++ b/contrib/xignitefeeder/timer/timer_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func Test_timeToNext(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	tests := []struct {
 		name string
@@ -25,7 +26,9 @@ func Test_timeToNext(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// --- when ---
 			got := timeToNext(tt.now, tt.hour)
 

--- a/contrib/xignitefeeder/writer/bar_writer_test.go
+++ b/contrib/xignitefeeder/writer/bar_writer_test.go
@@ -19,6 +19,7 @@ var (
 )
 
 func TestBarWriterImpl_Write(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	m := &internal.MockMarketStoreWriter{}
 	SUT := BarWriterImpl{
@@ -86,6 +87,7 @@ func TestBarWriterImpl_Write(t *testing.T) {
 }
 
 func TestBarWriterImpl_Write_IndexSymbol(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	m := &internal.MockMarketStoreWriter{}
 	SUT := BarWriterImpl{

--- a/contrib/xignitefeeder/writer/quotes_range_writer_test.go
+++ b/contrib/xignitefeeder/writer/quotes_range_writer_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestQuotesRangeWriterImpl_Write(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	m := &internal.MockMarketStoreWriter{}
 	SUT := QuotesRangeWriterImpl{
@@ -76,6 +77,7 @@ func TestQuotesRangeWriterImpl_Write(t *testing.T) {
 }
 
 func TestQuotesRangeWriterImpl_noDataToWrite(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	m := &internal.MockMarketStoreWriter{}
 	SUT := QuotesRangeWriterImpl{
@@ -110,6 +112,7 @@ func TestQuotesRangeWriterImpl_noDataToWrite(t *testing.T) {
 }
 
 func TestQuotesRangeWriterImpl_getLatestTime(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	t1 := time.Date(2019, 05, 01, 12, 34, 56, 0, time.UTC)
 	t2 := time.Date(2018, 05, 01, 12, 34, 56, 0, time.UTC)

--- a/contrib/xignitefeeder/writer/quotes_writer_test.go
+++ b/contrib/xignitefeeder/writer/quotes_writer_test.go
@@ -19,6 +19,7 @@ var (
 )
 
 func TestQuotesWriterImpl_Write(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	m := &internal.MockMarketStoreWriter{}
 	SUT := QuotesWriterImpl{
@@ -101,6 +102,7 @@ func TestQuotesWriterImpl_Write(t *testing.T) {
 
 //  UTCOffset response parameter is used to convert the time in API response to UTC.
 func TestQuotesWriterImpl_TimeLocation(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	m := &internal.MockMarketStoreWriter{}
 	SUT := QuotesWriterImpl{

--- a/executor/rewritebuffer_test.go
+++ b/executor/rewritebuffer_test.go
@@ -30,6 +30,7 @@ func TimeAndHeap(n int, f func()) (t int64, h uint64) {
 
 // TestRewriteBuffer checks the compatibility of C and Go implementations of rewrite buffer
 func TestRewriteBuffer(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	variableRecordLength := uint32(12)       // e.g. Ask(4bytes) + Bid(4bytes) + IntervalTicks(4byte)
 	numVarRecords := uint32(4)               // 4 records in 1 interval
@@ -57,6 +58,7 @@ func TestRewriteBuffer(t *testing.T) {
 }
 
 func TestGetTimeFromTicks(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	intervalStart := uint64(1546300800) // 2019-01-01 00:00:00
 	intervalsPerDay := uint32(86400)    // timeframe: 1sec

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestSortBuffer(t *testing.T) {
+	t.Parallel()
 	// --- given ---
 	// 4 records * 8byte, [3,4,2,1]
 	buffer := []byte{

--- a/executor/ticks_test.go
+++ b/executor/ticks_test.go
@@ -3,27 +3,24 @@ package executor
 import (
 	"fmt"
 	"math"
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/alpacahq/marketstore/v4/utils"
 	"github.com/alpacahq/marketstore/v4/utils/io"
-	. "gopkg.in/check.v1"
 )
 
-var _ = Suite(&TickTests{})
+func TestTimeToIntervals(t *testing.T) {
+	t.Parallel()
 
-type TickTests struct{}
-
-func (s *TickTests) SetUpSuite(c *C)    {}
-func (s *TickTests) TearDownSuite(c *C) {}
-
-func (s *TickTests) TestTimeToIntervals(c *C) {
 	t2 := time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
 	index := io.TimeToIndex(t2, time.Minute)
-	c.Assert(index == 1, Equals, true)
+	assert.Equal(t, index, int64(1))
 	t2 = time.Date(2016, 12, 31, 23, 59, 0, 0, time.UTC)
 	index = io.TimeToIndex(t2, time.Minute)
-	c.Assert(index == 366*1440, Equals, true)
+	assert.Equal(t, index, int64(366*1440))
 
 	//20161230 21:59:20 383000
 	t1 := time.Date(2016, 12, 30, 21, 59, 20, 383000000, time.UTC)
@@ -35,15 +32,15 @@ func (s *TickTests) TestTimeToIntervals(c *C) {
 
 	o_t1 := io.IndexToTime(index, time.Minute, 2016)
 	//fmt.Println("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
-	c.Assert(o_t1.Hour(), Equals, 21)
-	c.Assert(o_t1.Minute(), Equals, 59)
-	c.Assert(o_t1.Second(), Equals, 0)
+	assert.Equal(t, o_t1.Hour(), 21)
+	assert.Equal(t, o_t1.Minute(), 59)
+	assert.Equal(t, o_t1.Second(), 0)
 
 	o_t1 = io.IndexToTimeDepr(index, 1440, 2016)
 	fmt.Println("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
-	c.Assert(o_t1.Hour(), Equals, 21)
-	c.Assert(o_t1.Minute(), Equals, 59)
-	c.Assert(o_t1.Second(), Equals, 0)
+	assert.Equal(t, o_t1.Hour(), 21)
+	assert.Equal(t, o_t1.Minute(), 59)
+	assert.Equal(t, o_t1.Second(), 0)
 
 	ticks := io.GetIntervalTicks32Bit(t1, index, 1440)
 	fmt.Printf("Interval ticks = \t\t\t\t %d\n", int(ticks))
@@ -58,7 +55,7 @@ func (s *TickTests) TestTimeToIntervals(c *C) {
 	fSec1 := 60. * (float64(intervalTicks) / float64(math.MaxUint32))
 	fSec := 60. * (float64(ticks) / float64(math.MaxUint32))
 	fmt.Printf("Fractional seconds from reconstruction: %f, from calc: %f\n", fSec1, fSec)
-	c.Assert(math.Abs(fSec-20.383) < 0.0000001, Equals, true)
+	assert.Equal(t, math.Abs(fSec-20.383) < 0.0000001, true)
 
-	c.Assert(math.Abs(float64(intervalTicks)-float64(ticks)) < 2., Equals, true)
+	assert.Equal(t, math.Abs(float64(intervalTicks)-float64(ticks)) < 2., true)
 }

--- a/models/bar_test.go
+++ b/models/bar_test.go
@@ -1,21 +1,17 @@
 package models
 
 import (
-	"github.com/alpacahq/marketstore/v4/models/enum"
 	"testing"
 	"time"
 
+	"github.com/alpacahq/marketstore/v4/models/enum"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/alpacahq/marketstore/v4/utils"
-	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-var _ = Suite(&TestSuite{})
-
-type TestSuite struct{}
-
-func (t *TestSuite) TestFromTradesFieldExcludes(c *C) {
+func TestFromTradesFieldExcludes(t *testing.T) {
+	t.Parallel()
 	// Given a set of trades including ones with condition
 	// which should be excluded from the volume roll-up
 	symbol := "TEST_TICK_TO_BAR_FIELD_EXCLUDES"
@@ -40,27 +36,28 @@ func (t *TestSuite) TestFromTradesFieldExcludes(c *C) {
 	// When converted to bars
 	bars := FromTrades(trades, symbol, "1Min")
 
-	c.Check(bars, NotNil)
-	c.Check(len(bars.Epoch), Equals, 2)
-	c.Check(bars.Epoch[0], Equals,
+	assert.NotNil(t, bars)
+	assert.Len(t, bars.Epoch, 2)
+	assert.Equal(t, bars.Epoch[0],
 		time.Date(2020, 11, 20, 10, 3, 0, 0, utils.InstanceConfig.Timezone).Unix())
-	c.Check(bars.Open[0], Equals, enum.Price(100.1))
-	c.Check(bars.Close[0], Equals, enum.Price(100.1))
-	c.Check(bars.High[0], Equals, enum.Price(100.1))
-	c.Check(bars.Low[0], Equals, enum.Price(100.1))
-	c.Check(bars.Volume[0], Equals, enum.Size(21))
+	assert.Equal(t, bars.Open[0], enum.Price(100.1))
+	assert.Equal(t, bars.Close[0], enum.Price(100.1))
+	assert.Equal(t, bars.High[0], enum.Price(100.1))
+	assert.Equal(t, bars.Low[0], enum.Price(100.1))
+	assert.Equal(t, bars.Volume[0], enum.Size(21))
 
 	// Then the second bar will exclude the last & volume update for affected trades
-	c.Check(bars.Epoch[1], Equals,
+	assert.Equal(t, bars.Epoch[1],
 		time.Date(2020, 11, 20, 10, 4, 0, 0, utils.InstanceConfig.Timezone).Unix())
-	c.Check(bars.Open[1], Equals, enum.Price(100.2))
-	c.Check(bars.Close[1], Equals, enum.Price(100.2))
-	c.Check(bars.High[1], Equals, enum.Price(100.2))
-	c.Check(bars.Low[1], Equals, enum.Price(99.6))
-	c.Check(bars.Volume[1], Equals, enum.Size(13))
+	assert.Equal(t, bars.Open[1], enum.Price(100.2))
+	assert.Equal(t, bars.Close[1], enum.Price(100.2))
+	assert.Equal(t, bars.High[1], enum.Price(100.2))
+	assert.Equal(t, bars.Low[1], enum.Price(99.6))
+	assert.Equal(t, bars.Volume[1], enum.Size(13))
 }
 
-func (t *TestSuite) TestFromTradesDailyRollup(c *C) {
+func TestFromTradesDailyRollup(t *testing.T) {
+	t.Parallel()
 	// Given a set of trades including ones with condition
 	// which signals end of day price
 	symbol := "TEST_TICK_TO_BAR_DAILY_ROLLUP"
@@ -90,13 +87,13 @@ func (t *TestSuite) TestFromTradesDailyRollup(c *C) {
 	bars := FromTrades(trades, symbol, "1D")
 
 	// Then the daily close price should match to the specified
-	c.Check(bars, NotNil)
-	c.Check(len(bars.Epoch), Equals, 1)
-	c.Check(bars.Epoch[0], Equals,
+	assert.NotNil(t, bars)
+	assert.Len(t, bars.Epoch, 1)
+	assert.Equal(t, bars.Epoch[0],
 		time.Date(2020, 11, 20, 0, 0, 0, 0, utils.InstanceConfig.Timezone).Unix())
-	c.Check(bars.Open[0], Equals, enum.Price(100.1))
-	c.Check(bars.Close[0], Equals, enum.Price(105.6))
-	c.Check(bars.High[0], Equals, enum.Price(111.2))
-	c.Check(bars.Low[0], Equals, enum.Price(100.1))
-	c.Check(bars.Volume[0], Equals, enum.Size(130))
+	assert.Equal(t, bars.Open[0], enum.Price(100.1))
+	assert.Equal(t, bars.Close[0], enum.Price(105.6))
+	assert.Equal(t, bars.High[0], enum.Price(111.2))
+	assert.Equal(t, bars.Low[0], enum.Price(100.1))
+	assert.Equal(t, bars.Volume[0], enum.Size(130))
 }

--- a/replication/grpc_client_test.go
+++ b/replication/grpc_client_test.go
@@ -104,7 +104,6 @@ func TestGRPCReplicationClient_Recv(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			// --- given ---
-			t.Parallel()
 			client := replication.NewGRPCReplicationClient(&mock.ReplicationClient{StreamClient: tt.mockStreamClient})
 			_ = client.Connect(context.Background())
 

--- a/utils/functions/all_test.go
+++ b/utils/functions/all_test.go
@@ -4,25 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/alpacahq/marketstore/v4/utils/io"
-	. "gopkg.in/check.v1"
 )
 
-// Hook up gocheck into the "go test" runner.
-var _ = Suite(&TestSuite{})
-
-func Test(t *testing.T) { TestingT(t) }
-
-type TestSuite struct {
-}
-
-func (s *TestSuite) SetUpSuite(c *C) {
-}
-
-func (s *TestSuite) TearDownSuite(c *C) {
-}
-
-func (s *TestSuite) TestParameters(c *C) {
+func TestParameters(t *testing.T) {
+	t.Parallel()
 	var requiredColumns = []io.DataShape{
 		{Name: "A", Type: io.FLOAT32},
 		{Name: "B", Type: io.FLOAT32},
@@ -43,11 +31,11 @@ func (s *TestSuite) TestParameters(c *C) {
 	if err != nil {
 		fmt.Println("Error: ", err)
 	}
-	c.Assert(err == nil, Equals, true)
-	c.Assert(argMap.nameMap["A"][0].Name, Equals, "i")
-	c.Assert(argMap.nameMap["B"][0].Name, Equals, "j")
-	c.Assert(argMap.nameMap["C"][0].Name, Equals, "k")
-	c.Assert(argMap.nameMap["D"][0].Name, Equals, "l")
+	assert.Nil(t, err)
+	assert.Equal(t, argMap.nameMap["A"][0].Name, "i")
+	assert.Equal(t, argMap.nameMap["B"][0].Name, "j")
+	assert.Equal(t, argMap.nameMap["C"][0].Name, "k")
+	assert.Equal(t, argMap.nameMap["D"][0].Name, "l")
 
 	/*
 		All columns positionally specified with optionals
@@ -58,13 +46,13 @@ func (s *TestSuite) TestParameters(c *C) {
 	if err != nil {
 		fmt.Println("Error: ", err)
 	}
-	c.Assert(err == nil, Equals, true)
-	c.Assert(argMap.nameMap["A"][0].Name, Equals, "i")
-	c.Assert(argMap.nameMap["B"][0].Name, Equals, "j")
-	c.Assert(argMap.nameMap["C"][0].Name, Equals, "k")
-	c.Assert(argMap.nameMap["D"][0].Name, Equals, "l")
-	c.Assert(argMap.nameMap["E"][0].Name, Equals, "m")
-	c.Assert(argMap.nameMap["F"][0].Name, Equals, "n")
+	assert.Nil(t, err)
+	assert.Equal(t, argMap.nameMap["A"][0].Name, "i")
+	assert.Equal(t, argMap.nameMap["B"][0].Name, "j")
+	assert.Equal(t, argMap.nameMap["C"][0].Name, "k")
+	assert.Equal(t, argMap.nameMap["D"][0].Name, "l")
+	assert.Equal(t, argMap.nameMap["E"][0].Name, "m")
+	assert.Equal(t, argMap.nameMap["F"][0].Name, "n")
 
 	/*
 		Mixed positional and named
@@ -75,11 +63,11 @@ func (s *TestSuite) TestParameters(c *C) {
 	if err != nil {
 		fmt.Println("Error: ", err)
 	}
-	c.Assert(err == nil, Equals, true)
-	c.Assert(argMap.nameMap["A"][0].Name, Equals, "i")
-	c.Assert(argMap.nameMap["B"][0].Name, Equals, "j")
-	c.Assert(argMap.nameMap["C"][0].Name, Equals, "k")
-	c.Assert(argMap.nameMap["D"][0].Name, Equals, "l")
+	assert.Nil(t, err)
+	assert.Equal(t, argMap.nameMap["A"][0].Name, "i")
+	assert.Equal(t, argMap.nameMap["B"][0].Name, "j")
+	assert.Equal(t, argMap.nameMap["C"][0].Name, "k")
+	assert.Equal(t, argMap.nameMap["D"][0].Name, "l")
 
 	/*
 		Multiple inputs mapped to single
@@ -90,14 +78,14 @@ func (s *TestSuite) TestParameters(c *C) {
 	if err != nil {
 		fmt.Println("Error: ", err)
 	}
-	c.Assert(err == nil, Equals, true)
-	c.Assert(argMap.nameMap["A"][0].Name, Equals, "i1")
-	c.Assert(argMap.nameMap["A"][1].Name, Equals, "i2")
-	c.Assert(argMap.nameMap["B"][0].Name, Equals, "j")
-	c.Assert(argMap.nameMap["C"][0].Name, Equals, "k")
-	c.Assert(argMap.nameMap["D"][0].Name, Equals, "l1")
-	c.Assert(argMap.nameMap["D"][1].Name, Equals, "l2")
-	c.Assert(argMap.nameMap["D"][2].Name, Equals, "l3")
+	assert.Nil(t, err)
+	assert.Equal(t, argMap.nameMap["A"][0].Name, "i1")
+	assert.Equal(t, argMap.nameMap["A"][1].Name, "i2")
+	assert.Equal(t, argMap.nameMap["B"][0].Name, "j")
+	assert.Equal(t, argMap.nameMap["C"][0].Name, "k")
+	assert.Equal(t, argMap.nameMap["D"][0].Name, "l1")
+	assert.Equal(t, argMap.nameMap["D"][1].Name, "l2")
+	assert.Equal(t, argMap.nameMap["D"][2].Name, "l3")
 
 	/*
 		Multiple inputs mapped to single with optional columns included
@@ -108,16 +96,16 @@ func (s *TestSuite) TestParameters(c *C) {
 	if err != nil {
 		fmt.Println("Error: ", err)
 	}
-	c.Assert(err == nil, Equals, true)
-	c.Assert(argMap.nameMap["A"][0].Name, Equals, "i1")
-	c.Assert(argMap.nameMap["A"][1].Name, Equals, "i2")
-	c.Assert(argMap.nameMap["B"][0].Name, Equals, "j")
-	c.Assert(argMap.nameMap["C"][0].Name, Equals, "k")
-	c.Assert(argMap.nameMap["D"][0].Name, Equals, "l1")
-	c.Assert(argMap.nameMap["D"][1].Name, Equals, "l2")
-	c.Assert(argMap.nameMap["D"][2].Name, Equals, "l3")
-	c.Assert(argMap.nameMap["E"][0].Name, Equals, "m")
-	c.Assert(argMap.nameMap["F"][0].Name, Equals, "n")
+	assert.Nil(t, err)
+	assert.Equal(t, argMap.nameMap["A"][0].Name, "i1")
+	assert.Equal(t, argMap.nameMap["A"][1].Name, "i2")
+	assert.Equal(t, argMap.nameMap["B"][0].Name, "j")
+	assert.Equal(t, argMap.nameMap["C"][0].Name, "k")
+	assert.Equal(t, argMap.nameMap["D"][0].Name, "l1")
+	assert.Equal(t, argMap.nameMap["D"][1].Name, "l2")
+	assert.Equal(t, argMap.nameMap["D"][2].Name, "l3")
+	assert.Equal(t, argMap.nameMap["E"][0].Name, "m")
+	assert.Equal(t, argMap.nameMap["F"][0].Name, "n")
 
 	/*
 		Insufficient params (error)
@@ -128,5 +116,5 @@ func (s *TestSuite) TestParameters(c *C) {
 	if err != nil {
 		fmt.Println("Error: ", err)
 	}
-	c.Assert(err != nil, Equals, true)
+	assert.NotNil(t, err)
 }

--- a/utils/io/all_test.go
+++ b/utils/io/all_test.go
@@ -1,6 +1,7 @@
 package io
 
 import (
+	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -9,23 +10,19 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/alpacahq/marketstore/v4/utils"
 	. "gopkg.in/check.v1"
 )
-
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
-
-type TestSuite struct{}
-
-var _ = Suite(&TestSuite{})
 
 type ohlc struct {
 	index      int64
 	o, h, l, c float32
 }
 
-func (s *TestSuite) TestConvertByteSlice(c *C) {
+func TestConvertByteSlice(t *testing.T) {
+	t.Parallel()
 	s1 := ohlc{100000000, 200, 300, 400, 500}
 	s2 := ohlc{10, 20, 30, 40, 50}
 	baseArray := [2]ohlc{s1, s2}
@@ -36,44 +33,45 @@ func (s *TestSuite) TestConvertByteSlice(c *C) {
 	i_myarray := CopySliceByte(buffer, ohlc{})
 	myarray := i_myarray.([]ohlc)
 	for i, ohlc := range myarray {
-		c.Assert(ohlc, Equals, baseArray[i])
+		assert.Equal(t, ohlc, baseArray[i])
 	}
 
 	i_myarray = SwapSliceByte(buffer, ohlc{})
 	myarray = i_myarray.([]ohlc)
 	for i, ohlc := range myarray {
-		c.Assert(ohlc, Equals, baseArray[i])
+		assert.Equal(t, ohlc, baseArray[i])
 	}
 
 	i_mybyte := SwapSliceData(myarray, byte(0))
 	bytearray := i_mybyte.([]byte)
-	c.Assert(len(bytearray), Equals, 48)
+	assert.Len(t, bytearray, 48)
 	for i, val := range bytearray {
-		c.Assert(val, Equals, buffer[i])
+		assert.Equal(t, val, buffer[i])
 	}
 
 	bytearray = CastToByteSlice(myarray)
-	c.Assert(len(bytearray), Equals, 48)
+	assert.Len(t, bytearray, 48)
 	for i, val := range bytearray {
-		c.Assert(val, Equals, buffer[i])
+		assert.Equal(t, val, buffer[i])
 	}
 
 	i_myarray = SwapSliceData(buffer, ohlc{})
 	myarray = i_myarray.([]ohlc)
-	c.Assert(len(myarray), Equals, 2)
+	assert.Len(t, myarray, 2)
 	for i, val := range myarray {
-		c.Assert(val, Equals, baseArray[i])
+		assert.Equal(t, val, baseArray[i])
 	}
 
 	myInt64 := int64(65793)
 	bs := DataToByteSlice(myInt64)
-	c.Assert(len(bs), Equals, 8)
+	assert.Len(t, bs, 8)
 	for i, val := range []byte{1, 1, 1, 0, 0, 0, 0, 0} {
-		c.Assert(bs[i] == val, Equals, true)
+		assert.Equal(t, bs[i], val)
 	}
 }
 
-func (s *TestSuite) TestVariableBoundaryCases(c *C) {
+func TestVariableBoundaryCases(t *testing.T) {
+	t.Parallel()
 	/*
 		Reported problematic times:
 			Input:
@@ -91,8 +89,8 @@ func (s *TestSuite) TestVariableBoundaryCases(c *C) {
 	index := TimeToIndex(t1, time.Minute)
 	o_t1 := IndexToTime(index, time.Minute, 2008)
 	//fmt.Println("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
-	c.Assert(o_t1.Minute(), Equals, 24)
-	c.Assert(o_t1.Second(), Equals, 0)
+	assert.Equal(t, o_t1.Minute(), 24)
+	assert.Equal(t, o_t1.Second(), 0)
 	ticks := GetIntervalTicks32Bit(t1, index, 1440)
 	seconds := t1.Second()
 	nanos := t1.Nanosecond()
@@ -100,15 +98,15 @@ func (s *TestSuite) TestVariableBoundaryCases(c *C) {
 	fractionalInterval := fractionalSeconds / 60.
 	intervalTicks := uint32(fractionalInterval * math.MaxUint32)
 	//fmt.Println("Interval Ticks: ", intervalTicks)
-	c.Assert(intervalTicks, Equals, ticks)
+	assert.Equal(t, intervalTicks, ticks)
 
 	t1 = time.Date(2008, time.January, 3, 16, 24, 59, 1000*839106, time.UTC)
 
 	index = TimeToIndex(t1, time.Minute)
 	o_t1 = IndexToTime(index, time.Minute, 2008)
 	//fmt.Println("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
-	c.Assert(o_t1.Minute(), Equals, 24)
-	c.Assert(o_t1.Second(), Equals, 0)
+	assert.Equal(t, o_t1.Minute(), 24)
+	assert.Equal(t, o_t1.Second(), 0)
 	ticks = GetIntervalTicks32Bit(t1, index, 1440)
 	seconds = t1.Second()
 	nanos = t1.Nanosecond()
@@ -120,39 +118,40 @@ func (s *TestSuite) TestVariableBoundaryCases(c *C) {
 	if diff < 0 {
 		diff = -diff
 	}
-	c.Assert(diff < 2, Equals, true)
+	assert.True(t, diff < 2)
 }
 
-func (s *TestSuite) TestGenerics(c *C) {
+func TestGenerics(t *testing.T) {
+	t.Parallel()
 	// DownSizeSlice
 	input := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	output, err := DownSizeSlice(input, 6, LAST)
 	expected := []float64{5, 6, 7, 8, 9, 10}
-	c.Assert(err, Equals, nil)
-	c.Assert(reflect.DeepEqual(output, expected), Equals, true)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(output, expected))
 
 	output, err = DownSizeSlice(input, 6, FIRST)
 	expected = []float64{1, 2, 3, 4, 5, 6}
-	c.Assert(err, Equals, nil)
-	c.Assert(reflect.DeepEqual(output, expected), Equals, true)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(output, expected), Equals)
 
 	input2 := []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	output2, err := DownSizeSlice(input2, 6, FIRST)
 	expected2 := []uint32{1, 2, 3, 4, 5, 6}
-	c.Assert(err, Equals, nil)
-	c.Assert(reflect.DeepEqual(output2, expected2), Equals, true)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(output2, expected2))
 
 	input3 := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
 	output3, err := DownSizeSlice(input3, 6, FIRST)
 	expected3 := []string{"1", "2", "3", "4", "5", "6"}
-	c.Assert(err, Equals, nil)
-	c.Assert(reflect.DeepEqual(output3, expected3), Equals, true)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(output3, expected3))
 
 	/*
 		Test the error case
 	*/
 	_, err = DownSizeSlice("Should not work", 100, FIRST)
-	c.Assert(err != nil, Equals, true)
+	assert.NotNil(t, err)
 }
 
 func makeTestCS() *ColumnSeries {
@@ -171,9 +170,10 @@ func makeTestCS() *ColumnSeries {
 	return csA
 }
 
-func (s *TestSuite) TestSerializeColumnsToRows(c *C) {
+func TestSerializeColumnsToRows(t *testing.T) {
+	t.Parallel()
 	csA := makeTestCS()
-	c.Assert(csA.Len(), Equals, 3)
+	assert.Equal(t, csA.Len(), 3)
 
 	dsv := csA.GetDataShapes()
 
@@ -182,16 +182,16 @@ func (s *TestSuite) TestSerializeColumnsToRows(c *C) {
 	*/
 	UnalignedBytesPerRow := 8 + 4 + 8 + 4 + 8 + 1
 	data, reclen := SerializeColumnsToRows(csA, dsv, false)
-	c.Assert(reclen == UnalignedBytesPerRow, Equals, true)
-	c.Assert(reclen*3 == len(data), Equals, true)
+	assert.True(t, reclen == UnalignedBytesPerRow)
+	assert.True(t, reclen*3 == len(data))
 
 	/*
 		Aligned case
 	*/
 	AlignedBytesPerRow := AlignedSize(UnalignedBytesPerRow)
 	data, reclen = SerializeColumnsToRows(csA, dsv, true)
-	c.Assert(reclen == AlignedBytesPerRow, Equals, true)
-	c.Assert(reclen*3 == len(data), Equals, true)
+	assert.True(t, reclen == AlignedBytesPerRow)
+	assert.True(t, reclen*3 == len(data))
 
 	/*
 		Projection case
@@ -208,8 +208,8 @@ func (s *TestSuite) TestSerializeColumnsToRows(c *C) {
 	expectedLen = AlignedSize(expectedLen)
 
 	data, reclen = SerializeColumnsToRows(csA, dsvProjected, true)
-	c.Assert(reclen == expectedLen, Equals, true)
-	c.Assert(reclen*3 == len(data), Equals, true)
+	assert.True(t, reclen == expectedLen)
+	assert.True(t, reclen*3 == len(data))
 	/*
 		Type Coercion case
 	*/
@@ -224,12 +224,15 @@ func (s *TestSuite) TestSerializeColumnsToRows(c *C) {
 	expectedLen = AlignedSize(expectedLen)
 
 	data, reclen = SerializeColumnsToRows(csA, dsvProjected, true)
-	c.Assert(reclen == expectedLen, Equals, true)
-	c.Assert(reclen*3 == len(data), Equals, true)
+	assert.True(t, reclen == expectedLen)
+	assert.True(t, reclen*3 == len(data))
 }
 
-func (s *TestSuite) TestTimeBucketInfo(c *C) {
-	tempDir := c.MkDir()
+func TestTimeBucketInfo(t *testing.T) {
+	t.Parallel()
+	tempDir, _ := ioutil.TempDir("", "io.TestTimeBucketInfo")
+	defer os.RemoveAll(tempDir)
+
 	timeframe := utils.NewTimeframe("1Min")
 	filePath := filepath.Join(tempDir, "2018.bin")
 	description := "testing"
@@ -243,7 +246,7 @@ func (s *TestSuite) TestTimeBucketInfo(c *C) {
 	tbi := NewTimeBucketInfo(*timeframe, filePath, description, year, dsv, recType)
 
 	testFilePath, err := os.Create(filePath)
-	c.Check(err, IsNil)
+	assert.Nil(t, err)
 	WriteHeader(testFilePath, tbi)
 
 	tbi2 := TimeBucketInfo{
@@ -252,19 +255,20 @@ func (s *TestSuite) TestTimeBucketInfo(c *C) {
 	}
 
 	nElements := tbi2.GetNelements()
-	c.Check(nElements, Equals, int32(2))
+	assert.Equal(t, nElements, int32(2))
 
-	c.Check(tbi2.GetVariableRecordLength(), Equals, int32(0))
+	assert.Equal(t, tbi2.GetVariableRecordLength(), int32(0))
 
 	fcopy := tbi2.GetDeepCopy()
-	c.Check(fcopy.timeframe.Nanoseconds(), Equals, tbi.timeframe.Nanoseconds())
+	assert.Equal(t, fcopy.timeframe.Nanoseconds(), tbi.timeframe.Nanoseconds())
 
 	dsv2 := tbi2.GetDataShapes()
-	c.Check(dsv2[0].String(), Equals, dsv[0].String())
-	c.Check(dsv2[0].Equal(dsv[0]), Equals, true)
+	assert.Equal(t, dsv2[0].String(), dsv[0].String())
+	assert.Equal(t, dsv2[0].Equal(dsv[0]), true)
 }
 
-func (s *TestSuite) TestIndexAndOffset(c *C) {
+func TestIndexAndOffset(t *testing.T) {
+	t.Parallel()
 	recSize := int32(28)
 	loc, _ := time.LoadLocation("America/New_York")
 	utils.InstanceConfig.Timezone = loc
@@ -272,75 +276,76 @@ func (s *TestSuite) TestIndexAndOffset(c *C) {
 	// check the 1Min interval
 	t0 := time.Date(2018, time.January, 1, 0, 0, 0, 0, loc)
 	index := TimeToIndex(t0, time.Minute)
-	c.Assert(index, Equals, int64(1))
+	assert.Equal(t, index, int64(1))
 	o_t0 := IndexToTime(index, time.Minute, 2018)
-	c.Assert(o_t0, Equals, t0)
+	assert.Equal(t, o_t0, t0)
 
 	offset := TimeToOffset(t0, time.Minute, recSize)
 	o_o0 := IndexToOffset(index, recSize)
-	c.Assert(o_o0, Equals, offset)
+	assert.Equal(t, o_o0, offset)
 
 	epoch := t0.Unix()
-	c.Assert(EpochToOffset(epoch, time.Minute, recSize), Equals, offset)
+	assert.Equal(t, EpochToOffset(epoch, time.Minute, recSize), offset)
 
 	// Check the 5Min interval
 	t1 := time.Date(2018, time.January, 1, 0, 5, 0, 0, loc)
 	index = TimeToIndex(t1, 5*time.Minute)
-	c.Assert(index, Equals, int64(2))
+	assert.Equal(t, index, int64(2))
 	o_t1 := IndexToTime(index, 5*time.Minute, 2018)
-	c.Assert(o_t1, Equals, t1)
+	assert.Equal(t, o_t1, t1)
 
 	offset = TimeToOffset(t1, 5*time.Minute, recSize)
 	o_o1 := IndexToOffset(index, recSize)
-	c.Assert(o_o1, Equals, offset)
+	assert.Equal(t, o_o1, offset)
 
 	epoch = t1.Unix()
-	c.Assert(EpochToOffset(epoch, 5*time.Minute, recSize), Equals, offset)
+	assert.Equal(t, EpochToOffset(epoch, 5*time.Minute, recSize), offset)
 
 	// Check the 1D interval
 	t2 := time.Date(2018, time.February, 5, 0, 0, 0, 0, loc)
 	index = TimeToIndex(t2, utils.Day)
-	c.Assert(index, Equals, int64(35))
+	assert.Equal(t, index, int64(35))
 	o_t2 := IndexToTime(index, utils.Day, 2018)
-	c.Assert(o_t2, Equals, t2)
+	assert.Equal(t, o_t2 == t2, true)
 
 	offset = TimeToOffset(t2, utils.Day, recSize)
 	o_o2 := IndexToOffset(index, recSize)
-	c.Assert(o_o2, Equals, offset)
+	assert.Equal(t, o_o2, offset)
 
 	epoch = t2.Unix()
-	c.Assert(EpochToOffset(epoch, utils.Day, recSize), Equals, offset)
+	assert.Equal(t, EpochToOffset(epoch, utils.Day, recSize), offset)
 
 	// Check 1D at end of year
 	t3 := time.Date(2018, time.December, 31, 0, 0, 0, 0, loc)
 	index = TimeToIndex(t3, utils.Day)
-	c.Assert(index, Equals, int64(364))
+	assert.Equal(t, index, int64(364))
 	o_t3 := IndexToTime(index, utils.Day, 2018)
-	c.Assert(o_t3, Equals, t3)
+	assert.Equal(t, o_t3, t3)
 
 	offset = TimeToOffset(t3, utils.Day, recSize)
 	o_o3 := IndexToOffset(index, recSize)
-	c.Assert(o_o3, Equals, offset)
+	assert.Equal(t, o_o3, offset)
 
 	epoch = t3.Unix()
-	c.Assert(EpochToOffset(epoch, utils.Day, recSize), Equals, offset)
+	assert.Equal(t, EpochToOffset(epoch, utils.Day, recSize), offset)
 
 	// Check 1Min at end of year
 	t4 := time.Date(2018, time.December, 31, 23, 59, 0, 0, loc)
 	index = TimeToIndex(t4, time.Minute)
-	c.Assert(index, Equals, int64(525600))
+	assert.Equal(t, index, int64(525600))
 	o_t4 := IndexToTime(index, time.Minute, 2018)
-	c.Assert(o_t4, Equals, t4)
+	assert.Equal(t, o_t4, t4)
 
 	offset = TimeToOffset(t4, time.Minute, recSize)
 	o_o4 := IndexToOffset(index, recSize)
-	c.Assert(o_o4, Equals, offset)
+	assert.Equal(t, o_o4, offset)
 
 	epoch = t4.Unix()
-	c.Assert(EpochToOffset(epoch, time.Minute, recSize), Equals, offset)
+	assert.Equal(t, EpochToOffset(epoch, time.Minute, recSize), offset)
 }
 
-func (s *TestSuite) TestUnion(c *C) {
+func TestUnion(t *testing.T) {
+	t.Parallel()
 	csA := makeTestCS()
 	csB := makeTestCS()
 
@@ -354,25 +359,25 @@ func (s *TestSuite) TestUnion(c *C) {
 			bv := reflect.ValueOf(csB.columns[name])
 			cv := reflect.ValueOf(col)
 
-			c.Assert(av.Len(), Equals, cv.Len())
-			c.Assert(bv.Len(), Equals, cv.Len())
+			assert.Equal(t, av.Len(), cv.Len())
+			assert.Equal(t, bv.Len(), cv.Len())
 
 			for i := 0; i < cv.Len(); i++ {
-				c.Assert(av.Index(i).Interface(), Equals, cv.Index(i).Interface())
-				c.Assert(bv.Index(i).Interface(), Equals, cv.Index(i).Interface())
+				assert.Equal(t, av.Index(i).Interface(), cv.Index(i).Interface())
+				assert.Equal(t, bv.Index(i).Interface(), cv.Index(i).Interface())
 			}
 		}
 	}
 
 	// shorter cs union
-	c.Assert(csA.RestrictLength(2, LAST), IsNil)
+	assert.Nil(t, csA.RestrictLength(2, LAST))
 
 	cs = ColumnSeriesUnion(csA, csB)
 
-	c.Assert(len(cs.GetEpoch()), Equals, 3)
-	c.Assert(cs.GetEpoch()[0], Equals, csB.GetEpoch()[0])
-	c.Assert(cs.GetEpoch()[1], Equals, csA.GetEpoch()[0])
-	c.Assert(cs.GetEpoch()[2], Equals, csA.GetEpoch()[1])
+	assert.Equal(t, len(cs.GetEpoch()), 3)
+	assert.Equal(t, cs.GetEpoch()[0], csB.GetEpoch()[0])
+	assert.Equal(t, cs.GetEpoch()[1], csA.GetEpoch()[0])
+	assert.Equal(t, cs.GetEpoch()[2], csA.GetEpoch()[1])
 
 	// appending union
 	col1 := []float32{4, 5, 6}
@@ -389,71 +394,73 @@ func (s *TestSuite) TestUnion(c *C) {
 	csC.AddColumn("Five", col5)
 
 	cs = ColumnSeriesUnion(csB, csC)
-	c.Assert(len(cs.GetEpoch()), Equals, 6)
-	c.Assert(cs.GetEpoch()[0], Equals, csB.GetEpoch()[0])
-	c.Assert(cs.GetEpoch()[1], Equals, csB.GetEpoch()[1])
-	c.Assert(cs.GetEpoch()[2], Equals, csB.GetEpoch()[2])
-	c.Assert(cs.GetEpoch()[3], Equals, csC.GetEpoch()[0])
-	c.Assert(cs.GetEpoch()[4], Equals, csC.GetEpoch()[1])
-	c.Assert(cs.GetEpoch()[5], Equals, csC.GetEpoch()[2])
+	assert.Equal(t, len(cs.GetEpoch()), 6)
+	assert.Equal(t, cs.GetEpoch()[0], csB.GetEpoch()[0])
+	assert.Equal(t, cs.GetEpoch()[1], csB.GetEpoch()[1])
+	assert.Equal(t, cs.GetEpoch()[2], csB.GetEpoch()[2])
+	assert.Equal(t, cs.GetEpoch()[3], csC.GetEpoch()[0])
+	assert.Equal(t, cs.GetEpoch()[4], csC.GetEpoch()[1])
+	assert.Equal(t, cs.GetEpoch()[5], csC.GetEpoch()[2])
 }
 
-func (s *TestSuite) TestSliceByEpoch(c *C) {
+func TestSliceByEpoch(t *testing.T) {
+	t.Parallel()
 	cs := makeTestCS()
 
 	// just start
 	start := int64(2)
 	slc, err := SliceColumnSeriesByEpoch(*cs, &start, nil)
-	c.Assert(err, IsNil)
-	c.Assert(slc, NotNil)
-	c.Assert(slc.Len(), Equals, 2)
-	c.Assert(slc.GetEpoch()[0], Equals, cs.GetEpoch()[1])
+	assert.Nil(t, err)
+	assert.NotNil(t, slc)
+	assert.Equal(t, slc.Len(), 2)
+	assert.Equal(t, slc.GetEpoch()[0], cs.GetEpoch()[1])
 
 	// no slice
 	start = int64(0)
 	slc, err = SliceColumnSeriesByEpoch(*cs, &start, nil)
-	c.Assert(err, IsNil)
-	c.Assert(slc, NotNil)
-	c.Assert(slc.Len(), Equals, 3)
-	c.Assert(slc.GetEpoch()[0], Equals, cs.GetEpoch()[0])
+	assert.Nil(t, err)
+	assert.NotNil(t, slc)
+	assert.Equal(t, slc.Len(), 3)
+	assert.Equal(t, slc.GetEpoch()[0], cs.GetEpoch()[0])
 
 	// just end
 	end := int64(3)
 	slc, err = SliceColumnSeriesByEpoch(*cs, nil, &end)
-	c.Assert(err, IsNil)
-	c.Assert(slc, NotNil)
-	c.Assert(slc.Len(), Equals, 2)
-	c.Assert(slc.GetEpoch()[1], Equals, cs.GetEpoch()[1])
+	assert.Nil(t, err)
+	assert.NotNil(t, slc)
+	assert.Equal(t, slc.Len(), 2)
+	assert.Equal(t, slc.GetEpoch()[1], cs.GetEpoch()[1])
 
 	// no slice
 	end = int64(4)
 	slc, err = SliceColumnSeriesByEpoch(*cs, nil, &end)
-	c.Assert(err, IsNil)
-	c.Assert(slc, NotNil)
-	c.Assert(slc.Len(), Equals, 3)
-	c.Assert(slc.GetEpoch()[2], Equals, cs.GetEpoch()[2])
+	assert.Nil(t, err)
+	assert.NotNil(t, slc)
+	assert.Equal(t, slc.Len(), 3)
+	assert.Equal(t, slc.GetEpoch()[2], cs.GetEpoch()[2])
 
 	// start and end
 	start = int64(2)
 	end = int64(3)
 	slc, err = SliceColumnSeriesByEpoch(*cs, &start, &end)
-	c.Assert(err, IsNil)
-	c.Assert(slc, NotNil)
-	c.Assert(slc.Len(), Equals, 1)
-	c.Assert(slc.GetEpoch()[0], Equals, cs.GetEpoch()[1])
+	assert.Nil(t, err)
+	assert.NotNil(t, slc)
+	assert.Equal(t, slc.Len(), 1)
+	assert.Equal(t, slc.GetEpoch()[0], cs.GetEpoch()[1])
 
 	// no slice
 	start = int64(0)
 	end = int64(4)
 	slc, err = SliceColumnSeriesByEpoch(*cs, &start, &end)
-	c.Assert(err, IsNil)
-	c.Assert(slc, NotNil)
-	c.Assert(slc.Len(), Equals, 3)
-	c.Assert(slc.GetEpoch()[0], Equals, cs.GetEpoch()[0])
-	c.Assert(slc.GetEpoch()[2], Equals, cs.GetEpoch()[2])
+	assert.Nil(t, err)
+	assert.NotNil(t, slc)
+	assert.Equal(t, slc.Len(), 3)
+	assert.Equal(t, slc.GetEpoch()[0], cs.GetEpoch()[0])
+	assert.Equal(t, slc.GetEpoch()[2], cs.GetEpoch()[2])
 }
 
-func (s *TestSuite) TestApplyTimeQual(c *C) {
+func TestApplyTimeQual(t *testing.T) {
+	t.Parallel()
 	cs := makeTestCS()
 
 	tq := func(epoch int64) bool {
@@ -465,13 +472,13 @@ func (s *TestSuite) TestApplyTimeQual(c *C) {
 
 	tqCS := cs.ApplyTimeQual(tq)
 
-	c.Assert(tqCS.Len(), Equals, 1)
-	c.Assert(tqCS.GetEpoch()[0], Equals, cs.GetEpoch()[1])
-	c.Assert(tqCS.GetByName("One").([]float32)[0], Equals, cs.GetByName("One").([]float32)[1])
+	assert.Equal(t, tqCS.Len(), 1)
+	assert.Equal(t, tqCS.GetEpoch()[0], cs.GetEpoch()[1])
+	assert.Equal(t, tqCS.GetByName("One").([]float32)[0], cs.GetByName("One").([]float32)[1])
 
 	tq = func(epoch int64) bool {
 		return false
 	}
 
-	c.Assert(cs.ApplyTimeQual(tq).Len(), Equals, 0)
+	assert.Equal(t, cs.ApplyTimeQual(tq).Len(), 0)
 }

--- a/utils/pool/pool_test.go
+++ b/utils/pool/pool_test.go
@@ -4,16 +4,11 @@ import (
 	"testing"
 	"time"
 
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-var _ = Suite(&PoolTestSuite{})
-
-type PoolTestSuite struct{}
-
-func (s *PoolTestSuite) TestPool(c *C) {
+func TestPool(t *testing.T) {
+	t.Parallel()
 	jobCount := 0
 
 	job := func(input interface{}) {
@@ -31,5 +26,5 @@ func (s *PoolTestSuite) TestPool(c *C) {
 	close(cc)
 	<-time.After(time.Second)
 
-	c.Assert(jobCount, Equals, 10)
+	assert.Equal(t, jobCount, 10)
 }

--- a/utils/rpc/msgpack2/msgpack_test.go
+++ b/utils/rpc/msgpack2/msgpack_test.go
@@ -140,6 +140,7 @@ func executeRaw(t *testing.T, s *rpc.Server, req interface{}, res interface{}) e
 }
 
 func TestService(t *testing.T) {
+	t.Parallel()
 	s := rpc.NewServer()
 	s.RegisterCodec(NewCodec(), "application/x-msgpack")
 	s.RegisterService(new(Service1), "")
@@ -188,6 +189,7 @@ func TestService(t *testing.T) {
 }
 
 func TestDecodeNullResult(t *testing.T) {
+	t.Parallel()
 	data := []byte(`{"jsonrpc": "2.0", "id": 12345, "result": null}`)
 	var obj interface{}
 	json.Unmarshal(data, &obj)

--- a/utils/timeframe_test.go
+++ b/utils/timeframe_test.go
@@ -4,104 +4,100 @@ import (
 	"testing"
 	"time"
 
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
 )
 
-type UtilsTestSuite struct{}
-
-var _ = Suite(&UtilsTestSuite{})
-
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
-
-func (s *UtilsTestSuite) TestTimeframeFromDuration(c *C) {
+func TestTimeframeFromDuration(t *testing.T) {
+	t.Parallel()
 	tf := TimeframeFromDuration(22 * time.Minute)
-	c.Assert(tf.String, Equals, "22Min")
-	c.Assert(tf.Duration, Equals, 22*time.Minute)
+	assert.Equal(t, tf.String, "22Min")
+	assert.Equal(t, tf.Duration, 22*time.Minute)
 
 	tf = TimeframeFromDuration(time.Hour)
-	c.Assert(tf.String, Equals, "1H")
-	c.Assert(tf.Duration, Equals, time.Hour)
+	assert.Equal(t, tf.String, "1H")
+	assert.Equal(t, tf.Duration, time.Hour)
 
 	tf = TimeframeFromDuration(time.Nanosecond)
-	c.Assert(tf, IsNil)
+	assert.Nil(t, tf)
 
 	tf = TimeframeFromDuration(5 * Year)
-	c.Assert(tf, IsNil)
+	assert.Nil(t, tf)
 }
 
-func (s *UtilsTestSuite) TestTimeframeFromString(c *C) {
+func TestTimeframeFromString(t *testing.T) {
+	t.Parallel()
 	tf := TimeframeFromString("15H")
-	c.Assert(tf.String, Equals, "15H")
-	c.Assert(tf.Duration, Equals, 15*time.Hour)
+	assert.Equal(t, tf.String, "15H")
+	assert.Equal(t, tf.Duration, 15*time.Hour)
 
 	tf = TimeframeFromString("xyz")
-	c.Assert(tf, IsNil)
+	assert.Nil(t, tf)
 
 	tf = TimeframeFromString("0H")
-	c.Assert(tf, IsNil)
+	assert.Nil(t, tf)
 }
 
-func (s *UtilsTestSuite) TestCandleDuration(c *C) {
+func TestCandleDuration(t *testing.T) {
+	t.Parallel()
 	var cd *CandleDuration
 	var val, start time.Time
 	var within bool
 	cd = CandleDurationFromString("5Min")
 	val = time.Date(2017, 9, 10, 13, 47, 0, 0, time.UTC)
-	c.Assert(cd.Truncate(val), Equals, time.Date(2017, 9, 10, 13, 45, 0, 0, time.UTC))
-	c.Assert(cd.Ceil(val), Equals, time.Date(2017, 9, 10, 13, 50, 0, 0, time.UTC))
+	assert.Equal(t, cd.Truncate(val), time.Date(2017, 9, 10, 13, 45, 0, 0, time.UTC))
+	assert.Equal(t, cd.Ceil(val), time.Date(2017, 9, 10, 13, 50, 0, 0, time.UTC))
 	start = cd.Truncate(val)
 	within = cd.IsWithin(time.Date(2017, 9, 10, 13, 46, 0, 0, time.UTC), start)
-	c.Assert(within, Equals, true)
+	assert.Equal(t, within, true)
 	within = cd.IsWithin(time.Date(2017, 9, 10, 13, 51, 0, 0, time.UTC), start)
-	c.Assert(within, Equals, false)
+	assert.Equal(t, within, false)
 
 	cd = CandleDurationFromString("1M")
 	val = time.Date(2017, 9, 10, 13, 47, 0, 0, time.UTC)
-	c.Assert(cd.Truncate(val), Equals, time.Date(2017, 9, 1, 0, 0, 0, 0, time.UTC))
-	c.Assert(cd.Ceil(val), Equals, time.Date(2017, 10, 1, 0, 0, 0, 0, time.UTC))
+	assert.Equal(t, cd.Truncate(val), time.Date(2017, 9, 1, 0, 0, 0, 0, time.UTC))
+	assert.Equal(t, cd.Ceil(val), time.Date(2017, 10, 1, 0, 0, 0, 0, time.UTC))
 	start = cd.Truncate(val)
 	within = cd.IsWithin(time.Date(2017, 9, 26, 0, 0, 0, 0, time.UTC), start)
-	c.Assert(within, Equals, true)
+	assert.Equal(t, within, true)
 	within = cd.IsWithin(time.Date(2017, 10, 1, 0, 0, 0, 0, time.UTC), start)
-	c.Assert(within, Equals, false)
+	assert.Equal(t, within, false)
 	within = cd.IsWithin(time.Date(2017, 8, 31, 0, 0, 0, 0, time.UTC), start)
-	c.Assert(within, Equals, false)
+	assert.Equal(t, within, false)
 
 	val = time.Date(2017, 12, 10, 13, 47, 0, 0, time.UTC)
-	c.Assert(cd.Truncate(val), Equals, time.Date(2017, 12, 1, 0, 0, 0, 0, time.UTC))
-	c.Assert(cd.Ceil(val), Equals, time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC))
+	assert.Equal(t, cd.Truncate(val), time.Date(2017, 12, 1, 0, 0, 0, 0, time.UTC))
+	assert.Equal(t, cd.Ceil(val), time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC))
 	start = cd.Truncate(val)
 	within = cd.IsWithin(time.Date(2018, 1, 26, 0, 0, 0, 0, time.UTC), start)
-	c.Assert(within, Equals, false)
+	assert.Equal(t, within, false)
 	within = cd.IsWithin(time.Date(2016, 12, 10, 0, 0, 0, 0, time.UTC), start)
-	c.Assert(within, Equals, false)
+	assert.Equal(t, within, false)
 
 	cd = CandleDurationFromString("1W")
 	val = time.Date(2017, 1, 8, 0, 0, 0, 0, time.UTC)
 	start = time.Date(2018, 1, 7, 0, 0, 0, 0, time.UTC)
 	within = cd.IsWithin(val, start)
-	c.Assert(within, Equals, false)
+	assert.Equal(t, within, false)
 	val = time.Date(2018, 1, 8, 0, 0, 0, 0, time.UTC)
 	start = time.Date(2018, 1, 8, 0, 0, 0, 0, time.UTC)
 	within = cd.IsWithin(val, start)
-	c.Assert(within, Equals, true)
+	assert.Equal(t, within, true)
 
 	loc, _ := time.LoadLocation("America/New_York")
 	cd = CandleDurationFromString("1D")
 	val = time.Date(2018, 1, 8, 0, 0, 0, 0, loc)
 	start = cd.Truncate(val)
-	c.Assert(start.Hour(), Equals, 0)
-	c.Assert(start.Minute(), Equals, 0)
-	c.Assert(start.Day(), Equals, val.Day())
-	c.Assert(start.Month(), Equals, val.Month())
-	c.Assert(start.Year(), Equals, val.Year())
+	assert.Equal(t, start.Hour(), 0)
+	assert.Equal(t, start.Minute(), 0)
+	assert.Equal(t, start.Day(), val.Day())
+	assert.Equal(t, start.Month(), val.Month())
+	assert.Equal(t, start.Year(), val.Year())
 
-	c.Assert(cd.IsWithin(val, time.Date(2018, 1, 8, 23, 59, 0, 0, loc)), Equals, true)
-	c.Assert(cd.IsWithin(val, time.Date(2018, 1, 8, 0, 0, 0, 0, loc)), Equals, true)
-	c.Assert(cd.IsWithin(val, time.Date(2018, 1, 8, 0, 0, 0, 0, time.UTC)), Equals, false)
-	c.Assert(cd.IsWithin(val, time.Date(2018, 1, 8, 23, 59, 0, 0, time.UTC)), Equals, true)
+	assert.Equal(t, cd.IsWithin(val, time.Date(2018, 1, 8, 23, 59, 0, 0, loc)), true)
+	assert.Equal(t, cd.IsWithin(val, time.Date(2018, 1, 8, 0, 0, 0, 0, loc)), true)
+	assert.Equal(t, cd.IsWithin(val, time.Date(2018, 1, 8, 0, 0, 0, 0, time.UTC)), false)
+	assert.Equal(t, cd.IsWithin(val, time.Date(2018, 1, 8, 23, 59, 0, 0, time.UTC)), true)
 
 	cd = CandleDurationFromString("abc")
-	c.Assert(cd, IsNil)
+	assert.Nil(t, cd)
 }


### PR DESCRIPTION
## WHAT
- use testing.T and t.Parallel instead of  testSuite and C

## WHY
- to improve CI speed by executing unit tests in parallel