### PR TITLE
refactor: use only lower case for agg function name

### DIFF
--- a/sqlparser/all_test.go
+++ b/sqlparser/all_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -232,7 +233,7 @@ func TestAggregation(t *testing.T) {
 	agg := sqlparser.AggRegistry["blargle"] // aggregator not found
 	assert.Nil(t, agg)
 
-	agg = sqlparser.AggRegistry["TickCandler"]
+	agg = sqlparser.AggRegistry[strings.ToLower("TickCandler")]
 	assert.NotNil(t, agg)
 	tickCandler, argMap := agg.New()
 	dsPrice := io.DataShape{Name: "One", Type: io.FLOAT32}

--- a/sqlparser/registry.go
+++ b/sqlparser/registry.go
@@ -13,20 +13,12 @@ import (
 )
 
 var AggRegistry = map[string]uda.AggInterface{
-	"TickCandler":   &tickcandler.TickCandler{},
 	"tickcandler":   &tickcandler.TickCandler{},
-	"CandleCandler": &candlecandler.CandleCandler{},
 	"candlecandler": &candlecandler.CandleCandler{},
-	"Count":         &count.Count{},
 	"count":         &count.Count{},
-	"Min":           &min.Min{},
 	"min":           &min.Min{},
-	"Max":           &max.Max{},
 	"max":           &max.Max{},
-	"Avg":           &avg.Avg{},
 	"avg":           &avg.Avg{},
-	"Gap":           &gap.Gap{},
 	"gap":           &gap.Gap{},
-	"Adjust":        &adjust.Adjust{},
 	"adjust":        &adjust.Adjust{},
 }


### PR DESCRIPTION
## WHAT
- remove aggregator function names in camelCase

## WHY
- refactor. the function name is already being compared after `ToLower` function, so only function names in lower cases are necessary
https://github.com/alpacahq/marketstore/blob/5b3671d40bf7820a7b982cef1899c8e3a24ba0a6/frontend/query.go#L356