### PR TITLE
refactor: remove TimeBucketInfo from writer struct params

### DIFF
--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -121,7 +121,7 @@ func createTickBucket(symbol, rootDir string, catalogDir *catalog.Directory, wf 
 	/*
 		Write some data
 	*/
-	w, err := executor.NewWriter(tbinfo, catalogDir, wf)
+	w, err := executor.NewWriter(catalogDir, wf)
 	if err != nil {
 		panic(err)
 	}
@@ -134,7 +134,7 @@ func createTickBucket(symbol, rootDir string, catalogDir *catalog.Directory, wf 
 		ts = ts.Add(time.Second)
 		row.Epoch = ts.Unix()
 		buffer, _ := io.Serialize([]byte{}, row)
-		w.WriteRecords([]time.Time{ts}, buffer, dsv)
+		w.WriteRecords([]time.Time{ts}, buffer, dsv, tbinfo)
 	}
 	wf.RequestFlush()
 }

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -91,7 +91,7 @@ func TestQueryMulti(t *testing.T) {
 	*/
 	tbi, err := metadata.CatalogDir.GetLatestTimeBucketInfoFromKey(tbk)
 	assert.Nil(t, err)
-	writer, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
+	writer, err := executor.NewWriter(metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 	row := struct {
 		Epoch                  int64
@@ -103,7 +103,7 @@ func TestQueryMulti(t *testing.T) {
 	for ii := 0; ii < 10; ii++ {
 		ts = ts.Add(time.Minute)
 		row.Epoch = ts.Unix()
-		writer.WriteRecords([]time.Time{ts}, buffer, dsv)
+		writer.WriteRecords([]time.Time{ts}, buffer, dsv, tbi)
 	}
 	assert.Nil(t, err)
 	metadata.WALFile.FlushToWAL()
@@ -146,7 +146,7 @@ func TestWriteVariable(t *testing.T) {
 	parsed, _ := q.Parse()
 	tbi, err := metadata.CatalogDir.GetLatestTimeBucketInfoFromKey(tbk)
 	assert.Nil(t, err)
-	writer, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
+	writer, err := executor.NewWriter(metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 	row := struct {
 		Epoch    int64
@@ -159,7 +159,7 @@ func TestWriteVariable(t *testing.T) {
 		row.Epoch = ts.Unix()
 		inputTime = append(inputTime, ts)
 		buffer, _ := Serialize([]byte{}, row)
-		writer.WriteRecords([]time.Time{ts}, buffer, dsv)
+		writer.WriteRecords([]time.Time{ts}, buffer, dsv, tbi)
 	}
 	assert.Nil(t, err)
 	metadata.WALFile.FlushToWAL()
@@ -196,7 +196,7 @@ func TestWriteVariable(t *testing.T) {
 		row.Epoch = ts.Unix()
 		inputTime = append(inputTime, ts)
 		buffer, _ := Serialize([]byte{}, row)
-		writer.WriteRecords([]time.Time{ts}, buffer, dsv)
+		writer.WriteRecords([]time.Time{ts}, buffer, dsv, tbi)
 	}
 	assert.Nil(t, err)
 	metadata.WALFile.FlushToWAL()
@@ -227,7 +227,7 @@ func TestWriteVariable(t *testing.T) {
 		row.Epoch = ts.Unix()
 		inputTime = append(inputTime, ts)
 		buffer, _ := Serialize([]byte{}, row)
-		writer.WriteRecords([]time.Time{ts}, buffer, dsv)
+		writer.WriteRecords([]time.Time{ts}, buffer, dsv, tbi)
 	}
 	assert.Nil(t, err)
 	metadata.WALFile.FlushToWAL()
@@ -337,7 +337,7 @@ func TestDelete(t *testing.T) {
 	err := metadata.CatalogDir.AddTimeBucket(tbk, tbi)
 	assert.Nil(t, err)
 
-	writer, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
+	writer, err := executor.NewWriter(metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 
 	row := OHLCtest{0, 100., 200., 300., 400.}
@@ -351,7 +351,7 @@ func TestDelete(t *testing.T) {
 		tsA = append(tsA, ts)
 		buffer, _ = Serialize(buffer, row)
 	}
-	writer.WriteRecords(tsA, buffer, dsv)
+	writer.WriteRecords(tsA, buffer, dsv, tbi)
 	assert.Nil(t, err)
 	metadata.WALFile.FlushToWAL()
 	metadata.WALFile.CreateCheckpoint()
@@ -669,12 +669,12 @@ func TestAddSymbolThenWrite(t *testing.T) {
 	pr, _ := q.Parse()
 	tbi, err := metadata.CatalogDir.GetLatestTimeBucketInfoFromKey(tbk)
 	assert.Nil(t, err)
-	w, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
+	w, err := executor.NewWriter(metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 	ts := time.Now().UTC()
 	row := OHLCVtest{0, 100., 200., 300., 400., 1000}
 	buffer, _ := Serialize([]byte{}, row)
-	w.WriteRecords([]time.Time{ts}, buffer, dsv)
+	w.WriteRecords([]time.Time{ts}, buffer, dsv, tbi)
 	assert.Nil(t, err)
 	err = metadata.WALFile.FlushToWAL()
 	assert.Nil(t, err)
@@ -717,12 +717,12 @@ func TestWriter(t *testing.T) {
 		2016,
 		dsv, FIXED)
 
-	writer, err := executor.NewWriter(tbi, metadata.CatalogDir, metadata.WALFile)
+	writer, err := executor.NewWriter(metadata.CatalogDir, metadata.WALFile)
 	assert.Nil(t, err)
 	ts := time.Now().UTC()
 	row := OHLCtest{0, 100., 200., 300., 400.}
 	buffer, _ := Serialize([]byte{}, row)
-	writer.WriteRecords([]time.Time{ts}, buffer, tbi.GetDataShapes())
+	writer.WriteRecords([]time.Time{ts}, buffer, tbi.GetDataShapes(), tbi)
 	assert.Nil(t, err)
 	metadata.WALFile.FlushToWAL()
 	metadata.WALFile.CreateCheckpoint()

--- a/executor/wal_test.go
+++ b/executor/wal_test.go
@@ -356,7 +356,7 @@ func addTGData(root *catalog.Directory, walFile *executor.WALFileType,
 			csm[key] = cs
 			tbi, err := root.GetLatestTimeBucketInfoFromKey(&key)
 			tbiByKey[key] = tbi
-			writerByKey[key], err = executor.NewWriter(tbi, root, walFile)
+			writerByKey[key], err = executor.NewWriter(root, walFile)
 			if err != nil {
 				fmt.Printf("Failed to create a new writer")
 				return nil, err
@@ -398,7 +398,7 @@ func addTGData(root *catalog.Directory, walFile *executor.WALFileType,
 			buffer = append(buffer, io.DataToByteSlice(low[i])...)
 			buffer = append(buffer, io.DataToByteSlice(close[i])...)
 		}
-		writerByKey[key].WriteRecords(timestamps, buffer, tbiByKey[key].GetDataShapesWithEpoch())
+		writerByKey[key].WriteRecords(timestamps, buffer, tbiByKey[key].GetDataShapesWithEpoch(), tbiByKey[key])
 	}
 
 	return queryFiles, nil


### PR DESCRIPTION
## WHAT
- remove TimeBucketInfo from Writer struct params and add it as an argument of writer.WriteRecords function

## WHY
- refactor: We want to share a writer for multiple write requests in the near future