### PR TITLE
fix(integtest): change astype to view

### DIFF
--- a/tests/integ/tests/test_data_integrity.py
+++ b/tests/integ/tests/test_data_integrity.py
@@ -122,7 +122,7 @@ def test_csv_writer(symbol, timeframe, size, start, window, format):
     df = utils.generate_dataframe(size, start, end, random_data=False)
     # remove the nanoseconds to milliseconds
     if format == "ms":
-        total_ns = df.index.astype("i8")
+        total_ns = df.index.view("i8")
         df.index = pd.to_datetime(total_ns // 10 ** 3, unit="us", utc=True)
 
     result = write_with_csv_writer_from_filename(df, db_symbol, timeframe, format)
@@ -144,7 +144,7 @@ def write_with_csv_writer_from_filename(df, symbol, timeframe, format):
         # BUG: for some reason with pandas when formatting with "%Y%m%d %H:%M:%S %f"
         # it only output up to microseconds and not nanoseconds...
         str_dates = df.index.strftime("%Y%m%d %H:%M:%S")
-        str_ns = ["{:09d}".format(el) for el in (df.index.astype("i8") % (10 ** 9))]
+        str_ns = ["{:09d}".format(el) for el in (df.index.view("i8") % (10 ** 9))]
         formatted_df = df.copy()
         formatted_df["Epoch"] = str_dates + " " + str_ns
         formatted_df[["Epoch", "Ask", "Bid"]].to_csv(
@@ -237,8 +237,8 @@ def assert_query_result(df, symbol, size, timeframe, start, end):
 
         bad_locations = df.index != processed_out_df.index
         dilated_bad_locations = np.convolve(
-            bad_locations.astype(int), [1, 1, 1], mode="same"
-        ).astype(bool)
+            bad_locations.view(int), [1, 1, 1], mode="same"
+        ).view(bool)
         print("Show dilated bad locations".center(40, "-"))
         print("\ninput df")
         print(df.loc[dilated_bad_locations, :])

--- a/tests/integ/tests/test_nanoseconds_precision.py
+++ b/tests/integ/tests/test_nanoseconds_precision.py
@@ -39,8 +39,8 @@ def process_query_result(df: pd.DataFrame, inplace: bool = True) -> pd.DataFrame
 
     if "Nanoseconds" in df.columns:
         df.index = pd.to_datetime(
-            df.index.values.astype("datetime64[s]")
-            + df["Nanoseconds"].values.astype("timedelta64[ns]"),
+            df.index.values.view("datetime64[s]")
+            + df["Nanoseconds"].values.view("timedelta64[ns]"),
             utc=True,
         )
         df.index.name = "Epoch"
@@ -190,8 +190,8 @@ def build_test(in_df, symbol, timeframe, start, end):
 
         bad_locations = df1.index != df2.index
         dilated_bad_locations = np.convolve(
-            bad_locations.astype(int), [1, 1, 1], mode="same"
-        ).astype(bool)
+            bad_locations.view(int), [1, 1, 1], mode="same"
+        ).view(bool)
         # print("Show dilated bad locations".center(40, "-"))
         # print("\ninput df")
         # display(df1.loc[dilated_bad_locations, :])

--- a/tests/integ/tests/test_overflow_query.py
+++ b/tests/integ/tests/test_overflow_query.py
@@ -478,8 +478,8 @@ def build_test(in_df: pd.DataFrame, symbol: str, timeframe: str, start, end):
 
         bad_locations = df1.index != df2.index
         dilated_bad_locations = np.convolve(
-            bad_locations.astype(int), [1, 1, 1], mode="same"
-        ).astype(bool)
+            bad_locations.view(int), [1, 1, 1], mode="same"
+        ).view(bool)
         print("Show dilated bad locations".center(40, "-"))
         print("\ninput df")
         # display(df1.loc[dilated_bad_locations, :])

