### PR TITLE
refactor: remove RootPath from WAL struct

### DIFF
--- a/cmd/tool/wal/main.go
+++ b/cmd/tool/wal/main.go
@@ -49,7 +49,6 @@ func executeWAL(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	wf.FilePtr = filePtr
-	wf.RootPath = filepath.Base(wf.FilePath)
 
 	// Execute.
 	return wf.Replay(false)

--- a/executor/instance.go
+++ b/executor/instance.go
@@ -16,7 +16,8 @@ import (
 var ThisInstance *InstanceMetadata
 
 type InstanceMetadata struct {
-	// RootDir is the absolute path to the data directory
+	// RootDir is the absolute path to the data directory.
+	// e.g. RootDir = "/project/marketstore/data"
 	RootDir    string
 	CatalogDir *catalog.Directory
 	TXNPipe    *TransactionPipe
@@ -51,6 +52,8 @@ func NewInstanceSetup(relRootDir string, rs ReplicationSender, tm []*trigger.Tri
 	}
 
 	var err error
+	// rootDir is the absolute path to the data directory.
+	// e.g. rootDir = "/project/marketstore/data"
 	rootDir, err := filepath.Abs(filepath.Clean(relRootDir))
 	if err != nil {
 		log.Error("Cannot take absolute path of root directory %s", err.Error())

--- a/executor/wal/command.go
+++ b/executor/wal/command.go
@@ -8,8 +8,10 @@ import (
 // WriteCommand is a write request for WriteAheadLog (WAL).
 // One WriteCommand can have multiple row records that have the same index, in case of VariableLength record type.
 type WriteCommand struct {
-	RecordType    io.EnumRecordType
-	WALKeyPath    string
+	RecordType io.EnumRecordType
+	// WALKeyPath is the relative path from the root directory.
+	// e.g. "WALFile.1621901771897875000.walfile"
+	WALKeyPath string
 	// VarRecLen is used only in case of VARIABLE recordType.
 	// (The sum of field lengths in elementTypes without Epoch column) + 4 bytes(for intervalTicks)
 	VarRecLen     int

--- a/executor/writer.go
+++ b/executor/writer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	stdio "io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -98,7 +99,8 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte, dsWithEpoch []DataSha
 		rowLen    = len(data) / numRows
 	)
 
-	wkp := FullPathToWALKey(w.walFile.RootPath, w.tbi.Path)
+	rootDir := filepath.Dir(w.walFile.FilePtr.Name())
+	wkp := FullPathToWALKey(rootDir, w.tbi.Path)
 	vrl := w.tbi.GetVariableRecordLength()
 	rt := w.tbi.GetRecordType()
 	for i := 0; i < numRows; i++ {
@@ -110,7 +112,8 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte, dsWithEpoch []DataSha
 			if err := w.addNewYearFile(year); err != nil {
 				return fmt.Errorf("add new year file. path=%s, err: %w", w.tbi.Path, err)
 			}
-			wkp = FullPathToWALKey(w.walFile.RootPath, w.tbi.Path)
+			rootDir := filepath.Dir(w.walFile.FilePtr.Name())
+			wkp = FullPathToWALKey(rootDir, w.tbi.Path)
 		}
 		index := TimeToIndex(t, w.tbi.GetTimeframe())
 		offset := IndexToOffset(index, w.tbi.GetRecordLength())
@@ -150,9 +153,10 @@ func (w *Writer) WriteRecords(ts []time.Time, data []byte, dsWithEpoch []DataSha
 			// Setup next command
 			prevIndex = index
 			outBuf = formatRecord([]byte{}, record, t, index, w.tbi.GetIntervals(), w.tbi.GetRecordType() == VARIABLE)
+			rootDir := filepath.Dir(w.walFile.FilePtr.Name())
 			cc = &wal.WriteCommand{
 				RecordType: w.tbi.GetRecordType(),
-				WALKeyPath: FullPathToWALKey(w.walFile.RootPath, w.tbi.Path),
+				WALKeyPath: FullPathToWALKey(rootDir, w.tbi.Path),
 				VarRecLen:  int(w.tbi.GetVariableRecordLength()),
 				Offset:     offset,
 				Index:      index,

--- a/utils/io/metadata.go
+++ b/utils/io/metadata.go
@@ -38,7 +38,7 @@ type TimeBucketInfo struct {
 	// Year, Path and IsRead are all set on catalog startup
 	Year   int16
 	// Path is the absolute path to the data binary file.
-	// (e.g. "/mkts/data/TEST/1Sec/Tick/2021.bin")
+	// (e.g. "/project/marketstore/data/TEST/1Sec/Tick/2021.bin")
 	Path   string
 	IsRead bool
 


### PR DESCRIPTION
## WHAT
- remove `RootPath string` parameter from WAL struct

## WHY
- The rootDir can be obtained from `filePtr *os.File`.
- The physical directory where the WALfile resides should be hidden from other services in the future, for better portability/testability/abstraction.