### PR TITLE
refactor: use non-static WriteCSM function

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -155,7 +155,11 @@ func executeStart(_ *cobra.Command, _ []string) error {
 	log.Info("startup time: %s", startupTime)
 
 	// New server.
-	server, _ := frontend.NewServer(config.RootDirectory, instanceConfig.CatalogDir)
+	writer, err := executor.NewWriter(instanceConfig.CatalogDir, instanceConfig.WALFile)
+	if err != nil {
+		panic("init writer: " + err.Error())
+	}
+	server, _ := frontend.NewServer(config.RootDirectory, instanceConfig.CatalogDir, writer)
 
 	// Set rpc handler.
 	log.Info("launching rpc data server...")

--- a/executor/writer.go
+++ b/executor/writer.go
@@ -243,6 +243,102 @@ func WriteBufferToFileIndirect(fp *os.File, buffer wal.OffsetIndexBuffer, varRec
 	return err
 }
 
+// WriteCSM has the same logic as the executor.WriteCSM function.
+// In order to improve testability, use this function instead of the static WriteCSM function.
+func (w *Writer) WriteCSM(csm io.ColumnSeriesMap, isVariableLength bool) error {
+	// WRITE is not allowed on a replica
+	if utils.InstanceConfig.Replication.MasterHost != "" {
+		return errors.New("write is not allowed on replica")
+	}
+
+	start := time.Now()
+	for tbk, cs := range csm {
+		tf, err := tbk.GetTimeFrame()
+		if err != nil {
+			return err
+		}
+
+		/*
+			Prepare data for writing
+		*/
+		var alignData bool
+		times, err := cs.GetTime()
+		if err != nil {
+			return err
+		}
+		if isVariableLength {
+			cs.Remove("Nanoseconds")
+			alignData = false
+		}
+
+		tbi, err := w.root.GetLatestTimeBucketInfoFromKey(&tbk)
+		if err != nil {
+			/*
+				If we can't get the info, we try here to add a new one
+			*/
+			var recordType io.EnumRecordType
+			if isVariableLength {
+				recordType = io.VARIABLE
+			} else {
+				recordType = io.FIXED
+			}
+
+			t, err := cs.GetTime()
+			if err != nil {
+				return err
+			}
+			if len(t) == 0 {
+				continue
+			}
+
+			year := int16(t[0].Year())
+			tbi = io.NewTimeBucketInfo(
+				*tf,
+				tbk.GetPathToYearFiles(w.root.GetPath()),
+				"Created By Writer", year,
+				cs.GetDataShapes(), recordType)
+
+			/*
+				Verify there is an available TimeBucket for the destination
+			*/
+			if err := w.root.AddTimeBucket(&tbk, tbi); err != nil {
+				// If File Exists error, ignore it, otherwise return the error
+				if !strings.Contains(err.Error(), "Can not overwrite file") && !strings.Contains(err.Error(), "file exists") {
+					return err
+				}
+			}
+		}
+		// Check if the previously-written data schema matches the input
+		columnMismatchError := "unable to match data columns (%v) to bucket columns (%v)"
+		dbDSV := tbi.GetDataShapesWithEpoch()
+		csDSV := cs.GetDataShapes()
+		if len(dbDSV) != len(csDSV) {
+			return fmt.Errorf(columnMismatchError, csDSV, dbDSV)
+		}
+		missing, coercion := GetMissingAndTypeCoercionColumns(dbDSV, csDSV)
+		if missing != nil {
+			return fmt.Errorf(columnMismatchError, csDSV, dbDSV)
+		}
+
+		if coercion != nil {
+			for _, dbDS := range coercion {
+				if err := cs.CoerceColumnType(dbDS.Name, dbDS.Type); err != nil {
+					csType := GetElementType(cs.GetColumn(dbDS.Name))
+					log.Error("[%s] error coercing %s from %s to %s", tbk.GetItemKey(), dbDS.Name, csType.String(), dbDS.Type.String())
+					return err
+				}
+			}
+		}
+
+		rowData := cs.ToRowSeries(tbk, alignData).GetData()
+		w.WriteRecords(times, rowData, dbDSV, tbi)
+	}
+
+	w.walFile.RequestFlush()
+	metrics.WriteCSMDuration.Observe(time.Since(start).Seconds())
+	return nil
+}
+
 // WriteCSM writes ColumnSeriesMap (csm) to each destination file, and flush it to the disk,
 // isVariableLength is set to true if the record content is variable-length type. WriteCSM
 // also verifies the DataShapeVector of the incoming ColumnSeriesMap matches the on-disk

--- a/frontend/query_test.go
+++ b/frontend/query_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func setup(t *testing.T, testName string,
-) (tearDown func(), rootDir string, metadata *executor.InstanceMetadata) {
+) (tearDown func(), rootDir string, metadata *executor.InstanceMetadata, writer *executor.Writer) {
 	t.Helper()
 
 	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("frontend_test-%s", testName))
@@ -24,15 +24,16 @@ func setup(t *testing.T, testName string,
 	metadata, _, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
 	atomic.StoreUint32(&frontend.Queryable, uint32(1))
 
-	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, metadata
+	writer, _ = executor.NewWriter(metadata.CatalogDir, metadata.WALFile)
+	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, metadata, writer
 }
 
 func _TestQueryCustomTimeframes(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "_TestQueryCustomTimeframes")
+	tearDown, rootDir, metadata, writer := setup(t, "_TestQueryCustomTimeframes")
 	defer tearDown()
 
 	//TODO: Support custom timeframes
-	service := frontend.NewDataService(rootDir, metadata.CatalogDir)
+	service := frontend.NewDataService(rootDir, metadata.CatalogDir, writer)
 	service.Init()
 
 	args := &frontend.MultiQueryRequest{
@@ -90,10 +91,10 @@ func _TestQueryCustomTimeframes(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "TestQuery")
+	tearDown, rootDir, metadata, writer := setup(t, "TestQuery")
 	defer tearDown()
 
-	service := frontend.NewDataService(rootDir, metadata.CatalogDir)
+	service := frontend.NewDataService(rootDir, metadata.CatalogDir, writer)
 	service.Init()
 
 	args := &frontend.MultiQueryRequest{
@@ -126,10 +127,10 @@ func TestQuery(t *testing.T) {
 }
 
 func TestQueryFirstN(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "TestQueryFirstN")
+	tearDown, rootDir, metadata, writer := setup(t, "TestQueryFirstN")
 	defer tearDown()
 
-	service := frontend.NewDataService(rootDir, metadata.CatalogDir)
+	service := frontend.NewDataService(rootDir, metadata.CatalogDir, writer)
 	service.Init()
 
 	args := &frontend.MultiQueryRequest{
@@ -160,10 +161,10 @@ func TestQueryFirstN(t *testing.T) {
 }
 
 func TestQueryRange(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "TestQueryRange")
+	tearDown, rootDir, metadata, writer := setup(t, "TestQueryRange")
 	defer tearDown()
 
-	service := frontend.NewDataService(rootDir, metadata.CatalogDir)
+	service := frontend.NewDataService(rootDir, metadata.CatalogDir, writer)
 	service.Init()
 	{
 		args := &frontend.MultiQueryRequest{
@@ -210,10 +211,10 @@ func TestQueryRange(t *testing.T) {
 }
 
 func TestQueryNpyMulti(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "TestQueryNpyMulti")
+	tearDown, rootDir, metadata, writer := setup(t, "TestQueryNpyMulti")
 	defer tearDown()
 
-	service := frontend.NewDataService(rootDir, metadata.CatalogDir)
+	service := frontend.NewDataService(rootDir, metadata.CatalogDir, writer)
 	service.Init()
 
 	args := &frontend.MultiQueryRequest{
@@ -243,10 +244,10 @@ func TestQueryNpyMulti(t *testing.T) {
 }
 
 func TestQueryMulti(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "TestQueryMulti")
+	tearDown, rootDir, metadata, writer := setup(t, "TestQueryMulti")
 	defer tearDown()
 
-	service := frontend.NewDataService(rootDir, metadata.CatalogDir)
+	service := frontend.NewDataService(rootDir, metadata.CatalogDir, writer)
 	service.Init()
 
 	args := &frontend.MultiQueryRequest{
@@ -287,10 +288,10 @@ func TestQueryMulti(t *testing.T) {
 }
 
 func TestListSymbols(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "TestListSymbols")
+	tearDown, rootDir, metadata, writer := setup(t, "TestListSymbols")
 	defer tearDown()
 
-	service := frontend.NewDataService(rootDir, metadata.CatalogDir)
+	service := frontend.NewDataService(rootDir, metadata.CatalogDir, writer)
 	service.Init()
 
 	var response frontend.ListSymbolsResponse
@@ -323,10 +324,10 @@ func TestListSymbols(t *testing.T) {
 }
 
 func TestFunctions(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "TestFunctions")
+	tearDown, rootDir, metadata, writer := setup(t, "TestFunctions")
 	defer tearDown()
 
-	service := frontend.NewDataService(rootDir, metadata.CatalogDir)
+	service := frontend.NewDataService(rootDir, metadata.CatalogDir, writer)
 	service.Init()
 
 	call := "candlecandler('1Min',Open,High,Low,Close,Sum::Volume)"

--- a/frontend/server_test.go
+++ b/frontend/server_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestNewServer(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "TestNewServer")
+	tearDown, rootDir, metadata, writer := setup(t, "TestNewServer")
 	defer tearDown()
 
-	serv, _ := frontend.NewServer(rootDir, metadata.CatalogDir)
+	serv, _ := frontend.NewServer(rootDir, metadata.CatalogDir, writer)
 	assert.True(t, serv.HasMethod("DataService.Query"))
 }

--- a/frontend/write.go
+++ b/frontend/write.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alpacahq/marketstore/v4/executor"
 	"github.com/alpacahq/marketstore/v4/utils"
 	"github.com/alpacahq/marketstore/v4/utils/io"
 )
@@ -40,7 +39,7 @@ func (s *DataService) Write(r *http.Request, reqs *MultiWriteRequest, response *
 			response.appendResponse(err)
 			continue
 		}
-		if err = executor.WriteCSM(csm, req.IsVariableLength); err != nil {
+		if err = s.writer.WriteCSM(csm, req.IsVariableLength); err != nil {
 			response.appendResponse(err)
 			continue
 		}

--- a/frontend/write_test.go
+++ b/frontend/write_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestWrite(t *testing.T) {
-	tearDown, rootDir, metadata := setup(t, "TestWrite")
+	tearDown, rootDir, metadata, writer := setup(t, "TestWrite")
 	defer tearDown()
 
-	service := frontend.NewDataService(rootDir, metadata.CatalogDir)
+	service := frontend.NewDataService(rootDir, metadata.CatalogDir, writer)
 	service.Init()
 
 	qargs := &frontend.MultiQueryRequest{


### PR DESCRIPTION
## WHAT
- add WriteCSM function to Writer struct and use it instead of static WriteCSM function


## WHY
- refactor to improve testability