### PR TITLE
build: update go version to 1.17.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   golang:
     working_directory: ~/github.com/alpacahq/marketstore
     docker:
-      - image: circleci/golang:1.17.0
+      - image: circleci/golang:1.17.1
 
 variables:
   - filters: &all

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Uses a Go image to build a release binary.
 #
-FROM golang:1.17.0-buster as builder
+FROM golang:1.17.1-buster as builder
 ARG tag=latest
 ARG INCLUDE_PLUGINS=true
 ENV DOCKER_TAG=$tag


### PR DESCRIPTION
## WHAT
update the go build version from 1.17.0 to 1.17.1


## WHY
The go minor release includes a security fix according to the new security policy and a panic/fatal error.
https://groups.google.com/g/golang-announce/c/dx9d7IOseHw?pli=1