### PR TITLE
fix: ignore test files for coverage calculation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,8 +11,9 @@ coverage:
     patch:
       default:
         target: 70%
-# ignore:
-#   - xxx
+
+ignore:
+  - "tests"  # ignore integration tests under tests directory
 
 comment:
   layout: "header, diff, changes, tree"


### PR DESCRIPTION
## WHAT
- exclude integration test files for the calculation of test coverage.

## WHY
- without the rule, the more integration tests are added the worse test coverage gets