### PR TITLE
refactor(bitmex): mock API response

### DIFF
--- a/contrib/bitmexfeeder/bitmexfeeder.go
+++ b/contrib/bitmexfeeder/bitmexfeeder.go
@@ -48,9 +48,21 @@ func recast(config map[string]interface{}) *FetcherConfig {
 // NewBgWorker returns the new instance of GdaxFetcher.  See FetcherConfig
 // for the details of available configurations.
 func NewBgWorker(conf map[string]interface{}) (bgworker.BgWorker, error) {
-	httpClient := &http.Client{
-		Timeout: time.Second * 10,
+	var (
+		httpClient *http.Client
+		ok         bool
+	)
+	// inject httpClient (mainly for testing)
+	if hc, found := conf["httpClient"]; found {
+		httpClient, ok = hc.(*http.Client)
+		delete(conf, "httpClient") // without delete, err occurs when recast conf
 	}
+	if !ok {
+		httpClient = &http.Client{
+			Timeout: time.Second * 10,
+		}
+	}
+
 	client := bitmex.NewBitmexClient(httpClient)
 	symbols, err := client.GetInstruments()
 	if err != nil {


### PR DESCRIPTION
## WHAT
- use mock API response for BitMex feeder unit test
- API mock has been used since before this refactor, but it was not entirely used for the test

## WHY
- to stabilize the unit test by using the mock.