### PR TITLE
refactor(log): avoid using log.fatal and do error handlings

### DIFF
--- a/cmd/connect/session/local_api_client.go
+++ b/cmd/connect/session/local_api_client.go
@@ -19,9 +19,13 @@ func NewLocalAPIClient(dir string) (lc *LocalAPIClient, err error) {
 	// Configure db settings.
 	initCatalog, initWALCache, backgroundSync, WALBypass := true, true, false, true
 	walRotateInterval := 5
-	instanceConfig, _, _ := executor.NewInstanceSetup(dir,
+	instanceConfig, _, _, err := executor.NewInstanceSetup(dir,
 		nil, nil, walRotateInterval, initCatalog, initWALCache, backgroundSync, WALBypass,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("create a new instance setup for local API client: %w", err)
+	}
+
 	ar := sqlparser.NewDefaultAggRunner(instanceConfig.CatalogDir)
 	qs := frontend.NewQueryService(instanceConfig.CatalogDir)
 	writer, err := executor.NewWriter(instanceConfig.CatalogDir, instanceConfig.WALFile)

--- a/contrib/alpaca/handlers/handlers_test.go
+++ b/contrib/alpaca/handlers/handlers_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
 
@@ -15,7 +16,9 @@ func setup(t *testing.T, testName string) (tearDown func()) {
 	t.Helper()
 
 	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("handlers_test-%s", testName))
-	_, _, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false, true) // WAL Bypass
+	_, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
+		true, true, false, true) // WAL Bypass
+	assert.Nil(t, err)
 
 	return func() { test.CleanupDummyDataDir(rootDir) }
 }

--- a/contrib/candler/candlecandler/all_test.go
+++ b/contrib/candler/candlecandler/all_test.go
@@ -26,7 +26,8 @@ func setup(t *testing.T, testName string,
 
 	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("candlecandler_test-%s", testName))
 	itemsWritten = test.MakeDummyStockDir(rootDir, true, false)
-	metadata, _, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	metadata, _, _,err := executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	assert.Nil(t, err)
 
 	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, itemsWritten, metadata
 }

--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -27,7 +27,8 @@ func setup(t *testing.T, testName string,
 
 	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("tickcandler_test-%s", testName))
 	itemsWritten = test.MakeDummyCurrencyDir(rootDir, true, false)
-	metadata, _, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	assert.Nil(t, err)
 
 	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, itemsWritten, metadata
 }

--- a/contrib/ice/cmd/reorg/import.go
+++ b/contrib/ice/cmd/reorg/import.go
@@ -1,6 +1,7 @@
 package reorg
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 
 	"github.com/alpacahq/marketstore/v4/contrib/ice/reorg"
@@ -38,7 +39,11 @@ var ImportCmd = &cobra.Command{
 		}
 		dataDir := args[0]
 		reorgDir := args[1]
-		executor.NewInstanceSetup(dataDir, nil, nil, 5, true, true, true, true)
+		_, _, _, err := executor.NewInstanceSetup(dataDir, nil, nil, 5, true, true, true, true)
+		if err != nil {
+			return fmt.Errorf("failed to create new instance setup for Import: %w", err)
+		}
+
 		reorg.Import(reorgDir, reimport, storeWithoutSymbols)
 		return nil
 	},

--- a/contrib/ice/cmd/reorg/show.go
+++ b/contrib/ice/cmd/reorg/show.go
@@ -31,7 +31,10 @@ var ShowRecordsCmd = &cobra.Command{
 		}
 		cusip := args[1]
 		dataDir := args[0]
-		metadata, _, _ := executor.NewInstanceSetup(dataDir, nil, nil, 5, true, true, true, true)
+		metadata, _, _, err := executor.NewInstanceSetup(dataDir, nil, nil, 5, true, true, true, true)
+		if err != nil {
+			return fmt.Errorf("failed to create new instance setup for Show command: %w", err)
+		}
 		showRecords(cusip, metadata.CatalogDir)
 		return nil
 	},

--- a/contrib/iex/backfill/backfill.go
+++ b/contrib/iex/backfill/backfill.go
@@ -236,7 +236,7 @@ func nextBatch(bars []*consolidator.Bar, index int) ([]*consolidator.Bar, int) {
 	return batch, len(bars)
 }
 
