### PR TITLE
add: prometheus metric to monitor the disk usage of the data directory

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -139,7 +139,7 @@ func executeStart(_ *cobra.Command, _ []string) error {
 		config.WALBypass,
 	)
 
-	go metrics.StartDiskUsageMonitor(config.RootDirectory, 10 * time.Minute)
+	go metrics.StartDiskUsageMonitor(metrics.TotalDiskUsageBytes, config.RootDirectory, 10 * time.Minute)
 
 	startupTime := time.Since(start)
 	metrics.StartupTime.Set(startupTime.Seconds())

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -139,6 +139,8 @@ func executeStart(_ *cobra.Command, _ []string) error {
 		config.WALBypass,
 	)
 
+	go metrics.StartDiskUsageMonitor(config.RootDirectory, 10 * time.Minute)
+
 	startupTime := time.Since(start)
 	metrics.StartupTime.Set(startupTime.Seconds())
 	log.Info("startup time: %s", startupTime)

--- a/metrics/du.go
+++ b/metrics/du.go
@@ -9,16 +9,21 @@ import (
 	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
+// Setter is an interface for prometheus metrics to improve unit-testability
+type Setter interface {
+	Set(m float64)
+}
+
 // StartDiskUsageMonitor retrieves the total disk usage of the provided directory at each provided time interval,
 // and set it as a prometheus metric.
-func StartDiskUsageMonitor(rootDir string, interval time.Duration){
-	TotalDiskUsageBytes.Set(float64(diskUsage(rootDir)))
+func StartDiskUsageMonitor(s Setter, rootDir string, interval time.Duration) {
+	s.Set(float64(diskUsage(rootDir)))
 
 	t := time.NewTicker(interval)
 	for {
 		select {
 		case <-t.C:
-			TotalDiskUsageBytes.Set(float64(diskUsage(rootDir)))
+			s.Set(float64(diskUsage(rootDir)))
 		}
 	}
 }

--- a/metrics/du.go
+++ b/metrics/du.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
+)
+
+// StartDiskUsageMonitor retrieves the total disk usage of the provided directory at each provided time interval,
+// and set it as a prometheus metric.
+func StartDiskUsageMonitor(rootDir string, interval time.Duration){
+	TotalDiskUsageBytes.Set(float64(diskUsage(rootDir)))
+
+	t := time.NewTicker(interval)
+	for {
+		select {
+		case <-t.C:
+			TotalDiskUsageBytes.Set(float64(diskUsage(rootDir)))
+		}
+	}
+}
+
+func diskUsage(path string) int64 {
+	var totalSize int64
+	err := filepath.Walk(path, func(filepath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			// Since marketstore generates sparse data files by fp.truncate, it does not consume actual disk usage
+			// even if the large file size is allocated. Getting stat information here to monitor the disk usage.
+			sys := info.Sys()
+			if sys != nil {
+				stat, ok := sys.(*syscall.Stat_t)
+				if !ok {
+					log.Error("failed to get Stat_t for the file", filepath)
+				}
+				du := int64(stat.Blksize>>3) * stat.Blocks // >>3 = convert bits to bytes
+				totalSize += du
+			}
+		}
+		return err
+	})
+	if err != nil {
+		log.Error("get the disk usage of the directory for monitoring", path, err)
+	}
+	return totalSize
+}

--- a/metrics/du_test.go
+++ b/metrics/du_test.go
@@ -1,0 +1,82 @@
+package metrics_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/marketstore/v4/metrics"
+	"github.com/alpacahq/marketstore/v4/utils/test"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockMetricsSetter struct {
+	value float64
+}
+
+func (m *mockMetricsSetter) Set(v float64) {
+	m.value = v
+}
+
+type testCase struct {
+	setFilesFunc func(tt testCase, rootDir string) error
+	expMetric    float64
+}
+
+func TestStartDiskUsageMonitor(t *testing.T) {
+	t.Parallel()
+	tests := map[string]testCase{
+		"ok/ when some small bytes are written, only 1 blocksize is actually used and monitored as a diskUsage metric" +
+			" regardless of the allocated filesize": {
+			setFilesFunc: func(tt testCase, rootDir string) error {
+				fileName := rootDir + "/example"
+				fp, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR, 0600)
+				assert.Nil(t, err)
+
+				// truncate => allocate the filesize, writeBuffer => write actual data
+				assert.Nil(t, fp.Truncate(1024*256))
+				assert.Nil(t, writeBuffer(fp, 300))
+				return nil
+			},
+			expMetric: 4096, // actually, it depends on the block size of the disk that this test runs
+		},
+	}
+	for name := range tests {
+		tt := tests[name]
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// --- given ---
+			rootDir, _ := ioutil.TempDir("", "diskUsage-monitor-test")
+			err := tt.setFilesFunc(tt, rootDir)
+			assert.Nil(t, err)
+			m := mockMetricsSetter{}
+
+			// --- when ---
+			go metrics.StartDiskUsageMonitor(&m, rootDir, 10*time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
+
+			// --- then ---
+			assert.Equal(t, tt.expMetric, m.value)
+
+			// --- tearDown ---
+			test.CleanupDummyDataDir(rootDir)
+
+		})
+	}
+}
+
+func writeBuffer(fp *os.File, size int) error {
+	// fill bytes
+	b := make([]byte, size)
+	for i := 0; i < size; i++ {
+		b[i] = 1
+	}
+
+	_, err := fp.WriteAt(b, 0)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -55,4 +55,13 @@ var (
 		Help:      "WriteCSM call duration",
 		Buckets:   []float64{.0001, .001, .005, .01, .05, .1, .25, .5, 1},
 	})
+
+	// TotalDiskUsageBytes stores the total size of DB files managed by Marketstore
+	TotalDiskUsageBytes = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "total_disk_usage_bytes",
+			Help:      "Total disk usage [bytes] of the Marketstore data files",
+		})
 )


### PR DESCRIPTION
## WHAT
- Add Prometheus Metrics to monitor the disk usage consumed by the marketstore data directory.

```
$ curl -s http://localhost:5993/metrics | grep alpaca_marketstore_total_disk_usage_bytes
# HELP alpaca_marketstore_total_disk_usage_bytes Total disk usage [bytes] of the Marketstore data files
# TYPE alpaca_marketstore_total_disk_usage_bytes gauge
alpaca_marketstore_total_disk_usage_bytes 3.759292416e+09
```

## WHY
- As the more data the marketstore writes, errors can occur due to the out of disk space, so we want to add metrics that can be monitored. 