### PR TITLE
add(xignitefeeder): feature to run data feeding when the market is closed

### DIFF
--- a/contrib/xignitefeeder/README.md
+++ b/contrib/xignitefeeder/README.md
@@ -40,6 +40,9 @@ bgworkers:
       timeout: 10
       # Interval [sec] to call Xignite API
       interval: 10
+      # If a non-zero value is set for off_hours_interval,
+      # the data-feeding is executed every off_hours_interval[minute] even when the market is closed.
+      off_hours_interval: 5
       # XigniteFeeder runs from openTime ~ closeTime (UTC)
       openTime: "23:00:00" # 08:00 (JST)
       closeTime: "06:10:00" # 15:10 (JST)

--- a/contrib/xignitefeeder/configs/config.go
+++ b/contrib/xignitefeeder/configs/config.go
@@ -22,18 +22,21 @@ var json = jsoniter.ConfigCompatibleWithStandardLibrary
 // DefaultConfig is the configuration for XigniteFeeder you can define in
 // marketstore's config file through bgworker extension.
 type DefaultConfig struct {
-	Exchanges           []string  `json:"exchanges"`
-	IndexGroups         []string  `json:"index_groups"`
-	UpdateTime          time.Time `json:"update_time"`
-	Timeframe           string    `json:"timeframe"`
-	APIToken            string    `json:"token"`
-	Timeout             int       `json:"timeout"`
-	OpenTime            time.Time
-	CloseTime           time.Time
-	ClosedDaysOfTheWeek []time.Weekday
-	ClosedDays          []time.Time
-	Interval            int `json:"interval"`
-	Backfill            struct {
+	Exchanges            []string  `json:"exchanges"`
+	IndexGroups          []string  `json:"index_groups"`
+	UpdateTime           time.Time `json:"update_time"`
+	Timeframe            string    `json:"timeframe"`
+	APIToken             string    `json:"token"`
+	Timeout              int       `json:"timeout"`
+	OpenTime             time.Time
+	CloseTime            time.Time
+	ClosedDaysOfTheWeek  []time.Weekday
+	ClosedDays           []time.Time
+	Interval             int `json:"interval"`
+	// If a non-zero value is set for OffHoursInterval,
+	// the data-feeding is executed every offHoursInterval[minute] even when the market is closed.
+	OffHoursInterval int `json:"off_hours_interval"`
+	Backfill         struct {
 		Enabled   bool      `json:"enabled"`
 		Since     CustomDay `json:"since"`
 		Timeframe string    `json:"timeframe"`

--- a/contrib/xignitefeeder/feed/interval.go
+++ b/contrib/xignitefeeder/feed/interval.go
@@ -1,0 +1,40 @@
+package feed
+
+import (
+	"time"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
+)
+
+// IntervalMarketTimeChecker is used where periodic processing is needed to run even when the market is closed.
+type IntervalMarketTimeChecker struct {
+	MarketTimeChecker
+	// LastTime holds the last time that IntervalTimeChceker.IsOpen returned true.
+	LastTime time.Time
+	Interval time.Duration
+}
+
+func NewIntervalMarketTimeChecker(
+	mtc *MarketTimeChecker,
+	interval time.Duration,
+) *IntervalMarketTimeChecker {
+	return &IntervalMarketTimeChecker{
+		MarketTimeChecker: *mtc,
+		LastTime:          time.Time{},
+		Interval:          interval,
+	}
+}
+
+// IsOpen returns true when the market is open or the interval elapsed since LastTime.
+func (c *IntervalMarketTimeChecker) IsOpen(t time.Time) bool {
+	return c.MarketTimeChecker.IsOpen(t) || c.intervalElapsed(t)
+}
+
+func (c *IntervalMarketTimeChecker) intervalElapsed(t time.Time) bool {
+	elapsed := t.In(jst).Sub(c.LastTime) > c.Interval
+	if elapsed {
+		c.LastTime = t
+		log.Debug("[Xignite Feeder] interval elapsed since last time: " + t.String())
+	}
+	return elapsed
+}

--- a/contrib/xignitefeeder/feed/time_checker.go
+++ b/contrib/xignitefeeder/feed/time_checker.go
@@ -33,7 +33,12 @@ type DefaultMarketTimeChecker struct {
 }
 
 // NewDefaultMarketTimeChecker initializes the DefaultMarketTimeChecker object with the specifier parameters.s
-func NewDefaultMarketTimeChecker(closedDaysOfTheWeek []time.Weekday, closedDays []time.Time, openTime time.Time, closeTime time.Time) *DefaultMarketTimeChecker {
+func NewDefaultMarketTimeChecker(
+	closedDaysOfTheWeek []time.Weekday,
+	closedDays []time.Time,
+	openTime time.Time,
+	closeTime time.Time,
+) *DefaultMarketTimeChecker {
 	return &DefaultMarketTimeChecker{
 		ClosedDaysOfTheWeek: closedDaysOfTheWeek,
 		ClosedDays:          closedDays,

--- a/contrib/xignitefeeder/xignitefeeder.go
+++ b/contrib/xignitefeeder/xignitefeeder.go
@@ -34,11 +34,18 @@ func NewBgWorker(conf map[string]interface{}) (bgworker.BgWorker, error) {
 	apiClient := api.NewDefaultAPIClient(config.APIToken, config.Timeout)
 
 	// init Market Time Checker
-	timeChecker := feed.NewDefaultMarketTimeChecker(
+	var timeChecker feed.MarketTimeChecker
+	timeChecker = feed.NewDefaultMarketTimeChecker(
 		config.ClosedDaysOfTheWeek,
 		config.ClosedDays,
 		config.OpenTime,
 		config.CloseTime)
+	if config.OffHoursInterval != 0 {
+		timeChecker = feed.NewIntervalMarketTimeChecker(
+			&timeChecker,
+			time.Duration(config.OffHoursInterval)*time.Minute,
+		)
+	}
 
 	ctx := context.Background()
 	// init Symbols Manager to...


### PR DESCRIPTION
## WHAT
Added an option to run the XigniteFeeder process periodically, even while the market is closed.

## WHY
Because there was a concern that if we did an operation to delete Xignite data for some reason, we would have to wait until 8am the next business day to reinsert the current price data.