### PR TITLE
fix(integtest): change astype to view

### DIFF
--- a/tests/integ/tests/test_ticks.py
+++ b/tests/integ/tests/test_ticks.py
@@ -29,7 +29,7 @@ def convert(data, with_nanoseconds=False):
           - add the nanesecond field to the index at query time: TODO
     """
     data = data.copy()
-    total_ns = data.index.astype(np.int64)
+    total_ns = data.index.view(np.int64)
 
     if with_nanoseconds:
         data['Nanoseconds'] = total_ns % (10 ** 9)

--- a/tests/integ/tests/utils.py
+++ b/tests/integ/tests/utils.py
@@ -51,7 +51,7 @@ def to_records(df: pd.DataFrame, extract_nanoseconds: bool = True) -> np.recarra
         Data in a suitable format to write with pymarketstore client.
     """
     df = df.copy()
-    total_ns = df.index.astype("i8")
+    total_ns = df.index.view("i8")
 
     if extract_nanoseconds:
         df["Nanoseconds"] = total_ns % (10 ** 9)


### PR DESCRIPTION
## WHAT
- use `view` for casting datetime to int

## WHY
to address the following error:
```
FutureWarning: casting datetime64[ns, UTC] values to int64 with .astype(...) is deprecated and will raise in a future version. Use .view(...) instead.
```