-func initWriter() {
+func initWriter() error {
 	utils.InstanceConfig.Timezone = NY
 	walRotateInterval := 5
 	instanceID := time.Now().UTC().UnixNano()
@@ -256,13 +256,17 @@ func initWriter() {
 		trigger.NewMatcher(trig, "*/1Min/OHLCV"),
 	}
 
-	executor.NewInstanceSetup(
+	_, _, _, err = executor.NewInstanceSetup(
 		relRootDir, nil, triggerMatchers,
 		walRotateInterval, true, true, true, true)
+	if err != nil {
+		return fmt.Errorf("failed to create new instance setup for iex/backfill: %w", err)
+	}
 
 	log.Info(
 		"Initialized writer with InstanceID: %v - relRootDir: %v\n",
 		instanceID,
 		relRootDir,
 	)
+	return nil
 }

--- a/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
@@ -109,9 +109,10 @@ func TestFireBars(t *testing.T) {
 
 	rootDir := filepath.Join(tempDir, "mktsdb")
 	os.MkdirAll(rootDir, 0777)
-	executor.NewInstanceSetup(
+	_, _, _, err := executor.NewInstanceSetup(
 		rootDir, nil, nil,
 		5, true, true, false, false)
+	assert.Nil(t, err)
 
 	ts := utils.TriggerSetting{
 		Module: "ondiskagg.so",

--- a/contrib/polygon/handlers/handlers_test.go
+++ b/contrib/polygon/handlers/handlers_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -20,7 +21,8 @@ func setup(t *testing.T, testName string,
 	t.Helper()
 
 	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("handlers_test-%s", testName))
-	executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false, true)
+	_, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false, true)
+	assert.Nil(t, err)
 
 	return func() { test.CleanupDummyDataDir(rootDir) }
 }

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -28,7 +28,9 @@ func setup(t *testing.T, testName string,
 
 	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("executor_test-%s", testName))
 	itemsWritten = MakeDummyCurrencyDir(rootDir, true, false)
-	metadata, shutdownPending, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	metadata, shutdownPending, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
+		true, true, false)
+	assert.Nil(t, err)
 
 	return func() { CleanupDummyDataDir(rootDir) }, rootDir, itemsWritten, metadata, shutdownPending
 }

--- a/executor/wal.go
+++ b/executor/wal.go
@@ -71,7 +71,8 @@ func NewWALFile(rootDir string, owningInstanceID int64, rs ReplicationSender,
 	}
 
 	if err = wf.createFile(rootDir); err != nil {
-		log.Fatal("%v: Can not create new WALFile - Error: %v", io.GetCallerFileContext(0), err)
+		log.Error("%v: Can not create new WALFile - Error: %v", io.GetCallerFileContext(0), err)
+		return nil, fmt.Errorf("can not create new WALFile: %w", err)
 	}
 	wf.WriteStatus(wal.OPEN, wal.NOTREPLAYED)
 
@@ -810,7 +811,7 @@ func (wf *WALFileType) cleanupOldWALFiles(rootDir string) error {
 	rootDir = filepath.Clean(rootDir)
 	files, err := ioutil.ReadDir(rootDir)
 	if err != nil {
-		return fmt.Errorf("Unable to read root directory %s: %w", rootDir, err)
+		return fmt.Errorf("unable to read root directory %s: %w", rootDir, err)
 	}
 	myFileBase := filepath.Base(wf.FilePtr.Name())
 	log.Info("My WALFILE: %s", myFileBase)

--- a/frontend/query_test.go
+++ b/frontend/query_test.go
@@ -26,7 +26,8 @@ func setup(t *testing.T, testName string,
 
 	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("frontend_test-%s", testName))
 	test.MakeDummyCurrencyDir(rootDir, true, false)
-	metadata, _, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	assert.Nil(t, err)
 	atomic.StoreUint32(&frontend.Queryable, uint32(1))
 
 	qs := frontend.NewQueryService(metadata.CatalogDir)

--- a/frontend/stream/stream_test.go
+++ b/frontend/stream/stream_test.go
@@ -28,7 +28,8 @@ func setup(t *testing.T, testName string,
 	t.Helper()
 
 	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("stream_test-%s", testName))
-	_, _, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	_, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	assert.Nil(t, err)
 	stream.Initialize()
 
 	return func() { test.CleanupDummyDataDir(rootDir) }

--- a/sqlparser/all_test.go
+++ b/sqlparser/all_test.go
@@ -26,7 +26,8 @@ func setup(t *testing.T, testName string,
 
 	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("sqlparser_test-%s", testName))
 	test.MakeDummyStockDir(rootDir, true, false)
-	metadata, _, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false)
+	assert.Nil(t, err)
 
 	return func() { test.CleanupDummyDataDir(rootDir) }, metadata
 }

--- a/uda/adjust/adjust_test.go
+++ b/uda/adjust/adjust_test.go
@@ -25,7 +25,8 @@ func setup(t *testing.T, testName string,
 	rounderNum = math.Pow(10, 3)
 
 	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("adjust_test-%s", testName))
-	metadata, _, _ = executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false, true)
+	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, true, true, false, true)
+	assert.Nil(t, err)
 
 	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, metadata
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -123,14 +123,14 @@ func (m *MktsConfig) Parse(data []byte) (*MktsConfig, error) {
 
 	absoluteRootDir, err := filepath.Abs(filepath.Clean(aux.RootDirectory))
 	if aux.RootDirectory == "" || err != nil {
-		log.Fatal("Invalid root directory.")
-		return nil, errors.New("Invalid root directory.")
+		log.Error("Invalid root directory. rootDir=" + aux.RootDirectory)
+		return nil, errors.New(fmt.Sprintf("invalid root directory. rootDir=%s, err=%v", aux.RootDirectory, err))
 	}
 	m.RootDirectory = absoluteRootDir
 
 	if aux.ListenPort == "" {
-		log.Fatal("Invalid listen port.")
-		return nil, errors.New("Invalid listen port.")
+		log.Error("listen port can't be empty.")
+		return nil, errors.New("invalid listen port. Listen port can't be empty")
 	}
 
 	// GRPC is optional for now


### PR DESCRIPTION
## WHAT
same as title

## WHY
`log.Fatal` not only prints a log, but also terminates the marketstore process.
Therefore, using `log.fatal` outside of the main function may cause issues due to unexpected process termination.