### PR TITLE
fix(wal): continue transaction if it's partially failed

### DIFF
--- a/executor/wal.go
+++ b/executor/wal.go
@@ -281,7 +281,8 @@ func (wf *WALFileType) FlushCommandsToWAL(writeCommands []*wal.WriteCommand) (er
 		recordType := fileRecordTypes[keyPath]
 		varRecLen := varRecLens[keyPath]
 		if err := wf.writePrimary(keyPath, writes, recordType, varRecLen); err != nil {
-			return err
+			// TODO: what should we do if the write commit partially failed?
+			log.Error(fmt.Sprintf("failed to write data to file %s: %s", keyPath, err.Error()))
 		}
 		for i, buffer := range writes {
 			wf.tpd.AppendRecord(keyPath, trigger.Record(buffer.IndexAndPayload()))
@@ -347,7 +348,7 @@ func (wf *WALFileType) writePrimary(keyPath string, writes []wal.OffsetIndexBuff
 	}
 	if err != nil {
 		// this is critical, in fact, since tx has been committed
-		log.Error("cannot open file %s for write: %v", fullPath, err)
+		log.Error("cannot open file %s for write transaction commit: %v", fullPath, err)
 		return err
 	}
 	defer fp.Close()


### PR DESCRIPTION
## WHAT
- don't return an error in write transaction but continue the process

## WHY
- One of the factors that may cause a write transaction to fail is when data cannot be written to a file due to unexpected deletion of the data file from the OS. In such a case, rather than giving up other write requests in the same transaction set due to the failure of the corresponding data, it is considered to be closer to the expected result to continue to attempt to process those other write requests.

Currently, marketstore's DELETE API is implemented to simply delete data files from the OS without going through WAL, which may well lead to such an event.