### PR TITLE
feat(wal): move wal file to a temporary file when WAL replay failed

### DIFF
--- a/contrib/xignitefeeder/feed/interval.go
+++ b/contrib/xignitefeeder/feed/interval.go
@@ -33,8 +33,11 @@ func (c *IntervalMarketTimeChecker) IsOpen(t time.Time) bool {
 func (c *IntervalMarketTimeChecker) intervalElapsed(t time.Time) bool {
 	elapsed := t.Sub(c.LastTime) >= c.Interval
 	if elapsed {
+		// log if this is not the first time
+		if !c.LastTime.IsZero() {
+			log.Debug("[Xignite Feeder] interval elapsed since last time: " + t.String())
+		}
 		c.LastTime = t
-		log.Debug("[Xignite Feeder] interval elapsed since last time: " + t.String())
 	}
 	return elapsed
 }

--- a/executor/errors.go
+++ b/executor/errors.go
@@ -2,8 +2,6 @@ package executor
 
 import (
 	"fmt"
-	"strconv"
-
 	"github.com/alpacahq/marketstore/v4/utils/io"
 	"github.com/alpacahq/marketstore/v4/utils/log"
 )
@@ -61,18 +59,6 @@ type WALWriteError string
 
 func (msg WALWriteError) Error() string {
 	return errReport("%s: Error Writing to WAL", string(msg))
-}
-
-// WALReplayError is used when the WALfile Replay process fails.
-// If skipReplay:true, it will attempt to give up the Replay process,
-// move the walfile to a temporary file, and continue with other marketstore processing.
-type WALReplayError struct {
-	msg        string
-	skipReplay bool
-}
-
-func (e WALReplayError) Error() string {
-	return errReport("%s: Error Replaying WAL. skipReplay="+strconv.FormatBool(e.skipReplay), e.msg)
 }
 
 func errReport(base string, msg string) string {

--- a/executor/wal/errors.go
+++ b/executor/wal/errors.go
@@ -2,6 +2,7 @@ package wal
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/alpacahq/marketstore/v4/utils/io"
 	"github.com/alpacahq/marketstore/v4/utils/log"
@@ -11,6 +12,18 @@ type ShortReadError string
 
 func (msg ShortReadError) Error() string {
 	return errReport("%s: Unexpectedly short read", string(msg))
+}
+
+// ReplayError is used when the WALfile Replay process fails.
+// If Cont:true, it will give up the Replay process,
+// move the walfile to a temporary file, and continue with other marketstore processing.
+type ReplayError struct {
+	Msg  string
+	Cont bool
+}
+
+func (e ReplayError) Error() string {
+	return errReport("%s: Error Replaying WAL. Cont="+strconv.FormatBool(e.Cont), e.Msg)
 }
 
 func errReport(base string, msg string) string {

--- a/executor/wal/errors.go
+++ b/executor/wal/errors.go
@@ -11,7 +11,7 @@ import (
 type ShortReadError string
 
 func (msg ShortReadError) Error() string {
-	return errReport("%s: Unexpectedly short read", string(msg))
+	return errReport("Unexpectedly short read:%s", string(msg))
 }
 
 // ReplayError is used when the WALfile Replay process fails.
@@ -23,11 +23,11 @@ type ReplayError struct {
 }
 
 func (e ReplayError) Error() string {
-	return errReport("%s: Error Replaying WAL. Cont="+strconv.FormatBool(e.Cont), e.Msg)
+	return errReport("Error Replaying WAL. Cont="+strconv.FormatBool(e.Cont)+":%s", e.Msg)
 }
 
 func errReport(base string, msg string) string {
 	base = io.GetCallerFileContext(2) + ":" + base
-	log.Error(base, msg)
+	log.Warn(base, msg)
 	return fmt.Sprintf(base, msg)
 }

--- a/executor/wal/find.go
+++ b/executor/wal/find.go
@@ -1,0 +1,44 @@
+package wal
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
+)
+
+type Finder struct {
+	dirRead func(dir string) ([]fs.FileInfo, error)
+}
+
+func NewFinder(dirRead func(dir string) ([]fs.FileInfo, error)) *Finder {
+	return &Finder{dirRead: dirRead}
+}
+
+// Find returns all absolute paths to "*.walfile" files directly under the directory.
+func (f *Finder) Find(dir string) ([]string, error) {
+	var ret []string
+	//files, err := ioutil.ReadDir(rootDir)
+	files, err := f.dirRead(dir)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read the directory %s: %w", dir, err)
+	}
+	for _, file := range files {
+		// ignore directories
+		if file.IsDir() {
+			// ignore
+			continue
+		}
+
+		// ignore files except wal
+		filename := file.Name()
+		if filepath.Ext(filename) != ".walfile" {
+			continue
+		}
+
+		log.Debug("found a WALFILE: %s", filename)
+		ret = append(ret, filepath.Join(dir, filename))
+	}
+	return ret, nil
+}

--- a/executor/wal/move.go
+++ b/executor/wal/move.go
@@ -12,6 +12,6 @@ func Move(oldFP, newFP string) error {
 	if err != nil {
 		return fmt.Errorf("failed to move %s to %s:%w", oldFP, newFP, err)
 	}
-	log.Info(fmt.Sprintf("moved %s to %s", oldFP, newFP))
+	log.Debug(fmt.Sprintf("moved %s to %s", oldFP, newFP))
 	return nil
 }

--- a/executor/wal/move.go
+++ b/executor/wal/move.go
@@ -1,0 +1,17 @@
+package wal
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
+)
+
+func Move(oldFP, newFP string) error {
+	err := os.Rename(oldFP, newFP)
+	if err != nil {
+		return fmt.Errorf("failed to move %s to %s:%w", oldFP, newFP, err)
+	}
+	log.Info(fmt.Sprintf("moved %s to %s", oldFP, newFP))
+	return nil
+}

--- a/executor/wal_test.go
+++ b/executor/wal_test.go
@@ -144,7 +144,7 @@ func TestBrokenWAL(t *testing.T) {
 	fp.Close()
 
 	// Take over the broken WALFile and replay it
-	WALFile, err := executor.TakeOverWALFile(rootDir, BrokenWALFileName)
+	WALFile, err := executor.TakeOverWALFile(filepath.Join(rootDir, BrokenWALFileName))
 	assert.Nil(t, err)
 	newTGC := executor.NewTransactionPipe()
 	assert.NotNil(t, newTGC)
@@ -233,7 +233,7 @@ func TestWALReplay(t *testing.T) {
 	io.Syncfs()
 
 	// Take over the new WALFile and replay it into a new TG cache
-	WALFile, err := executor.TakeOverWALFile(rootDir, newWALFileName)
+	WALFile, err := executor.TakeOverWALFile(filepath.Join(rootDir, newWALFileName))
 	assert.Nil(t, err)
 	data, _ := ioutil.ReadFile(newWALFilePath)
 	ioutil.WriteFile("/tmp/wal", data, 0644)

--- a/executor/walclean.go
+++ b/executor/walclean.go
@@ -1,0 +1,71 @@
+package executor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/alpacahq/marketstore/v4/executor/wal"
+	"github.com/alpacahq/marketstore/v4/utils/log"
+)
+
+type WALCleaner struct {
+	ignoreFile   string
+	myInstanceID int64
+}
+
+func NewWALCleaner(ignoreFile string, myInstanceID int64) *WALCleaner {
+	return &WALCleaner{
+		ignoreFile:   ignoreFile,
+		myInstanceID: myInstanceID,
+	}
+}
+
+func (c *WALCleaner) CleanupOldWALFiles(walfileAbsPaths []string) error {
+	for _, fp := range walfileAbsPaths {
+		if fp == c.ignoreFile {
+			continue
+		}
+
+		log.Info("Found a WALFILE: %s, entering replay...", fp)
+		fi, err := os.Stat(fp)
+		if err != nil {
+			log.Error("failed to get fileStat of " + fp)
+			continue
+		}
+		if fi.Size() < 11 {
+			log.Info("WALFILE: %s is empty, removing it...", fp)
+			err = os.Remove(fp)
+			if err != nil {
+				log.Error("failed to remove an empty WALfile", fp)
+			}
+			continue
+		}
+
+		w, err := TakeOverWALFile(fp)
+		if err != nil {
+			return fmt.Errorf("opening %s: %w", fp, err)
+		}
+		if err = w.Replay(false); err != nil {
+			return fmt.Errorf("unable to replay %s: %w", fp, err)
+		}
+
+		//if err = w.Delete(wf.OwningInstanceID); err != nil {
+		if err = w.Delete(c.myInstanceID); err != nil {
+			return fmt.Errorf("failed to delete wal file after replay:%w", err)
+		}
+
+		// ---  move walfile to a temporary file and ignore to continue other marketstore process
+		var walReplayErr *wal.ReplayError
+		if !errors.As(err, &walReplayErr) {
+			continue
+		}
+		if !walReplayErr.Cont {
+			continue
+		}
+		if err := wal.Move(fp, fp+".tmp"); err != nil {
+			return fmt.Errorf("failed to move old wal file %s to a tmp file:%w", fp, err)
+		}
+	}
+	return nil
+}

--- a/executor/walreplay.go
+++ b/executor/walreplay.go
@@ -2,12 +2,13 @@ package executor
 
 import (
 	"fmt"
-	"github.com/alpacahq/marketstore/v4/executor/wal"
-	"github.com/alpacahq/marketstore/v4/utils/io"
-	"github.com/alpacahq/marketstore/v4/utils/log"
 	goio "io"
 	"path/filepath"
 	"sort"
+
+	"github.com/alpacahq/marketstore/v4/executor/wal"
+	"github.com/alpacahq/marketstore/v4/utils/io"
+	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 // Replay loads this WAL File's unwritten transactions to primary store and mark it completely processed.
@@ -29,9 +30,9 @@ func (wf *WALFileType) Replay(dryRun bool) error {
 	}
 	if !needsReplay {
 		log.Info("No WAL Replay needed.")
-		return WALReplayError{
-			msg:        "WALFileType.NeedsReplay No Replay Needed",
-			skipReplay: true,
+		return wal.ReplayError{
+			Msg:  "WALFileType.NeedsReplay No Replay Needed",
+			Cont: true,
 		}
 	}
 
@@ -77,9 +78,9 @@ func (wf *WALFileType) Replay(dryRun bool) error {
 			// give up Replay if there is already a TG data location in this WAL
 			if _, ok := offsetTGDataInWAL[tgID]; ok {
 				log.Error(io.GetCallerFileContext(0) + ": Duplicate TG Data in WAL")
-				return WALReplayError{
-					msg:        fmt.Sprintf("Duplicate TG Data in WAL. tgID=%d", tgID),
-					skipReplay: true,
+				return wal.ReplayError{
+					Msg:  fmt.Sprintf("Duplicate TG Data in WAL. tgID=%d", tgID),
+					Cont: true,
 				}
 			}
 			// log.Info("Successfully read past TG data for tgID: %v", tgID)

--- a/executor/walreplay.go
+++ b/executor/walreplay.go
@@ -178,7 +178,12 @@ func (wf *WALFileType) replayTGData(tgID int64, wtSets []wal.WTSet) (err error) 
 	for _, wtSet := range wtSets {
 		fp, err := cfp.GetFP(wtSet.FilePath)
 		if err != nil {
-			return err
+			return wal.ReplayError{
+				Msg: fmt.Sprintf("failed to open a filepath %s in write transaction set:%v",
+					wtSet.FilePath, err.Error(),
+				),
+				Cont: true,
+			}
 		}
 		switch wtSet.RecordType {
 		case io.FIXED:


### PR DESCRIPTION
## WHAT
- feature to move wal file to a temporary file when WAL replay failed, and continue marketstore startup process
- change some unimportant errors' loglevel from ERROR to WARN
- add error handlings
- separate some logics to independent small structs

## WHY
- When marketstore starts up, it replays old WAL files if any, but if the WAL replay fails, the marketstore is forced to shut down (without this PR). However, the only thing the operator can do manually after that is to delete the WAL file and restart the marketstore.
This PR is to reduce the operational load by automatically saving the WAL file to a temporary file and continuing the marketstore startup process when the replay fails.

- add more information in case of errors
- refactor for better code readability