### PR TITLE
fix: remove Output function from AggFunc

### DIFF
--- a/contrib/candler/candlecandler/all_test.go
+++ b/contrib/candler/candlecandler/all_test.go
@@ -68,17 +68,17 @@ func TestCandleCandler(t *testing.T) {
 	scanner, err := executor.NewReader(parsed)
 	assert.Nil(t, err)
 	csm, _ := scanner.Read()
+	var output *io.ColumnSeries
 	for _, cs := range csm {
 		epoch := cs.GetEpoch()
 		assert.Equal(t, time.Unix(epoch[0], 0).UTC(), startDate)
 		assert.Equal(t, time.Unix(epoch[len(epoch)-1], 0).UTC(), endDate)
-		err = cdl.Accum(*tbk, am, cs, metadata.CatalogDir)
+		output, err = cdl.Accum(*tbk, am, cs, metadata.CatalogDir)
 		assert.Nil(t, err)
 	}
-	cols := cdl.Output()
-	assert.Equal(t, cols.Len(), 4)
-	vsum := cols.GetColumn("Volume_SUM")
-	vavg := cols.GetColumn("Volume_AVG")
+	assert.Equal(t, output.Len(), 4)
+	vsum := output.GetColumn("Volume_SUM")
+	vavg := output.GetColumn("Volume_AVG")
 	/*
 		There should be four 5Min candles in the interval 12:00 -> 12:15
 		12:00, 12:05, 12:10 and 12:15

--- a/contrib/candler/candlecandler/candlecandler.go
+++ b/contrib/candler/candlecandler/candlecandler.go
@@ -57,9 +57,9 @@ func (ca *CandleCandler) GetInitArgs() []io.DataShape {
 */
 func (ca *CandleCandler) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap,
 	cols io.ColumnInterface, _ *catalog.Directory,
-) error {
+) (*io.ColumnSeries, error) {
 	if cols.Len() == 0 {
-		return fmt.Errorf("Empty input to Accum")
+		return nil, fmt.Errorf("Empty input to Accum")
 	}
 	/*
 		Get the input column for "Price"
@@ -70,19 +70,19 @@ func (ca *CandleCandler) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap
 	closeCols := argMap.GetMappedColumns(requiredColumns[3].Name)
 	open, err := candler.GetAverageColumnFloat32(cols, openCols)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	high, err := candler.GetAverageColumnFloat32(cols, highCols)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	low, err := candler.GetAverageColumnFloat32(cols, lowCols)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	close, err := candler.GetAverageColumnFloat32(cols, closeCols)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	/*
@@ -90,7 +90,7 @@ func (ca *CandleCandler) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap
 	*/
 	ts, err := cols.GetTime()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	/*
 		Update each candle
@@ -102,7 +102,7 @@ func (ca *CandleCandler) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap
 		for _, name := range ca.AccumSumNames {
 			sumCols[name], err = uda.ColumnToFloat32(cols, name)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
@@ -118,5 +118,5 @@ func (ca *CandleCandler) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap
 		}
 		candle.Count++
 	}
-	return nil
+	return ca.Output(), nil
 }

--- a/contrib/candler/candler.go
+++ b/contrib/candler/candler.go
@@ -75,8 +75,8 @@ OVERRIDES - these methods should be overridden in a concrete implementation of t
 	OVERRIDE THIS METHOD
 	Accum() sends new data to the aggregate
 */
-func (ca *Candler) Accum(cols io.ColumnInterface) error {
-	return fmt.Errorf("Accum called from base class, must override implementation")
+func (ca *Candler) Accum(cols io.ColumnInterface) (*io.ColumnSeries, error) {
+	return nil, fmt.Errorf("Accum called from base class, must override implementation")
 }
 
 /*

--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -52,7 +52,7 @@ func TestTickCandler(t *testing.T) {
 	/*
 		We expect an error with an empty input arg set
 	*/
-	err = cdl.Accum(io.TimeBucketKey{}, am, &io.Rows{}, metadata.CatalogDir)
+	_, err = cdl.Accum(io.TimeBucketKey{}, am, &io.Rows{}, metadata.CatalogDir)
 	assert.NotNil(t, err)
 
 	/*
@@ -75,12 +75,12 @@ func TestTickCandler(t *testing.T) {
 	csm, err := reader.Read()
 	assert.Nil(t, err)
 	assert.Len(t, csm, 1)
+	var rows *io.ColumnSeries
 	for _, cs := range csm {
 		assert.Equal(t, cs.Len(), 200)
-		err = cdl.Accum(*tbk, am, cs, metadata.CatalogDir)
+		rows, err = cdl.Accum(*tbk, am, cs, metadata.CatalogDir)
 		assert.Nil(t, err)
 	}
-	rows := cdl.Output()
 	assert.Equal(t, rows.Len(), 4)
 	tsa, err := rows.GetTime()
 	tbase := time.Date(2016, time.December, 31, 2, 59, 0, 0, time.UTC)
@@ -100,10 +100,9 @@ func TestTickCandler(t *testing.T) {
 	assert.Nil(t, err)
 	for _, cs := range csm {
 		assert.Equal(t, cs.Len(), 200)
-		err = cdl.Accum(*tbk, am, cs, metadata.CatalogDir)
+		rows, err = cdl.Accum(*tbk, am, cs, metadata.CatalogDir)
 		assert.Nil(t, err)
 	}
-	rows = cdl.Output()
 	assert.Equal(t, rows.Len(), 4)
 	tsa, err = rows.GetTime()
 	tbase = time.Date(2016, time.December, 31, 2, 59, 0, 0, time.UTC)

--- a/contrib/candler/tickcandler/tickcandler.go
+++ b/contrib/candler/tickcandler/tickcandler.go
@@ -55,9 +55,9 @@ func (ca *TickCandler) GetInitArgs() []io.DataShape {
 */
 func (ca *TickCandler) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap,
 	cols io.ColumnInterface, _ *catalog.Directory,
-) error {
+) (*io.ColumnSeries, error) {
 	if cols.Len() == 0 {
-		return fmt.Errorf("Empty input to Accum")
+		return nil, fmt.Errorf("Empty input to Accum")
 	}
 	/*
 		Get the input column for "Price"
@@ -65,7 +65,7 @@ func (ca *TickCandler) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap,
 	priceCols := argMap.GetMappedColumns(requiredColumns[0].Name)
 	price, err := candler.GetAverageColumnFloat32(cols, priceCols)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	/*
@@ -82,7 +82,7 @@ func (ca *TickCandler) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap,
 		for _, name := range ca.AccumSumNames {
 			sumCols[name], err = uda.ColumnToFloat32(cols, name)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
@@ -98,5 +98,5 @@ func (ca *TickCandler) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap,
 		}
 		candle.Count++
 	}
-	return nil
+	return ca.Output(), nil
 }

--- a/frontend/query.go
+++ b/frontend/query.go
@@ -400,10 +400,9 @@ func runAggFunctions(callChain []string, csInput *io.ColumnSeries, tbk io.TimeBu
 		/*
 			Execute the aggregate function
 		*/
-		if err = aggfunc.Accum(tbk, argMap, csInput, catDir); err != nil {
+		if cs, err = aggfunc.Accum(tbk, argMap, csInput, catDir); err != nil {
 			return nil, err
 		}
-		cs = aggfunc.Output()
 		if cs == nil {
 			return nil, fmt.Errorf(
 				"No result from aggregate %s",

--- a/sqlparser/all_test.go
+++ b/sqlparser/all_test.go
@@ -243,8 +243,7 @@ func TestAggregation(t *testing.T) {
 	dsPrice := io.DataShape{Name: "One", Type: io.FLOAT32}
 	argMap.MapRequiredColumn("CandlePrice", dsPrice)
 	assert.Nil(t, tickCandler.Init(argMap, "1Min"))
-	tickCandler.Accum(io.TimeBucketKey{}, argMap, cs, metadata.CatalogDir)
-	result := tickCandler.Output()
+	result, _ := tickCandler.Accum(io.TimeBucketKey{}, argMap, cs, metadata.CatalogDir)
 	r_epoch := result.GetColumn("Epoch").([]int64)
 	r_open := result.GetColumn("Open").([]float32)
 	r_high := result.GetColumn("High").([]float32)
@@ -296,8 +295,7 @@ func TestCount(t *testing.T) {
 	tickCandler := agg.New()
 	argMap.MapRequiredColumn("*", io.DataShape{Name: "Epoch", Type: io.INT64})
 	assert.Nil(t, tickCandler.Init(argMap))
-	tickCandler.Accum(io.TimeBucketKey{}, argMap, cs, metadata.CatalogDir)
-	result := tickCandler.Output()
+	result, _ := tickCandler.Accum(io.TimeBucketKey{}, argMap, cs, metadata.CatalogDir)
 	count := result.GetColumn("Count").([]int64)
 	assert.Equal(t, count[0], int64(5))
 

--- a/sqlparser/selectrelation.go
+++ b/sqlparser/selectrelation.go
@@ -533,11 +533,10 @@ func (sr *SelectRelation) Materialize(catDir *catalog.Directory) (outputColumnSe
 				} else {
 					tbk = *key
 				}
-				err := aggfunc.Accum(tbk, argMap, outputColumnSeries, catDir)
+				functionResult, err := aggfunc.Accum(tbk, argMap, outputColumnSeries, catDir)
 				if err != nil {
 					return nil, err
 				}
-				functionResult := aggfunc.Output()
 				if functionResult == nil {
 					return nil, fmt.Errorf(
 						"No result from aggregate %s",

--- a/uda/adjust/adjust.go
+++ b/uda/adjust/adjust.go
@@ -89,10 +89,10 @@ func (adj *Adjust) Init(_ *functions.ArgumentMap, args ...interface{}) error {
 
 func (adj *Adjust) Accum(tbk io.TimeBucketKey, _ *functions.ArgumentMap,
 	cols io.ColumnInterface, catalogDir *catalog.Directory,
-) error {
+) (*io.ColumnSeries, error) {
 	epochs, ok := cols.GetColumn("Epoch").([]int64)
 	if !ok {
-		return errors.New("adjust: Input data must have an Epoch column")
+		return nil, errors.New("adjust: Input data must have an Epoch column")
 	}
 	adj.epochs = epochs
 	for _, ds := range cols.GetDataShapes() {
@@ -112,7 +112,7 @@ func (adj *Adjust) Accum(tbk io.TimeBucketKey, _ *functions.ArgumentMap,
 		catalogDir,
 	)
 	if len(rateChanges) == 0 {
-		return nil
+		return adj.Output(), nil
 	}
 
 	// always append a default no-op rate change to help avoid handling edge cases below
@@ -139,7 +139,7 @@ func (adj *Adjust) Accum(tbk io.TimeBucketKey, _ *functions.ArgumentMap,
 			}
 		}
 	}
-	return nil
+	return adj.Output(), nil
 }
 
 func (adj *Adjust) Output() *io.ColumnSeries {

--- a/uda/adjust/adjust_test.go
+++ b/uda/adjust/adjust_test.go
@@ -77,9 +77,7 @@ func evalCase(t *testing.T, testCase AdjustTestCase, catDir *catalog.Directory) 
 	inputCs := toColumnSeries(testCase.input)
 
 	aggfunc.Init(am)
-	aggfunc.Accum(*tbk, am, inputCs, catDir)
-
-	outputCs := aggfunc.Output()
+	outputCs, _ := aggfunc.Accum(*tbk, am, inputCs, catDir)
 
 	outEpochs := outputCs.GetColumn("Epoch").([]int64)
 	outPrice := outputCs.GetColumn("Price").([]float64)

--- a/uda/count/count.go
+++ b/uda/count/count.go
@@ -48,9 +48,9 @@ func (ca *Count) GetInitArgs() []io.DataShape {
 */
 func (ca *Count) Accum(_ io.TimeBucketKey, _ *functions.ArgumentMap,
 	cols io.ColumnInterface, _ *catalog.Directory,
-) error {
+) (*io.ColumnSeries, error) {
 	ca.Sum += int64(cols.Len())
-	return nil
+	return ca.Output(), nil
 }
 
 /*

--- a/uda/datatypes.go
+++ b/uda/datatypes.go
@@ -40,14 +40,12 @@ type AggInterface interface {
 	Init(argMap *functions.ArgumentMap, args ...interface{}) error
 	/*
 		Accum() sends new data to the aggregate
+		and returns the currently valid output of this aggregate
 	*/
 	//Accum(ts []time.Time, rows io.Rows)
+	// The io.ColumnInterface parameter is one of; ColumnSeries or Rows
 	Accum(io.TimeBucketKey, *functions.ArgumentMap, io.ColumnInterface, *catalog.Directory,
-	) error // The parameter is one of; ColumnSeries or Rows
-	/*
-		Output() returns the currently valid output of this aggregate
-	*/
-	Output() *io.ColumnSeries
+	) (*io.ColumnSeries, error)
 }
 
 //TODO: This is where we break out a UDF API

--- a/uda/gap/gap.go
+++ b/uda/gap/gap.go
@@ -59,18 +59,18 @@ func (g *Gap) GetInitArgs() []io.DataShape {
 // Use Zscore to find out the big hole in data.
 func (g *Gap) Accum(_ io.TimeBucketKey, _ *functions.ArgumentMap,
 	cols io.ColumnInterface, _ *catalog.Directory,
-) error {
+) (*io.ColumnSeries, error) {
 	g.BigGapIdxs = []int{}
 	g.Input = &cols
 
 	if cols.Len() == 0 {
-		return nil
+		return g.Output(), nil
 	}
 
 	epochs, err := uda.ColumnToFloat64(cols, "Epoch")
 
 	if err != nil || epochs == nil || len(epochs) < 2 {
-		return nil
+		return g.Output(), nil
 	}
 
 	size := len(epochs)
@@ -105,7 +105,7 @@ func (g *Gap) Accum(_ io.TimeBucketKey, _ *functions.ArgumentMap,
 
 	}
 
-	return nil
+	return g.Output(), nil
 }
 
 /*

--- a/uda/max/max.go
+++ b/uda/max/max.go
@@ -43,15 +43,15 @@ func (ma *Max) GetInitArgs() []io.DataShape {
 */
 func (ma *Max) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap,
 	cols io.ColumnInterface, _ *catalog.Directory,
-) error {
+) (*io.ColumnSeries, error) {
 	if cols.Len() == 0 {
-		return nil
+		return ma.Output(), nil
 	}
 	inputColDSV := argMap.GetMappedColumns(requiredColumns[0].Name)
 	inputColName := inputColDSV[0].Name
 	inputCol, err := uda.ColumnToFloat32(cols, inputColName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !ma.IsInitialized {
@@ -63,7 +63,7 @@ func (ma *Max) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap,
 			ma.Max = value
 		}
 	}
-	return nil
+	return ma.Output(), nil
 }
 
 /*
@@ -71,14 +71,14 @@ func (ma *Max) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap,
 	for inputColumns and optionalInputColumns
 */
 func (m Max) New() (out uda.AggInterface) {
-	ma := NewCount()
+	ma := NewMax()
 	return ma
 }
 
 /*
 CONCRETE - these may be suitable methods for general usage
 */
-func NewCount() (ma *Max) {
+func NewMax() (ma *Max) {
 	ma = new(Max)
 	return ma
 }

--- a/uda/min/min.go
+++ b/uda/min/min.go
@@ -41,15 +41,16 @@ func (mn *Min) GetInitArgs() []io.DataShape {
 /*
 	Accum() sends new data to the aggregate
 */
-func (mn *Min) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap, cols io.ColumnInterface, _ *catalog.Directory) error {
+func (mn *Min) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap, cols io.ColumnInterface, _ *catalog.Directory,
+) (*io.ColumnSeries, error) {
 	if cols.Len() == 0 {
-		return nil
+		return mn.Output(), nil
 	}
 	inputColDSV := argMap.GetMappedColumns(requiredColumns[0].Name)
 	inputColName := inputColDSV[0].Name
 	inputCol, err := uda.ColumnToFloat32(cols, inputColName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !mn.IsInitialized {
@@ -61,7 +62,7 @@ func (mn *Min) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap, cols io.
 			mn.Min = value
 		}
 	}
-	return nil
+	return mn.Output(), nil
 }
 
 /*


### PR DESCRIPTION
## WHAT
remove `Output()` function from AggFunc interface

## WHY
simplify AggFunc interface and make it static to improve testability