### PR TITLE
refactor: wrap TransactionPipe in WAL

### DIFF
--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -53,7 +53,7 @@ func TestTickCandler(t *testing.T) {
 	/*
 		Create some tick data with symbol "TEST"
 	*/
-	createTickBucket("TEST", rootDir, metadata.CatalogDir, metadata.TXNPipe, metadata.WALFile)
+	createTickBucket("TEST", rootDir, metadata.CatalogDir, metadata.WALFile)
 
 	/*
 		Read some tick data
@@ -107,8 +107,7 @@ func TestTickCandler(t *testing.T) {
 /*
 Utility functions
 */
-func createTickBucket(symbol, rootDir string, catalogDir *catalog.Directory, txnPipe *executor.TransactionPipe,
-	wf *executor.WALFileType) {
+func createTickBucket(symbol, rootDir string, catalogDir *catalog.Directory, wf *executor.WALFileType) {
 
 	// Create a new variable data bucket
 	tbk := io.NewTimeBucketKey(symbol + "/1Min/TICK")
@@ -122,7 +121,7 @@ func createTickBucket(symbol, rootDir string, catalogDir *catalog.Directory, txn
 	/*
 		Write some data
 	*/
-	w, err := executor.NewWriter(tbinfo, txnPipe, catalogDir, wf)
+	w, err := executor.NewWriter(tbinfo, catalogDir, wf)
 	if err != nil {
 		panic(err)
 	}

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -91,7 +91,7 @@ func TestQueryMulti(t *testing.T) {
 	*/
 	tbi, err := metadata.CatalogDir.GetLatestTimeBucketInfoFromKey(tbk)
 	assert.Nil(t, err)
-	writer, err := executor.NewWriter(tbi, metadata.TXNPipe, metadata.CatalogDir, metadata.WALFile)
+	writer, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 	row := struct {
 		Epoch                  int64
@@ -106,7 +106,7 @@ func TestQueryMulti(t *testing.T) {
 		writer.WriteRecords([]time.Time{ts}, buffer, dsv)
 	}
 	assert.Nil(t, err)
-	metadata.WALFile.FlushToWAL(metadata.TXNPipe)
+	metadata.WALFile.FlushToWAL()
 	metadata.WALFile.CreateCheckpoint()
 
 	q := NewQuery(metadata.CatalogDir)
@@ -146,7 +146,7 @@ func TestWriteVariable(t *testing.T) {
 	parsed, _ := q.Parse()
 	tbi, err := metadata.CatalogDir.GetLatestTimeBucketInfoFromKey(tbk)
 	assert.Nil(t, err)
-	writer, err := executor.NewWriter(tbi, metadata.TXNPipe, metadata.CatalogDir, metadata.WALFile)
+	writer, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 	row := struct {
 		Epoch    int64
@@ -162,7 +162,7 @@ func TestWriteVariable(t *testing.T) {
 		writer.WriteRecords([]time.Time{ts}, buffer, dsv)
 	}
 	assert.Nil(t, err)
-	metadata.WALFile.FlushToWAL(metadata.TXNPipe)
+	metadata.WALFile.FlushToWAL()
 	metadata.WALFile.CreateCheckpoint()
 
 	/*
@@ -199,7 +199,7 @@ func TestWriteVariable(t *testing.T) {
 		writer.WriteRecords([]time.Time{ts}, buffer, dsv)
 	}
 	assert.Nil(t, err)
-	metadata.WALFile.FlushToWAL(metadata.TXNPipe)
+	metadata.WALFile.FlushToWAL()
 	metadata.WALFile.CreateCheckpoint()
 
 	csm, err = reader.Read()
@@ -230,7 +230,7 @@ func TestWriteVariable(t *testing.T) {
 		writer.WriteRecords([]time.Time{ts}, buffer, dsv)
 	}
 	assert.Nil(t, err)
-	metadata.WALFile.FlushToWAL(metadata.TXNPipe)
+	metadata.WALFile.FlushToWAL()
 	metadata.WALFile.CreateCheckpoint()
 
 	q = NewQuery(metadata.CatalogDir)
@@ -337,7 +337,7 @@ func TestDelete(t *testing.T) {
 	err := metadata.CatalogDir.AddTimeBucket(tbk, tbi)
 	assert.Nil(t, err)
 
-	writer, err := executor.NewWriter(tbi, metadata.TXNPipe, metadata.CatalogDir, metadata.WALFile)
+	writer, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 
 	row := OHLCtest{0, 100., 200., 300., 400.}
@@ -353,7 +353,7 @@ func TestDelete(t *testing.T) {
 	}
 	writer.WriteRecords(tsA, buffer, dsv)
 	assert.Nil(t, err)
-	metadata.WALFile.FlushToWAL(metadata.TXNPipe)
+	metadata.WALFile.FlushToWAL()
 	metadata.WALFile.CreateCheckpoint()
 
 	endTime := tsA[len(tsA)-1]
@@ -669,14 +669,14 @@ func TestAddSymbolThenWrite(t *testing.T) {
 	pr, _ := q.Parse()
 	tbi, err := metadata.CatalogDir.GetLatestTimeBucketInfoFromKey(tbk)
 	assert.Nil(t, err)
-	w, err := executor.NewWriter(tbi, metadata.TXNPipe, metadata.CatalogDir, metadata.WALFile)
+	w, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 	ts := time.Now().UTC()
 	row := OHLCVtest{0, 100., 200., 300., 400., 1000}
 	buffer, _ := Serialize([]byte{}, row)
 	w.WriteRecords([]time.Time{ts}, buffer, dsv)
 	assert.Nil(t, err)
-	err = metadata.WALFile.FlushToWAL(metadata.TXNPipe)
+	err = metadata.WALFile.FlushToWAL()
 	assert.Nil(t, err)
 
 	q = NewQuery(metadata.CatalogDir)
@@ -717,14 +717,14 @@ func TestWriter(t *testing.T) {
 		2016,
 		dsv, FIXED)
 
-	writer, err := executor.NewWriter(tbi, metadata.TXNPipe, metadata.CatalogDir, metadata.WALFile)
+	writer, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 	ts := time.Now().UTC()
 	row := OHLCtest{0, 100., 200., 300., 400.}
 	buffer, _ := Serialize([]byte{}, row)
 	writer.WriteRecords([]time.Time{ts}, buffer, tbi.GetDataShapes())
 	assert.Nil(t, err)
-	metadata.WALFile.FlushToWAL(metadata.TXNPipe)
+	metadata.WALFile.FlushToWAL()
 	metadata.WALFile.CreateCheckpoint()
 }
 

--- a/executor/instance.go
+++ b/executor/instance.go
@@ -20,7 +20,6 @@ type InstanceMetadata struct {
 	// e.g. RootDir = "/project/marketstore/data"
 	RootDir    string
 	CatalogDir *catalog.Directory
-	TXNPipe    *TransactionPipe
 	WALFile    *WALFileType
 }
 
@@ -87,11 +86,11 @@ func NewInstanceSetup(relRootDir string, rs ReplicationSender, tm []*trigger.Tri
 	walWG = &sync.WaitGroup{}
 	if initWALCache {
 		// initialize TransactionPipe
-		ThisInstance.TXNPipe = NewTransactionPipe()
+		txnPipe := NewTransactionPipe()
 
 		// initialize WAL File
 		ThisInstance.WALFile, err = NewWALFile(rootDir, instanceID, rs,
-			WALBypass, &shutdownPend, walWG, tpd,
+			WALBypass, &shutdownPend, walWG, tpd, txnPipe,
 		)
 		if err != nil {
 			log.Fatal("Unable to create WAL")

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/timpalpant/go-iex v0.0.0-20181027174710-0b8a5fdd2ec1
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	go.uber.org/zap v1.15.0
-	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064
 	gonum.org/v1/gonum v0.0.0-20190618015908-5dc218f86579
 	google.golang.org/grpc v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -273,7 +273,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
## WHAT
- refactor: wrap TransactionPipe object in WAL

## WHY
- WAL is the only user of Transaction Pipe, so some code can be simplified by making TransactionPipe and WAL as a set (e.g. Transaction Pipe can be removed from the singleton `ThisInstance` config)