--- a/tests/integ/tests/test_query_overlapping_years.py
+++ b/tests/integ/tests/test_query_overlapping_years.py
@@ -98,8 +98,8 @@ def build_test(in_df, symbol, timeframe, start, end):
 
         bad_locations = df1.index != df2.index
         dilated_bad_locations = np.convolve(
-            bad_locations.astype(int), [1, 1, 1], mode="same"
-        ).astype(bool)
+            bad_locations.view(int), [1, 1, 1], mode="same"
+        ).view(bool)
         print("Show dilated bad locations".center(40, "-"))
         print("\ninput df")
         print(df1.loc[dilated_bad_locations, :])

--- a/tests/integ/tests/test_ticks.py
+++ b/tests/integ/tests/test_ticks.py
@@ -29,11 +29,11 @@ def convert(data, with_nanoseconds=False):
           - add the nanesecond field to the index at query time: TODO
     """
     data = data.copy()
-    total_ns = data.index.astype(np.int64)
+    total_ns = data.index.view(np.int64)
 
     if with_nanoseconds:
         data['Nanoseconds'] = total_ns % (10 ** 9)
-        data = data.astype({"Nanoseconds": 'i4'})
+        data = data.view({"Nanoseconds": 'i4'})
 
     data.index = total_ns // 10 ** 9
     data.index.name = 'Epoch'

--- a/tests/integ/tests/utils.py
+++ b/tests/integ/tests/utils.py
@@ -26,8 +26,8 @@ def build_dataframe(data, index, columns=None, nanoseconds=None) -> pd.DataFrame
 
     if nanoseconds is not None:
         df.index = pd.to_datetime(
-            df.index.values.astype("datetime64[s]")
-            + np.array(nanoseconds).astype("timedelta64[ns]"),
+            df.index.values.view("datetime64[s]")
+            + np.array(nanoseconds).view("timedelta64[ns]"),
             utc=True,
         )
 
@@ -51,13 +51,13 @@ def to_records(df: pd.DataFrame, extract_nanoseconds: bool = True) -> np.recarra
         Data in a suitable format to write with pymarketstore client.
     """
     df = df.copy()
-    total_ns = df.index.astype("i8")
+    total_ns = df.index.view("i8")
 
     if extract_nanoseconds:
         df["Nanoseconds"] = total_ns % (10 ** 9)
 
     if "Nanoseconds" in df.columns:
-        df.loc[:, "Nanoseconds"] = df["Nanoseconds"].astype("i4")
+        df.loc[:, "Nanoseconds"] = df["Nanoseconds"].view("i4")
 
     df.index = total_ns // (10 ** 9)
     df.index.name = "Epoch"
@@ -88,8 +88,8 @@ def process_query_result(df: pd.DataFrame, inplace: bool = True) -> pd.DataFrame
 
     if "Nanoseconds" in df.columns:
         df.index = pd.to_datetime(
-            df.index.values.astype("datetime64[s]")
-            + df["Nanoseconds"].values.astype("timedelta64[ns]"),
+            df.index.values.view("datetime64[s]")
+            + df["Nanoseconds"].values.view("timedelta64[ns]"),
             utc=True,
         )
         df.index.name = "Epoch"
@@ -122,13 +122,13 @@ def generate_dataframe(
     """
     if random_data:
         data = dict(
-            Bid=np.random.RandomState(0).random(size=size).astype(np.float32),
-            Ask=np.random.RandomState(0).random(size=size).astype(np.float32),
+            Bid=np.random.RandomState(0).random(size=size).view(np.float32),
+            Ask=np.random.RandomState(0).random(size=size).view(np.float32),
         )
     else:
         data = dict(
-            Bid=np.arange(size).astype(np.float32),
-            Ask=np.arange(size).astype(np.float32),
+            Bid=np.arange(size).view(np.float32),
+            Ask=np.arange(size).view(np.float32),
         )
 
     start_ts = pd.Timestamp(start).value


### PR DESCRIPTION
## WHAT
- change `astype` to `view` function

## WHY
- to address the following error:
```
 FutureWarning: casting datetime64[ns, UTC] values to int64 with .astype(...) is deprecated and will raise in a future version. Use .view(...) instead.
```