### PR TITLE
refactor: include tbk to arguments of Accum function

### DIFF
--- a/contrib/candler/candlecandler/all_test.go
+++ b/contrib/candler/candlecandler/all_test.go
@@ -48,6 +48,7 @@ func TestCandleCandler(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test data range query - across year
+	tbk := io.NewTimeBucketKey("OHLCV/AAPL/1Min")
 	q := planner.NewQuery(metadata.CatalogDir)
 	q.AddRestriction("AttributeGroup", "OHLCV")
 	q.AddRestriction("Symbol", "AAPL")
@@ -63,7 +64,7 @@ func TestCandleCandler(t *testing.T) {
 		epoch := cs.GetEpoch()
 		assert.Equal(t, time.Unix(epoch[0], 0).UTC(), startDate)
 		assert.Equal(t, time.Unix(epoch[len(epoch)-1], 0).UTC(), endDate)
-		err = cdl.Accum(cs, metadata.CatalogDir)
+		err = cdl.Accum(*tbk, cs, metadata.CatalogDir)
 		assert.Nil(t, err)
 	}
 	cols := cdl.Output()

--- a/contrib/candler/candlecandler/candlecandler.go
+++ b/contrib/candler/candlecandler/candlecandler.go
@@ -55,7 +55,7 @@ func (ca *CandleCandler) GetInitArgs() []io.DataShape {
 /*
 	Accum() sends new data to the aggregate
 */
-func (ca *CandleCandler) Accum(cols io.ColumnInterface, _ *catalog.Directory) error {
+func (ca *CandleCandler) Accum(_ io.TimeBucketKey, cols io.ColumnInterface, _ *catalog.Directory) error {
 	if cols.Len() == 0 {
 		return fmt.Errorf("Empty input to Accum")
 	}
@@ -117,12 +117,4 @@ func (ca *CandleCandler) Accum(cols io.ColumnInterface, _ *catalog.Directory) er
 		candle.Count++
 	}
 	return nil
-}
-
-/*
-Utility Functions
-*/
-
-func (ca *CandleCandler) SetTimeBucketKey(tbk io.TimeBucketKey) {
-	// for compatibility reasons only
 }

--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -47,7 +47,7 @@ func TestTickCandler(t *testing.T) {
 	/*
 		We expect an error with an empty input arg set
 	*/
-	err = cdl.Accum(&io.Rows{}, metadata.CatalogDir)
+	err = cdl.Accum(io.TimeBucketKey{}, &io.Rows{}, metadata.CatalogDir)
 	assert.NotNil(t, err)
 
 	/*
@@ -58,6 +58,7 @@ func TestTickCandler(t *testing.T) {
 	/*
 		Read some tick data
 	*/
+	tbk := io.NewTimeBucketKeyFromString("TEST/TICK/1Min")
 	q := planner.NewQuery(metadata.CatalogDir)
 	q.AddRestriction("Symbol", "TEST")
 	q.AddRestriction("AttributeGroup", "TICK")
@@ -71,7 +72,7 @@ func TestTickCandler(t *testing.T) {
 	assert.Len(t, csm, 1)
 	for _, cs := range csm {
 		assert.Equal(t, cs.Len(), 200)
-		err = cdl.Accum(cs, metadata.CatalogDir)
+		err = cdl.Accum(*tbk, cs, metadata.CatalogDir)
 		assert.Nil(t, err)
 	}
 	rows := cdl.Output()
@@ -93,7 +94,7 @@ func TestTickCandler(t *testing.T) {
 	cdl.Reset()
 	for _, cs := range csm {
 		assert.Equal(t, cs.Len(), 200)
-		err = cdl.Accum(cs, metadata.CatalogDir)
+		err = cdl.Accum(*tbk, cs, metadata.CatalogDir)
 		assert.Nil(t, err)
 	}
 	rows = cdl.Output()

--- a/contrib/candler/tickcandler/tickcandler.go
+++ b/contrib/candler/tickcandler/tickcandler.go
@@ -52,7 +52,7 @@ func (ca *TickCandler) GetInitArgs() []io.DataShape {
 /*
 	Accum() sends new data to the aggregate
 */
-func (ca *TickCandler) Accum(cols io.ColumnInterface, _ *catalog.Directory) error {
+func (ca *TickCandler) Accum(_ io.TimeBucketKey, cols io.ColumnInterface, _ *catalog.Directory) error {
 	if cols.Len() == 0 {
 		return fmt.Errorf("Empty input to Accum")
 	}
@@ -96,12 +96,4 @@ func (ca *TickCandler) Accum(cols io.ColumnInterface, _ *catalog.Directory) erro
 		candle.Count++
 	}
 	return nil
-}
-
-/*
-Utility Functions
-*/
-
-func (ca *TickCandler) SetTimeBucketKey(tbk io.TimeBucketKey) {
-	// for compatibility reasons only
 }

--- a/frontend/query.go
+++ b/frontend/query.go
@@ -367,7 +367,6 @@ func runAggFunctions(callChain []string, csInput *io.ColumnSeries, tbk io.TimeBu
 			return nil, fmt.Errorf("No function in the UDA Registry named \"%s\"", aggName)
 		}
 		aggfunc, argMap := agg.New()
-		aggfunc.SetTimeBucketKey(tbk)
 
 		err = argMap.PrepareArguments(parameterList)
 		if err != nil {
@@ -395,7 +394,7 @@ func runAggFunctions(callChain []string, csInput *io.ColumnSeries, tbk io.TimeBu
 		/*
 			Execute the aggregate function
 		*/
-		if err = aggfunc.Accum(csInput, catDir); err != nil {
+		if err = aggfunc.Accum(tbk, csInput, catDir); err != nil {
 			return nil, err
 		}
 		cs = aggfunc.Output()

--- a/sqlparser/all_test.go
+++ b/sqlparser/all_test.go
@@ -239,7 +239,7 @@ func TestAggregation(t *testing.T) {
 	dsPrice := io.DataShape{Name: "One", Type: io.FLOAT32}
 	argMap.MapRequiredColumn("CandlePrice", dsPrice)
 	assert.Nil(t, tickCandler.Init("1Min"))
-	tickCandler.Accum(cs, metadata.CatalogDir)
+	tickCandler.Accum(io.TimeBucketKey{}, cs, metadata.CatalogDir)
 	result := tickCandler.Output()
 	r_epoch := result.GetColumn("Epoch").([]int64)
 	r_open := result.GetColumn("Open").([]float32)
@@ -291,7 +291,7 @@ func TestCount(t *testing.T) {
 	tickCandler, argMap := agg.New()
 	argMap.MapRequiredColumn("*", io.DataShape{Name: "Epoch", Type: io.INT64})
 	assert.Nil(t, tickCandler.Init())
-	tickCandler.Accum(cs, metadata.CatalogDir)
+	tickCandler.Accum(io.TimeBucketKey{}, cs, metadata.CatalogDir)
 	result := tickCandler.Output()
 	count := result.GetColumn("Count").([]int64)
 	assert.Equal(t, count[0], int64(5))

--- a/sqlparser/selectrelation.go
+++ b/sqlparser/selectrelation.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/alpacahq/marketstore/v4/catalog"
 	"strings"
 	"time"
+
+	"github.com/alpacahq/marketstore/v4/catalog"
 
 	"github.com/alpacahq/marketstore/v4/executor"
 	"github.com/alpacahq/marketstore/v4/planner"
@@ -519,7 +520,13 @@ func (sr *SelectRelation) Materialize(catDir *catalog.Directory) (outputColumnSe
 				/*
 					Execute the aggregate function
 				*/
-				err := aggfunc.Accum(outputColumnSeries, catDir)
+				var tbk io.TimeBucketKey
+				if key == nil { // if the input does not have tbk (e.g. input is a result from inner subquery)
+					tbk = io.TimeBucketKey{}
+				} else {
+					tbk = *key
+				}
+				err := aggfunc.Accum(tbk, outputColumnSeries, catDir)
 				if err != nil {
 					return nil, err
 				}

--- a/uda/adjust/adjust.go
+++ b/uda/adjust/adjust.go
@@ -35,8 +35,6 @@ type Adjust struct {
 	epochs         []int64
 	output         map[io.DataShape]interface{}
 	skippedColumns map[string]interface{}
-
-	tbk io.TimeBucketKey
 }
 
 func (adj *Adjust) GetRequiredArgs() []io.DataShape {
@@ -91,15 +89,11 @@ func (adj *Adjust) Init(args ...interface{}) error {
 	return nil
 }
 
-func (adj *Adjust) SetTimeBucketKey(tbk io.TimeBucketKey) {
-	adj.tbk = tbk
-}
-
 func (adj *Adjust) Reset() {
 	// intentionally left empty
 }
 
-func (adj *Adjust) Accum(cols io.ColumnInterface, catalogDir *catalog.Directory) error {
+func (adj *Adjust) Accum(tbk io.TimeBucketKey, cols io.ColumnInterface, catalogDir *catalog.Directory) error {
 	epochs, ok := cols.GetColumn("Epoch").([]int64)
 	if !ok {
 		return errors.New("adjust: Input data must have an Epoch column")
@@ -117,7 +111,7 @@ func (adj *Adjust) Accum(cols io.ColumnInterface, catalogDir *catalog.Directory)
 		}
 	}
 
-	symbol := adj.tbk.GetItemInCategory("Symbol")
+	symbol := tbk.GetItemInCategory("Symbol")
 	rateChanges := GetRateChanges(symbol, adj.AdjustSplit, adj.AdjustDividend,
 		catalogDir,
 	)

--- a/uda/adjust/adjust_test.go
+++ b/uda/adjust/adjust_test.go
@@ -63,7 +63,6 @@ func evalCase(t *testing.T, testCase AdjustTestCase, catDir *catalog.Directory) 
 	tbk := io.NewTimeBucketKeyFromString(tbkStr)
 	adj := Adjust{}
 	aggfunc, _ := adj.New()
-	aggfunc.SetTimeBucketKey(*tbk)
 
 	rateChangeCache[CacheKey{symbol, true, true}] = RateChangeCache{
 		Changes:   testCase.rateChanges,
@@ -74,7 +73,7 @@ func evalCase(t *testing.T, testCase AdjustTestCase, catDir *catalog.Directory) 
 	inputCs := toColumnSeries(testCase.input)
 
 	aggfunc.Init()
-	aggfunc.Accum(inputCs, catDir)
+	aggfunc.Accum(*tbk, inputCs, catDir)
 
 	outputCs := aggfunc.Output()
 

--- a/uda/avg/avg.go
+++ b/uda/avg/avg.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/alpacahq/marketstore/v4/catalog"
 	"github.com/alpacahq/marketstore/v4/uda"
 	"github.com/alpacahq/marketstore/v4/utils/functions"
 	"github.com/alpacahq/marketstore/v4/utils/io"
-	"github.com/alpacahq/marketstore/v4/catalog"
 )
 
 var (
@@ -43,7 +43,7 @@ func (av *Avg) GetInitArgs() []io.DataShape {
 /*
 	Accum() sends new data to the aggregate
 */
-func (av *Avg) Accum(cols io.ColumnInterface, _ *catalog.Directory) error {
+func (av *Avg) Accum(_ io.TimeBucketKey, cols io.ColumnInterface, _ *catalog.Directory) error {
 	if cols.Len() == 0 {
 		return nil
 	}
@@ -103,14 +103,4 @@ func (av *Avg) Output() *io.ColumnSeries {
 func (av *Avg) Reset() {
 	av.Avg = 0
 	av.Count = 0
-}
-
-/*
-Utility Functions
-*/
-
-/*
-	SetTimeBucketKey()
-*/
-func (av *Avg) SetTimeBucketKey(tbk io.TimeBucketKey) {
 }

--- a/uda/count/count.go
+++ b/uda/count/count.go
@@ -48,7 +48,7 @@ func (ca *Count) GetInitArgs() []io.DataShape {
 /*
 	Accum() sends new data to the aggregate
 */
-func (ca *Count) Accum(cols io.ColumnInterface, _ *catalog.Directory) error {
+func (ca *Count) Accum(tbk io.TimeBucketKey, cols io.ColumnInterface, _ *catalog.Directory) error {
 	ca.Sum += int64(cols.Len())
 	return nil
 }
@@ -93,14 +93,4 @@ func (ca *Count) Output() *io.ColumnSeries {
 */
 func (ca *Count) Reset() {
 	ca.Sum = 0
-}
-
-/*
-Utility Functions
-*/
-
-/*
-	SetTimeBucketKey()
-*/
-func (ca *Count) SetTimeBucketKey(tbk io.TimeBucketKey) {
 }

--- a/uda/datatypes.go
+++ b/uda/datatypes.go
@@ -41,7 +41,8 @@ type AggInterface interface {
 		Accum() sends new data to the aggregate
 	*/
 	//Accum(ts []time.Time, rows io.Rows)
-	Accum(io.ColumnInterface, *catalog.Directory) error // The parameter is one of; ColumnSeries or Rows
+	Accum(io.TimeBucketKey, io.ColumnInterface, *catalog.Directory,
+	) error // The parameter is one of; ColumnSeries or Rows
 	/*
 		Output() returns the currently valid output of this aggregate
 	*/
@@ -50,11 +51,6 @@ type AggInterface interface {
 		Reset() puts the aggregate state back to "new"
 	*/
 	Reset()
-
-	/*
-		SetTimeBucketKey() sets the TimeBucketKey for the aggregator function
-	*/
-	SetTimeBucketKey(io.TimeBucketKey)
 }
 
 //TODO: This is where we break out a UDF API

--- a/uda/gap/gap.go
+++ b/uda/gap/gap.go
@@ -58,7 +58,7 @@ func (g *Gap) GetInitArgs() []io.DataShape {
 
 // Accum() sends new data to the aggregate
 // Use Zscore to find out the big hole in data.
-func (g *Gap) Accum(cols io.ColumnInterface, _ *catalog.Directory) error {
+func (g *Gap) Accum(_ io.TimeBucketKey, cols io.ColumnInterface, _ *catalog.Directory) error {
 	g.BigGapIdxs = []int{}
 	g.Input = &cols
 
@@ -192,10 +192,4 @@ func (g *Gap) Reset() {
 	g.BigGapIdxs = []int{}
 	g.Input = nil
 	g.avgGapIntervalSeconds = -1
-}
-
-/*
-	SetTimeBucketKey()
-*/
-func (g *Gap) SetTimeBucketKey(tbk io.TimeBucketKey) {
 }

--- a/uda/max/max.go
+++ b/uda/max/max.go
@@ -43,7 +43,7 @@ func (ma *Max) GetInitArgs() []io.DataShape {
 /*
 	Accum() sends new data to the aggregate
 */
-func (ma *Max) Accum(cols io.ColumnInterface, _ *catalog.Directory) error {
+func (ma *Max) Accum(_ io.TimeBucketKey, cols io.ColumnInterface, _ *catalog.Directory) error {
 	if cols.Len() == 0 {
 		return nil
 	}
@@ -107,14 +107,4 @@ func (ma *Max) Output() *io.ColumnSeries {
 func (ma *Max) Reset() {
 	ma.Max = 0
 	ma.IsInitialized = false
-}
-
-/*
-Utility Functions
-*/
-
-/*
-	SetTimeBucketKey()
-*/
-func (ma *Max) SetTimeBucketKey(tbk io.TimeBucketKey) {
 }

--- a/uda/min/min.go
+++ b/uda/min/min.go
@@ -43,7 +43,7 @@ func (mn *Min) GetInitArgs() []io.DataShape {
 /*
 	Accum() sends new data to the aggregate
 */
-func (mn *Min) Accum(cols io.ColumnInterface, _ *catalog.Directory) error {
+func (mn *Min) Accum(_ io.TimeBucketKey, cols io.ColumnInterface, _ *catalog.Directory) error {
 	if cols.Len() == 0 {
 		return nil
 	}
@@ -107,14 +107,4 @@ func (mn *Min) Output() *io.ColumnSeries {
 func (mn *Min) Reset() {
 	mn.Min = 0
 	mn.IsInitialized = false
-}
-
-/*
-Utility Functions
-*/
-
-/*
-	SetTimeBucketKey()
-*/
-func (mn *Min) SetTimeBucketKey(tbk io.TimeBucketKey) {
 }


### PR DESCRIPTION
## WHAT
include TimeBucketKey name in Accum function arguments

## WHY
In order to improve testability of Aggregator functions, AggregatorFunctions need to be a static function (not a stateful function). By removing "SetTimeBucketKey" function from aggfunc and include TimeBucketKey in the arguments, aggfunc becomes more static.