### PR TITLE
refactor: use testing.T instead of TestSuite

### DIFF
--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -1,62 +1,53 @@
-package catalog
+package catalog_test
 
 import (
 	"errors"
 	"fmt"
-	"path"
-	"testing"
-
-	. "gopkg.in/check.v1"
-
-	"os"
-	"path/filepath"
-
+	"github.com/alpacahq/marketstore/v4/catalog"
 	"github.com/alpacahq/marketstore/v4/utils"
 	"github.com/alpacahq/marketstore/v4/utils/io"
-	. "github.com/alpacahq/marketstore/v4/utils/test"
+	"github.com/alpacahq/marketstore/v4/utils/test"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
+func setup(t *testing.T, testName string,
+) (tearDown func(), rootDir string, catalogDir *catalog.Directory) {
+	t.Helper()
 
-type TestSuite struct {
-	DataDirectory *Directory
-	Rootdir       string
-}
-
-var _ = Suite(&TestSuite{nil, ""})
-
-func (s *TestSuite) SetUpSuite(c *C) {
-	s.Rootdir = c.MkDir()
-	//	s.Rootdir = "/tmp/LALTest"
-	//	os.Mkdir(s.Rootdir, 0770)
-	MakeDummyCurrencyDir(s.Rootdir, false, false)
-	var err error
-	s.DataDirectory, err = NewDirectory(s.Rootdir)
+	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("catalog_test-%s", testName))
+	test.MakeDummyCurrencyDir(rootDir, false, false)
+	catalogDir, err := catalog.NewDirectory(rootDir)
 	if err != nil {
-		c.Fatal("failed to create a catalog dir.err=" + err.Error())
+		t.Fatal("failed to create a catalog dir.err=" + err.Error())
 	}
+
+	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, catalogDir
 }
 
-func (s *TestSuite) TearDownSuite(c *C) {
-	CleanupDummyDataDir(s.Rootdir)
+func TestGetDirectMap(t *testing.T) {
+	tearDown, _, catalogDir := setup(t, "TestGetDirectMap")
+	defer tearDown()
+
+	assert.Len(t, catalogDir.DirectMap, 18)
 }
 
-func (s *TestSuite) TestGetDirectMap(c *C) {
-	/*
-		for key, _ := range s.DataDirectory.directMap {
-			fmt.Println(key)
-		}
-	*/
-	c.Assert(len(s.DataDirectory.directMap), Equals, 18)
-}
+func TestGetCatList(t *testing.T) {
+	tearDown, _, catalogDir := setup(t, "TestGetCatList")
+	defer tearDown()
 
-func (s *TestSuite) TestGetCatList(c *C) {
-	CatList := s.DataDirectory.GatherCategoriesFromCache()
-	c.Assert(len(CatList), Equals, 4)
+	CatList := catalogDir.GatherCategoriesFromCache()
+	assert.Len(t, CatList, 4)
 }
-func (s *TestSuite) TestGetCatItemMap(c *C) {
-	catList := s.DataDirectory.GatherCategoriesAndItems()
+func TestGetCatItemMap(t *testing.T) {
+	tearDown, _, catalogDir := setup(t, "TestGetCatItemMap")
+	defer tearDown()
+
+	catList := catalogDir.GatherCategoriesAndItems()
 	/*
 		for key, list := range catList {
 			fmt.Printf("Category: %s: {", key)
@@ -71,83 +62,90 @@ func (s *TestSuite) TestGetCatItemMap(c *C) {
 			fmt.Printf("}\n")
 		}
 	*/
-	c.Assert(len(catList), Equals, 4)
+	assert.Len(t, catList, 4)
 }
-func (s *TestSuite) TestGetDirList(c *C) {
-	dirList := s.DataDirectory.gatherDirectories()
-	c.Assert(len(dirList), Equals, 40)
+func TestGetDirList(t *testing.T) {
+	tearDown, _, catalogDir := setup(t, "TestGetDirList")
+	defer tearDown()
+
+	dirList := catalogDir.GatherDirectories()
+	assert.Len(t, dirList, 40)
 }
-func (s *TestSuite) TestGatherFilePaths(c *C) {
-	filePathList := s.DataDirectory.gatherFilePaths()
+func TestGatherFilePaths(t *testing.T) {
+	tearDown, _, catalogDir := setup(t, "TestGatherFilePaths")
+	defer tearDown()
+
+	filePathList := catalogDir.GatherFilePaths()
 	//	for _, filePath := range filePathList {
 	//		fmt.Printf("File Path: %s\n",filePath)
 	//	}
-	c.Assert(len(filePathList), Equals, 54)
+	assert.Len(t, filePathList, 54)
 }
-func (s *TestSuite) TestGatherFileInfo(c *C) {
-	fileInfoList := s.DataDirectory.GatherTimeBucketInfo()
+func TestGatherFileInfo(t *testing.T) {
+	tearDown, _, catalogDir := setup(t, "TestGatherFileInfo")
+	defer tearDown()
+
+	fileInfoList := catalogDir.GatherTimeBucketInfo()
 	//for _, fileInfo := range fileInfoList {
 	//	fmt.Printf("File Path: %s Year: %d\n",fileInfo.Path,fileInfo.Year)
 	//}
-	c.Assert(len(fileInfoList), Equals, 54)
+	assert.Len(t, fileInfoList, 54)
 }
-func (s *TestSuite) TestPathToFileInfo(c *C) {
-	fileInfo, err := s.DataDirectory.PathToTimeBucketInfo("nil")
+func TestPathToFileInfo(t *testing.T) {
+	tearDown, rootDir, catalogDir := setup(t, "TestPathToFileInfo")
+	defer tearDown()
+
+	fileInfo, err := catalogDir.PathToTimeBucketInfo("nil")
 	if err != nil {
-		if _, ok := err.(NotFoundError); ok {
-			c.Assert(fileInfo, Equals, (*io.TimeBucketInfo)(nil))
+		if _, ok := err.(catalog.NotFoundError); ok {
+			assert.Equal(t, fileInfo, (*io.TimeBucketInfo)(nil))
 		} else {
-			c.Fail()
+			t.Fail()
 		}
 	}
-	mypath := s.Rootdir + "/EURUSD/1Min/OHLC/2001.bin"
-	fileInfo, err = s.DataDirectory.PathToTimeBucketInfo(mypath)
+	mypath := rootDir + "/EURUSD/1Min/OHLC/2001.bin"
+	fileInfo, err = catalogDir.PathToTimeBucketInfo(mypath)
 	if err != nil {
 		fmt.Println(err)
 	}
-	c.Assert(err == nil, Equals, true)
-	c.Assert(fileInfo.Path, Equals, mypath)
+	assert.Nil(t, err)
+	assert.Equal(t, fileInfo.Path, mypath)
 }
-func (s *TestSuite) TestAddFile(c *C) {
-	d, err := NewDirectory(s.Rootdir)
-	if err != nil {
-		c.Fatal("failed to create a catalog dir.err=" + err.Error())
-		return
-	}
+func TestAddFile(t *testing.T) {
+	tearDown, _, catalogDir := setup(t, "TestAddFile")
+	defer tearDown()
+
 	// Get the owning subdirectory for a test file path
-	filePathList := d.gatherFilePaths()
+	filePathList := catalogDir.GatherFilePaths()
 	filePath := filePathList[0]
 	// fmt.Println(filePath)
-	subDir, err := d.GetOwningSubDirectory(filePath)
+	subDir, err := catalogDir.GetOwningSubDirectory(filePath)
 	if err != nil {
 		fmt.Println(err)
 	}
-	c.Assert(err == nil, Equals, true)
+	assert.Nil(t, err)
 	// fmt.Println(subDir.GetPath())
 	// Get the latest year file in subdir
-	_, err = subDir.getLatestYearFile()
-	c.Assert(err == nil, Equals, true)
-	// latestFile, err := subDir.getLatestYearFile()
+	_, err = subDir.GetLatestYearFile()
+	assert.Nil(t, err)
+	// latestFile, err := subDir.GetLatestYearFile()
 	// fmt.Println(latestFile.Path)
 	if _, err = subDir.AddFile(int16(2016)); err != nil {
 		fmt.Println(err)
 	}
-	c.Assert(err == nil, Equals, true)
-	_, err = subDir.getLatestYearFile()
-	c.Assert(err == nil, Equals, true)
+	assert.Nil(t, err)
+	_, err = subDir.GetLatestYearFile()
+	assert.Nil(t, err)
 	// fmt.Println("New Latest Year:", latestFile.Year, latestFile.Path)
 }
 
-func (s *TestSuite) TestAddAndRemoveDataItem(c *C) {
-	d, err := NewDirectory(s.Rootdir)
-	if err != nil {
-		c.Fatal("failed to create a catalog dir.err=" + err.Error())
-		return
-	}
+func TestAddAndRemoveDataItem(t *testing.T) {
+	tearDown, rootDir, catalogDir := setup(t, "TestPathToFileInfo")
+	defer tearDown()
 
 	catKey := "Symbol/Timeframe/AttributeGroup"
 	dataItemKey := "TEST/1Min/OHLCV"
-	dataItemPath := filepath.Join(s.Rootdir, dataItemKey)
+	dataItemPath := filepath.Join(rootDir, dataItemKey)
 	dsv := io.NewDataShapeVector(
 		[]string{"Open", "High", "Low", "Close", "Volume"},
 		[]io.EnumElementType{io.FLOAT32, io.FLOAT32, io.FLOAT32, io.FLOAT32, io.INT32},
@@ -156,74 +154,82 @@ func (s *TestSuite) TestAddAndRemoveDataItem(c *C) {
 		dsv, io.FIXED)
 
 	tbk := io.NewTimeBucketKey(dataItemKey, catKey)
-	err = d.AddTimeBucket(tbk, tbinfo)
-	c.Assert(err, Equals, nil)
-	catList := d.GatherCategoriesAndItems()
+	err := catalogDir.AddTimeBucket(tbk, tbinfo)
+	assert.Nil(t, err)
+
+	catList := catalogDir.GatherCategoriesAndItems()
 	_, ok := catList["Symbol"]["TEST"]
-	c.Assert(ok, Equals, true)
+	assert.True(t, ok)
 	// Construct the known new path to this subdirectory so that we can verify it is in the catalog
 
-	oldFilePath := path.Join(s.Rootdir, "EURUSD", "1Min", "OHLC", "2000.bin")
-	_, err = d.GetOwningSubDirectory(oldFilePath)
-	c.Assert(err == nil, Equals, true)
+	oldFilePath := path.Join(rootDir, "EURUSD", "1Min", "OHLC", "2000.bin")
+	_, err = catalogDir.GetOwningSubDirectory(oldFilePath)
+	assert.Nil(t, err)
 
-	newFilePath := path.Join(s.Rootdir, "TEST", "1Min", "OHLCV", "2016.bin")
-	_, err = d.GetOwningSubDirectory(newFilePath)
-	c.Assert(err == nil, Equals, true)
+	newFilePath := path.Join(rootDir, "TEST", "1Min", "OHLCV", "2016.bin")
+	_, err = catalogDir.GetOwningSubDirectory(newFilePath)
+	assert.Nil(t, err)
 
-	err = d.RemoveTimeBucket(tbk)
+	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
 		fmt.Println(err)
 	}
-	c.Assert(err == nil, Equals, true)
-	catList = d.GatherCategoriesAndItems()
+	assert.Nil(t, err)
+	catList = catalogDir.GatherCategoriesAndItems()
 	_, ok = catList["Symbol"]["TEST"]
-	c.Assert(ok, Equals, false)
+	assert.False(t, ok)
 	npath := newFilePath
-	c.Assert(exists(npath), Equals, false)
-	npath = path.Join(s.Rootdir, "TEST", "1Min", "OHLCV")
-	c.Assert(exists(npath), Equals, false)
-	npath = path.Join(s.Rootdir, "TEST", "1Min")
-	c.Assert(exists(npath), Equals, false)
-	npath = path.Join(s.Rootdir, "TEST")
-	c.Assert(exists(npath), Equals, false)
-	npath = path.Join(s.Rootdir, "EURUSD")
-	c.Assert(exists(npath), Equals, true)
+	assert.False(t, exists(npath))
+	npath = path.Join(rootDir, "TEST", "1Min", "OHLCV")
+	assert.False(t, exists(npath))
+	npath = path.Join(rootDir, "TEST", "1Min")
+	assert.False(t, exists(npath))
+	npath = path.Join(rootDir, "TEST")
+	assert.False(t, exists(npath))
+	npath = path.Join(rootDir, "EURUSD")
+	assert.True(t, exists(npath))
+}
 
-	/*
-		Test using an empty root directory
-	*/
-	rootDir := c.MkDir()
-	d, err = NewDirectory(rootDir)
-	var e *ErrCategoryFileNotFound
+func TestAddAndRemoveDataItemFromEmptyDirectory(t *testing.T) {
+	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("catalog_test-TestAddAndRemoveDataItemFromEmptyDirectory"))
+	catalogDir, err := catalog.NewDirectory(rootDir)
+	var e *catalog.ErrCategoryFileNotFound
 	if err != nil && !errors.As(err, &e) {
-		c.Fatal("failed to create a catalog dir.err=" + err.Error())
+		t.Fatal("failed to create a catalog dir.err=" + err.Error())
 		return
 	}
 
-	dataItemPath = filepath.Join(rootDir, dataItemKey)
-	dsv = io.NewDataShapeVector(
+	defer test.CleanupDummyDataDir(rootDir)
+
+
+
+	catKey := "Symbol/Timeframe/AttributeGroup"
+	dataItemKey := "TEST/1Min/OHLCV"
+	tbk := io.NewTimeBucketKey(dataItemKey, catKey)
+
+	dataItemPath := filepath.Join(rootDir, dataItemKey)
+	dsv := io.NewDataShapeVector(
 		[]string{"Open", "High", "Low", "Close", "Volume"},
 		[]io.EnumElementType{io.FLOAT32, io.FLOAT32, io.FLOAT32, io.FLOAT32, io.INT32},
 	)
-	tbinfo = io.NewTimeBucketInfo(*utils.TimeframeFromString("1Min"), dataItemPath, "Test item", 2016,
+	tbinfo := io.NewTimeBucketInfo(*utils.TimeframeFromString("1Min"), dataItemPath, "Test item", 2016,
 		dsv, io.FIXED)
 
-	err = d.AddTimeBucket(tbk, tbinfo)
-	c.Assert(err, Equals, nil)
+	err = catalogDir.AddTimeBucket(tbk, tbinfo)
+	assert.Nil(t, err)
 
-	catList = d.GatherCategoriesAndItems()
-	_, ok = catList["Symbol"]["TEST"]
-	c.Assert(ok, Equals, true)
-	newFilePath = path.Join(rootDir, "TEST", "1Min", "OHLCV", "2016.bin")
-	npath = newFilePath
-	c.Assert(exists(npath), Equals, true)
+	catList := catalogDir.GatherCategoriesAndItems()
+	_, ok := catList["Symbol"]["TEST"]
+	assert.True(t, ok)
+	newFilePath := path.Join(rootDir, "TEST", "1Min", "OHLCV", "2016.bin")
+	npath := newFilePath
+	assert.True(t, exists(npath))
 	npath = path.Join(rootDir, "TEST", "1Min", "OHLCV")
-	c.Assert(exists(npath), Equals, true)
+	assert.True(t, exists(npath))
 	npath = path.Join(rootDir, "TEST", "1Min")
-	c.Assert(exists(npath), Equals, true)
+	assert.True(t, exists(npath))
 	npath = path.Join(rootDir, "TEST")
-	c.Assert(exists(npath), Equals, true)
+	assert.True(t, exists(npath))
 	// fmt.Println(catList)
 
 	/*
@@ -238,60 +244,54 @@ func (s *TestSuite) TestAddAndRemoveDataItem(c *C) {
 	tbinfo = io.NewTimeBucketInfo(*utils.TimeframeFromString("1Min"), dataItemPath, "Test item", 2016,
 		dsv, io.FIXED)
 	tbk = io.NewTimeBucketKey(dataItemKey, catKey)
-	err = d.AddTimeBucket(tbk, tbinfo)
-	c.Assert(err, Equals, nil)
-	catList = d.GatherCategoriesAndItems()
+	err = catalogDir.AddTimeBucket(tbk, tbinfo)
+	assert.Nil(t, err)
+	catList = catalogDir.GatherCategoriesAndItems()
 	_, ok = catList["Symbol"]["TEST2"]
-	c.Assert(ok, Equals, true)
+	assert.True(t, ok)
 
 	// This should fail
-	err = d.AddTimeBucket(tbk, tbinfo)
-	c.Assert(err != nil, Equals, true)
+	err = catalogDir.AddTimeBucket(tbk, tbinfo)
+	assert.NotNil(t, err)
 
 	// Now let's remove the symbol and then re-add it - should work
-	err = d.RemoveTimeBucket(tbk)
+	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
 		fmt.Println(err)
 	}
-	c.Assert(err, Equals, nil)
-	err = d.AddTimeBucket(tbk, tbinfo)
-	c.Assert(err, Equals, nil)
+	assert.Nil(t, err)
+	err = catalogDir.AddTimeBucket(tbk, tbinfo)
+	assert.Nil(t, err)
 
 	// Sometimes people may call AddTimeBucket with an empty directory, let's test that
-	err = d.RemoveTimeBucket(tbk)
+	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
 		fmt.Println(err)
 	}
-	c.Assert(err, Equals, nil)
-	err = d.AddTimeBucket(tbk, tbinfo)
-	c.Assert(err, Equals, nil)
+	assert.Nil(t, err)
+	err = catalogDir.AddTimeBucket(tbk, tbinfo)
+	assert.Nil(t, err)
 
 	// Let's try two subsequent RemoveTimeBucket calls, the first should work, the second should err
-	err = d.RemoveTimeBucket(tbk)
+	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
 		fmt.Println(err)
 	}
-	c.Assert(err, Equals, nil)
-	err = d.RemoveTimeBucket(tbk)
+	assert.Nil(t, err)
+	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
 		fmt.Println(err)
 	}
-	c.Assert(err != nil, Equals, true)
+	assert.NotNil(t, err)
 }
 
-func (s *TestSuite) TestCreateNewDirectory(c *C) {
-	newRootDir := c.MkDir()
-
-	d, err := NewDirectory(newRootDir)
-	var e *ErrCategoryFileNotFound
-	if err != nil && !errors.As(err, &e) {
-		c.Fatal("failed to create a catalog dir.err=" + err.Error())
-		return
-	}
+func TestCreateNewDirectory(t *testing.T) {
+	tearDown, rootDir, catalogDir := setup(t, "TestPathToFileInfo")
+	defer tearDown()
 
 	catKey := "Symbol/Timeframe/AttributeGroup"
 	dataItemKey := "TEST/1Min/OHLCV"
-	dataItemPath := filepath.Join(newRootDir, dataItemKey)
+	dataItemPath := filepath.Join(rootDir, dataItemKey)
 	dsv := io.NewDataShapeVector(
 		[]string{"Open", "High", "Low", "Close", "Volume"},
 		[]io.EnumElementType{io.FLOAT32, io.FLOAT32, io.FLOAT32, io.FLOAT32, io.INT32},
@@ -300,16 +300,16 @@ func (s *TestSuite) TestCreateNewDirectory(c *C) {
 		dsv, io.FIXED)
 
 	tbk := io.NewTimeBucketKey(dataItemKey, catKey)
-	err = d.AddTimeBucket(tbk, tbinfo)
-	c.Assert(err, Equals, nil)
-	catList := d.GatherCategoriesAndItems()
+	err := catalogDir.AddTimeBucket(tbk, tbinfo)
+	assert.Nil(t, err)
+	catList := catalogDir.GatherCategoriesAndItems()
 	_, ok := catList["Symbol"]["TEST"]
-	c.Assert(ok, Equals, true)
+	assert.True(t, ok)
 
 	// Construct the known new path to this subdirectory so that we can verify it is in the catalog
-	newFilePath := path.Join(newRootDir, "TEST", "1Min", "OHLCV", "2016.bin")
-	_, err = d.GetOwningSubDirectory(newFilePath)
-	c.Assert(err == nil, Equals, true)
+	newFilePath := path.Join(rootDir, "TEST", "1Min", "OHLCV", "2016.bin")
+	_, err = catalogDir.GetOwningSubDirectory(newFilePath)
+	assert.Nil(t, err)
 }
 
 func exists(path string) bool {

--- a/contrib/alpaca/handlers/handlers_test.go
+++ b/contrib/alpaca/handlers/handlers_test.go
@@ -1,33 +1,24 @@
-package handlers
+package handlers_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
-	"github.com/alpacahq/marketstore/v4/catalog"
+	"github.com/alpacahq/marketstore/v4/contrib/alpaca/handlers"
+	"github.com/alpacahq/marketstore/v4/utils/test"
 
 	"github.com/alpacahq/marketstore/v4/executor"
-
-	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
+func setup(t *testing.T, testName string) (tearDown func()) {
+	t.Helper()
 
-var _ = Suite(&HandlersTestSuite{})
+	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("handlers_test-%s", testName))
+	_, _, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false, true) // WAL Bypass
 
-type HandlersTestSuite struct {
-	DataDirectory *catalog.Directory
-	Rootdir       string
-	WALFile       *executor.WALFileType
+	return func() { test.CleanupDummyDataDir(rootDir) }
 }
-
-func (s *HandlersTestSuite) SetUpSuite(c *C) {
-	s.Rootdir = c.MkDir()
-	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, nil, 5, true, true, false, true) // WAL Bypass
-	s.DataDirectory = metadata.CatalogDir
-	s.WALFile = metadata.WALFile
-}
-
-func (s *HandlersTestSuite) TearDownSuite(c *C) {}
 
 func getTestTrade() []byte {
 	return []byte(`{"data":{"ev":"T","T":"SPY","i":117537207,"x":2,"p":283.63,"s":2,"t":1587407015152775000,"c":[14, 37, 41],"z":2}}`)
@@ -38,17 +29,20 @@ func getTestQuote() []byte {
 func getTestAggregate() []byte {
 	return []byte(`{"data":{"ev":"AM","T":"SPY","v":48526,"av":9663586,"op":282.6,"vw":282.0362,"o":282.13,"c":281.94,"h":282.14,"l":281.86,"a":284.4963,"s":1587409020000,"e":1587409080000}}`)
 }
-func (s *HandlersTestSuite) TestHandlers(c *C) {
+func TestHandlers(t *testing.T) {
+	tearDown := setup(t, "TestHandlers")
+	defer tearDown()
+
 	// trade
 	{
-		MessageHandler(getTestTrade())
+		handlers.MessageHandler(getTestTrade())
 	}
 	// quote
 	{
-		MessageHandler(getTestQuote())
+		handlers.MessageHandler(getTestQuote())
 	}
 	// aggregate
 	{
-		MessageHandler(getTestAggregate())
+		handlers.MessageHandler(getTestAggregate())
 	}
 }

--- a/frontend/query.go
+++ b/frontend/query.go
@@ -94,7 +94,7 @@ func (s *DataService) Query(r *http.Request, reqs *MultiQueryRequest, response *
 	for _, req := range reqs.Requests {
 		var (
 			resp *QueryResponse
-			err error
+			err  error
 		)
 		// SQL
 		if req.IsSQLStatement {
@@ -102,7 +102,7 @@ func (s *DataService) Query(r *http.Request, reqs *MultiQueryRequest, response *
 			if err != nil {
 				return err
 			}
-		}else {
+		} else {
 			// Query
 			resp, err = s.executeQuery(&req)
 			if err != nil {
@@ -348,7 +348,7 @@ func runAggFunctions(callChain []string, csInput *io.ColumnSeries, tbk io.TimeBu
 		if cs != nil {
 			csInput = cs
 		}
-		aggName, literalList, parameterList, err := parseFunctionCall(call)
+		aggName, literalList, parameterList, err := ParseFunctionCall(call)
 		if err != nil {
 			return nil, err
 		}
@@ -399,7 +399,10 @@ func runAggFunctions(callChain []string, csInput *io.ColumnSeries, tbk io.TimeBu
 	return cs, nil
 }
 
-func parseFunctionCall(call string) (funcName string, literalList, parameterList []string, err error) {
+// ParseFunctionCall parses a string to call an aggregator function.
+// e.g. "FuncName (P1, 'Lit1', P2,P3,P4, 'Lit2' , Sum::P5, Avg::P6)"
+// -> funcName="FuncName" , literalList=["Lit1", "Lit2"], parameterList=["P1","P2","P3","P4","Sum::P5", "Avg::P6"]
+func ParseFunctionCall(call string) (funcName string, literalList, parameterList []string, err error) {
 	call = strings.Trim(call, " ")
 	left := strings.Index(call, "(")
 	right := strings.LastIndex(call, ")")

--- a/frontend/server_test.go
+++ b/frontend/server_test.go
@@ -1,41 +1,16 @@
-package frontend
+package frontend_test
 
 import (
 	"testing"
 
-	. "gopkg.in/check.v1"
-
-	"sync/atomic"
-
-	"github.com/alpacahq/marketstore/v4/catalog"
-	"github.com/alpacahq/marketstore/v4/executor"
-	"github.com/alpacahq/marketstore/v4/utils/test"
+	"github.com/alpacahq/marketstore/v4/frontend"
+	"github.com/stretchr/testify/assert"
 )
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
+func TestNewServer(t *testing.T) {
+	tearDown, rootDir, metadata := setup(t, "TestNewServer")
+	defer tearDown()
 
-type ServerTestSuite struct {
-	root    *catalog.Directory
-	Rootdir string
-}
-
-var _ = Suite(&ServerTestSuite{nil, ""})
-
-func (s *ServerTestSuite) SetUpSuite(c *C) {
-	s.Rootdir = c.MkDir()
-	//s.Rootdir = "/tmp/LALtemp"
-	test.MakeDummyCurrencyDir(s.Rootdir, true, false)
-	metadata, _, _ := executor.NewInstanceSetup(s.Rootdir, nil, nil,5, true, true, false, false)
-	s.root = metadata.CatalogDir
-	atomic.StoreUint32(&Queryable, uint32(1))
-}
-
-func (s *ServerTestSuite) TearDownSuite(c *C) {
-	test.CleanupDummyDataDir(s.Rootdir)
-}
-
-func (s *ServerTestSuite) TestNewServer(c *C) {
-	serv, _ := NewServer(s.Rootdir, s.root)
-	c.Check(serv.HasMethod("DataService.Query"), Equals, true)
+	serv, _ := frontend.NewServer(rootDir, metadata.CatalogDir)
+	assert.True(t, serv.HasMethod("DataService.Query"))
 }


### PR DESCRIPTION
## WHAT
- a part of refactor to use testing.T instead of TestSuite

## WHY
- to make each test more independent (and parallelize in the future)