### PR TITLE
refactor(test): use testing.T instead of TestSuite

### DIFF
--- a/executor/buffile/buffile.go
+++ b/executor/buffile/buffile.go
@@ -26,14 +26,14 @@ type BufferedFile struct {
 	bufferOffset int64
 }
 
-const defaultBlockSize = 32 * 1024
+const DefaultBlockSize = 32 * 1024
 
 func New(filePath string) (*BufferedFile, error) {
 	fp, err := os.OpenFile(filePath, os.O_RDWR, 0700)
 	if err != nil {
 		return nil, err
 	}
-	blockSize := defaultBlockSize
+	blockSize := DefaultBlockSize
 	return &BufferedFile{
 		fp:        fp,
 		blockSize: blockSize,

--- a/executor/buffile/buffile_test.go
+++ b/executor/buffile/buffile_test.go
@@ -1,38 +1,37 @@
-package buffile
+package buffile_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"github.com/alpacahq/marketstore/v4/executor/buffile"
+	"github.com/alpacahq/marketstore/v4/utils/test"
+	"github.com/stretchr/testify/assert"
 )
 
-type TestSuite struct{}
+func TestBufferedFile(t *testing.T) {
+	tempDir, _ := ioutil.TempDir("", fmt.Sprintf("plugins_test-%s", "TestBufferedFile"))
+	defer test.CleanupDummyDataDir(tempDir)
 
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) { TestingT(t) }
-
-var _ = Suite(&TestSuite{})
-
-func (t *TestSuite) TestBufferedFile(c *C) {
-	tempDir := c.MkDir()
 	filePath := filepath.Join(tempDir, "test.bin")
 	fp, err := os.OpenFile(filePath, os.O_CREATE|os.O_RDWR, 0700)
-	c.Check(err, IsNil)
+	assert.Nil(t, err)
 	err = fp.Truncate(1024 * 1024)
-	c.Check(err, IsNil)
+	assert.Nil(t, err)
 	fp.Close()
 
-	bf, err := New(filePath)
-	c.Check(err, IsNil)
+	bf, err := buffile.New(filePath)
+	assert.Nil(t, err)
 	dataIn := make([]byte, 64)
 	for i := 0; i < len(dataIn); i++ {
 		dataIn[i] = 0xaa
 	}
 	offset := int64(128)
 	offset2 := offset * 3
-	offset3 := int64(defaultBlockSize - 2)
+	offset3 := int64(buffile.DefaultBlockSize - 2)
 	offset4 := int64(1024*1024 - len(dataIn))
 	bf.WriteAt(dataIn, offset)
 	bf.WriteAt(dataIn, offset2)
@@ -44,11 +43,11 @@ func (t *TestSuite) TestBufferedFile(c *C) {
 	checkFunc := func(offset int64, size int) {
 		outData := make([]byte, size+2)
 		fp.ReadAt(outData, offset-1)
-		c.Check(outData[0], Equals, byte(0x00))
+		assert.Equal(t, outData[0], byte(0x00))
 		for i := 0; i < size; i++ {
-			c.Check(outData[i+1], Equals, byte(0xaa))
+			assert.Equal(t, outData[i+1], byte(0xaa))
 		}
-		c.Check(outData[size+1], Equals, byte(0x00))
+		assert.Equal(t, outData[size+1], byte(0x00))
 	}
 	checkFunc(offset, len(dataIn))
 	checkFunc(offset2, len(dataIn))
@@ -56,6 +55,6 @@ func (t *TestSuite) TestBufferedFile(c *C) {
 	checkFunc(offset4, len(dataIn))
 	fs, _ := fp.Stat()
 	// make sure the file hasn't extended
-	c.Check(fs.Size(), Equals, int64(1024*1024))
+	assert.Equal(t, fs.Size(), int64(1024*1024))
 	fp.Close()
 }

--- a/frontend/utilities_test.go
+++ b/frontend/utilities_test.go
@@ -5,18 +5,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
+	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/alpacahq/marketstore/v4/utils"
-	. "gopkg.in/check.v1"
 )
 
-// Hook up gocheck into the "go test" runner.
-type HeartbeatTestSuite struct{}
-
-var _ = Suite(&HeartbeatTestSuite{})
-
-func (s *HeartbeatTestSuite) TestHandler(c *C) {
+func TestHandler(t *testing.T) {
 	startTime := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
 	utils.Tag = "dev"
 	var TestValues = map[string]struct {
@@ -44,26 +41,26 @@ func (s *HeartbeatTestSuite) TestHandler(c *C) {
 			hm := HeartbeatMessage{}
 			err := json.NewDecoder(val.Recorder.Body).Decode(&hm)
 			if err != nil {
-				c.Fatal(err)
+				t.Fatal(err)
 			}
 			if hm.Version != val.ExpectedVersion {
-				c.Error("Wrong version - Expected:", val.ExpectedVersion, "Got:", hm.Version)
+				t.Error("Wrong version - Expected:", val.ExpectedVersion, "Got:", hm.Version)
 			}
-			c.Assert(hm.Status, Equals, "queryable")
-			c.Assert(val.Recorder.Code, Equals, http.StatusOK)
+			assert.Equal(t, hm.Status, "queryable")
+			assert.Equal(t, val.Recorder.Code, http.StatusOK)
 		case "Failure":
 			atomic.StoreUint32(&Queryable, uint32(0))
 			NewUtilityAPIHandlers(startTime).heartbeat(val.Recorder, nil)
 			hm := HeartbeatMessage{}
 			err := json.NewDecoder(val.Recorder.Body).Decode(&hm)
 			if err != nil {
-				c.Fatal(err)
+				t.Fatal(err)
 			}
 			if hm.Version != val.ExpectedVersion {
-				c.Error("Wrong version - Expected:", val.ExpectedVersion, "Got:", hm.Version)
+				t.Error("Wrong version - Expected:", val.ExpectedVersion, "Got:", hm.Version)
 			}
-			c.Assert(hm.Status, Equals, "not queryable")
-			c.Assert(val.Recorder.Code, Equals, http.StatusServiceUnavailable)
+			assert.Equal(t, hm.Status, "not queryable")
+			assert.Equal(t, val.Recorder.Code, http.StatusServiceUnavailable)
 		}
 	}
 }

--- a/utils/io/numpy_test.go
+++ b/utils/io/numpy_test.go
@@ -2,63 +2,60 @@ package io
 
 import (
 	"reflect"
+	"testing"
 
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
 )
 
-type TestSuite3 struct{}
-
-var _ = Suite(&TestSuite3{})
-
-func (s *TestSuite3) TestNewNumpyDataset(c *C) {
+func TestNewNumpyDataset(t *testing.T) {
 	epoch := []int64{10, 11, 12}
 	cs := NewColumnSeries()
 	cs.AddColumn("Epoch", epoch)
 	nds, err := NewNumpyDataset(cs)
-	c.Check(err, Equals, nil)
-	c.Check(nds.Length, Equals, 3)
-	c.Check(nds.ColumnNames[0], Equals, "Epoch")
-	c.Check(len(nds.ColumnData), Equals, 1)
-	c.Check(nds.Length, Equals, 3)
+	assert.Nil(t, err)
+	assert.Equal(t, nds.Length, 3)
+	assert.Equal(t, nds.ColumnNames[0], "Epoch")
+	assert.Len(t, nds.ColumnData, 1)
+	assert.Equal(t, nds.Length, 3)
 
 	dsv, err := nds.buildDataShapes()
-	c.Check(len(dsv), Equals, 1)
-	c.Check(err, IsNil)
+	assert.Len(t, dsv, 1)
+	assert.Nil(t, err)
 }
 
-func (s *TestSuite3) TestNewNumpyMultiDataset(c *C) {
+func TestNewNumpyMultiDataset(t *testing.T) {
 	epoch := []int64{10, 11, 12}
 	cs := NewColumnSeries()
 	cs.AddColumn("Epoch", epoch)
 	nds, err := NewNumpyDataset(cs)
-	c.Check(err, Equals, nil)
+	assert.Nil(t, err)
 	tbk := NewTimeBucketKey("TSLA/1Min/OHLCV")
 	nmds, err := NewNumpyMultiDataset(nds, *tbk)
-	c.Check(err, Equals, nil)
-	c.Check(nmds.Length, Equals, 3)
-	c.Check(nmds.ColumnNames[0], Equals, "Epoch")
-	c.Check(nmds.StartIndex[tbk.String()], Equals, 0)
-	c.Check(len(nmds.ColumnData), Equals, 1)
-	c.Check(nmds.Length, Equals, 3)
+	assert.Nil(t, err)
+	assert.Equal(t, nmds.Length, 3)
+	assert.Equal(t, nmds.ColumnNames[0], "Epoch")
+	assert.Equal(t, nmds.StartIndex[tbk.String()], 0)
+	assert.Len(t, nmds.ColumnData, 1)
+	assert.Equal(t, nmds.Length, 3)
 }
 
-func (s *TestSuite3) TestAppend(c *C) {
+func TestAppend(t *testing.T) {
 	epoch := []int64{10, 11, 12}
 	col1 := []float32{5.5, 6.6, 7.7}
 	cs := NewColumnSeries()
 	cs.AddColumn("Epoch", epoch)
 	cs.AddColumn("col1", col1)
 	nds, err := NewNumpyDataset(cs)
-	c.Check(err, Equals, nil)
+	assert.Nil(t, err)
 	tbk := NewTimeBucketKey("TSLA/1Min/OHLCV")
 	nmds, err := NewNumpyMultiDataset(nds, *tbk)
-	c.Check(err, Equals, nil)
-	c.Check(nmds.Length, Equals, 3)
-	c.Check(nmds.ColumnNames[0], Equals, "Epoch")
-	c.Check(nmds.ColumnNames[1], Equals, "col1")
-	c.Check(nmds.StartIndex[tbk.String()], Equals, 0)
-	c.Check(len(nmds.ColumnData), Equals, 2)
-	c.Check(nmds.Length, Equals, 3)
+	assert.Nil(t, err)
+	assert.Equal(t, nmds.Length, 3)
+	assert.Equal(t, nmds.ColumnNames[0], "Epoch")
+	assert.Equal(t, nmds.ColumnNames[1], "col1")
+	assert.Equal(t, nmds.StartIndex[tbk.String()], 0)
+	assert.Len(t, nmds.ColumnData, 2)
+	assert.Equal(t, nmds.Length, 3)
 
 	epoch = []int64{5, 6, 7}
 	col3 := []float32{1.1, 2.2, 3.3}
@@ -67,35 +64,35 @@ func (s *TestSuite3) TestAppend(c *C) {
 	cs2.AddColumn("col1", col3)
 	tbk2 := NewTimeBucketKey("NVDA/1Min/OHLCV")
 	err = nmds.Append(cs2, *tbk2)
-	c.Check(err, Equals, nil)
-	c.Check(nmds.Lengths[tbk2.String()], Equals, 3)
-	c.Check(nmds.Length, Equals, 6)
-	c.Check(len(nmds.ColumnData), Equals, 2)
+	assert.Nil(t, err)
+	assert.Equal(t, nmds.Lengths[tbk2.String()], 3)
+	assert.Equal(t, nmds.Length, 6)
+	assert.Len(t, nmds.ColumnData, 2)
 	badCol := []int64{12, 13, 14, 15}
 	badCS := NewColumnSeries()
 	badCS.AddColumn("bad", badCol)
 	tbkBad := NewTimeBucketKey("FORD/1Min/OHLCV")
 	err = nmds.Append(badCS, *tbkBad)
-	c.Check(err != nil, Equals, true)
+	assert.NotNil(t, err)
 }
 
-func (s *TestSuite3) TestToColumnSeries(c *C) {
+func TestToColumnSeries(t *testing.T) {
 	epoch := []int64{10, 11, 12}
 	cs := NewColumnSeries()
 	cs.AddColumn("Epoch", epoch)
 	nds, err := NewNumpyDataset(cs)
-	c.Check(err, Equals, nil)
-	c.Check(nds.Length, Equals, 3)
-	c.Check(nds.ColumnNames[0], Equals, "Epoch")
-	c.Check(len(nds.ColumnData[0]), Equals, 24)
-	c.Check(nds.Len(), Equals, 3)
+	assert.Nil(t, err)
+	assert.Equal(t, nds.Length, 3)
+	assert.Equal(t, nds.ColumnNames[0], "Epoch")
+	assert.Len(t, nds.ColumnData[0], 24)
+	assert.Equal(t, nds.Len(), 3)
 
 	csReturned, err := nds.ToColumnSeries(0, nds.Len())
-	c.Check(err, Equals, nil)
-	c.Check(reflect.DeepEqual(csReturned, cs), Equals, true)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(csReturned, cs))
 
 	nds.dataShapes = nil
 	csReturned, err = nds.ToColumnSeries(0, cs.Len())
-	c.Check(err, Equals, nil)
-	c.Check(reflect.DeepEqual(csReturned, cs), Equals, true)
+	assert.Nil(t, err)
+	assert.True(t, reflect.DeepEqual(csReturned, cs))
 }


### PR DESCRIPTION
## WHAT
- a part of refactor to use testing.T instead of TestSuite

## WHY
- to make each test more independent (and parallelize in the future)