### PR TITLE
refactor(wal): readability improvement by early return

### DIFF
--- a/cmd/connect/session/trim.go
+++ b/cmd/connect/session/trim.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	io2 "io"
 	"os"
 	"strings"
 
@@ -37,7 +38,7 @@ func (c *Client) trim(line string) {
 				log.Error("Failed to open file %v - Error: %v", info.Path, err)
 				continue
 			}
-			fp.Seek(offset, os.SEEK_SET)
+			fp.Seek(offset, io2.SeekStart)
 			zeroes := make([]byte, io.FileSize(info.GetTimeframe(), int(info.Year), int(info.GetRecordLength()))-offset)
 			fp.Write(zeroes)
 			fp.Close()

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -574,7 +574,7 @@ func TestLastN(t *testing.T) {
 		fmt.Println("Filename: ", filename)
 		fp, err := os.OpenFile(filename, os.O_RDWR, 0600)
 		c.Assert(err == nil, Equals, true)
-		fp.Seek(io.Headersize, os.SEEK_SET)
+		fp.Seek(io.Headersize, io.SeekStart)
 		OneDayOfMinutes := int(24 * 60 * 24)
 		buffer = make([]byte, OneDayOfMinutes)
 		n, _ := fp.Write(buffer)

--- a/executor/scanner.go
+++ b/executor/scanner.go
@@ -490,7 +490,7 @@ func (ex *ioExec) packingReader(packedBuffer *[]byte, f io.ReadSeeker, buffer []
 
 				// Update lastKnown only once the first time
 				if fp.seekingLast {
-					if offset, err := f.Seek(0, os.SEEK_CUR); err == nil {
+					if offset, err := f.Seek(0, io.SeekCurrent); err == nil {
 						offset = offset - nn + int64(i)*recordSize64
 					}
 					fp.seekingLast = false
@@ -562,7 +562,7 @@ func (ex *ioExec) readBackward(finalBuffer []byte, fp *ioFilePlan,
 	defer f.Close()
 
 	// Seek to the right end of the search set
-	f.Seek(beginPos+fp.Length, os.SEEK_SET)
+	f.Seek(beginPos+fp.Length, io.SeekStart)
 	// Seek backward one buffer size (max)
 	maxToRead, curpos, err := seekBackward(f, maxToBuffer, beginPos)
 	if err != nil {
@@ -624,7 +624,7 @@ func (ex *ioExec) readBackward(finalBuffer []byte, fp *ioFilePlan,
 
 func seekBackward(f io.Seeker, relative_offset int32, lowerBound int64) (seekAmt int64, curpos int64, err error) {
 	// Find the current file position
-	curpos, err = f.Seek(0, os.SEEK_CUR)
+	curpos, err = f.Seek(0, io.SeekCurrent)
 	if err != nil {
 		log.Error("Read: cannot find current file position: %s", err)
 		return 0, curpos, err
@@ -635,7 +635,7 @@ func seekBackward(f io.Seeker, relative_offset int32, lowerBound int64) (seekAmt
 	} else {
 		seekAmt = int64(relative_offset)
 	}
-	curpos, err = f.Seek(-seekAmt, os.SEEK_CUR)
+	curpos, err = f.Seek(-seekAmt, io.SeekCurrent)
 	if err != nil {
 		err = fmt.Errorf("Error: seeking to rel offset: %d lowerBound: %d | %s",
 			relative_offset, lowerBound, err)

--- a/executor/wal/file.go
+++ b/executor/wal/file.go
@@ -2,6 +2,7 @@ package wal
 
 import (
 	"fmt"
+	io2 "io"
 	"os"
 
 	"github.com/alpacahq/marketstore/v4/utils/io"
@@ -36,13 +37,13 @@ func Read(fp *os.File, targetOffset int64, buffer []byte) (result []byte, newOff
 		Read from the WAL file
 			targetOffset: -1 will read from current position
 	*/
-	offset, err := fp.Seek(0, os.SEEK_CUR)
+	offset, err := fp.Seek(0, io2.SeekCurrent)
 	if err != nil {
 		log.Fatal(io.GetCallerFileContext(0) + ": Unable to seek in WALFile")
 	}
 	if targetOffset != -1 {
 		if offset != targetOffset {
-			fp.Seek(targetOffset, os.SEEK_SET)
+			fp.Seek(targetOffset, io2.SeekStart)
 		}
 	}
 	numToRead := len(buffer)

--- a/executor/walreplay.go
+++ b/executor/walreplay.go
@@ -47,18 +47,6 @@ func (wf *WALFileType) Replay(writeData bool) error {
 	txnStatePrimary := make(map[int64]TxnStatusEnum)
 	offsetTGDataInWAL := make(map[int64]int64)
 
-	fullRead := func(err error) bool {
-		// Check to see if we have read only partial data
-		if err != nil {
-			if _, ok := err.(wal.ShortReadError); ok {
-				log.Info("Partial Read")
-				return false
-			} else {
-				log.Fatal(io.GetCallerFileContext(0) + ": Uncorrectable IO error in WAL Replay")
-			}
-		}
-		return true
-	}
 	log.Info("Beginning WAL Replay")
 	if !writeData {
 		log.Info("Debugging mode enabled - no writes will be performed...")
@@ -192,4 +180,18 @@ func (wf *WALFileType) replayTGData(tgID int64, wtSets []wal.WTSet) (err error) 
 	wf.CreateCheckpoint()
 
 	return nil
+}
+
+func fullRead(err error) bool {
+	// Check to see if we have read only partial data
+	if err != nil {
+		if _, ok := err.(wal.ShortReadError); ok {
+			log.Info(fmt.Sprintf("Partial Read. err=%v", err))
+			return false
+		} else {
+			log.Fatal(io.GetCallerFileContext(0) + ": Uncorrectable IO error in WAL Replay")
+
+		}
+	}
+	return true
 }

--- a/utils/io/metadata.go
+++ b/utils/io/metadata.go
@@ -2,6 +2,7 @@ package io
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"sync"
 	"unsafe"
@@ -265,7 +266,7 @@ func (f *TimeBucketInfo) readHeader(path string) (err error) {
 		return err
 	}
 	// Read past empty element name space
-	file.Seek(1024*32-secondReadSize, os.SEEK_CUR)
+	file.Seek(1024*32-secondReadSize, io.SeekCurrent)
 
 	// Read element types
 	start := 312 + 1024*32

--- a/utils/test/setup.go
+++ b/utils/test/setup.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strconv"
@@ -167,7 +168,7 @@ func DummyDataFromText(rootDir, symbol, timeframe, data string) {
 				c:     candle.c,
 			}
 			data := SwapSliceData([]ohlc{ondisk}, byte(0)).([]byte)
-			file.Seek(offset, os.SEEK_SET)
+			file.Seek(offset, io.SeekStart)
 			_, err = file.Write(data)
 			checkfail(err, "Unable to write data to: "+fileName)
 		}


### PR DESCRIPTION
## WHAT
- replace os.SEEK_* with io.Seek* as they are deprecated
- improve readability by using early return

## WHY
- refactor for readability