### PR TITLE
refactor(category): ignore partially deleted data dir

### DIFF
--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -185,7 +185,7 @@ func TestAddAndRemoveDataItem(t *testing.T) {
 func TestAddAndRemoveDataItemFromEmptyDirectory(t *testing.T) {
 	rootDir, _ := ioutil.TempDir("", "catalog_test-TestAddAndRemoveDataItemFromEmptyDirectory")
 	catalogDir, err := catalog.NewDirectory(rootDir)
-	var e *catalog.ErrCategoryFileNotFound
+	var e catalog.ErrCategoryFileNotFound
 	if err != nil && !errors.As(err, &e) {
 		t.Fatal("failed to create a catalog dir.err=" + err.Error())
 		return

--- a/catalog/errors.go
+++ b/catalog/errors.go
@@ -59,6 +59,6 @@ type ErrCategoryFileNotFound struct {
 	msg      string
 }
 
-func (e *ErrCategoryFileNotFound) Error() string {
+func (e ErrCategoryFileNotFound) Error() string {
 	return "Could not find a category_name file under:" + e.filePath + ", msg=" + e.msg
 }

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -43,7 +43,7 @@ func TestAddDir(t *testing.T) {
 
 	// make catelog directory
 	catDir, err := NewDirectory(tempRootDir)
-	var e *ErrCategoryFileNotFound
+	var e ErrCategoryFileNotFound
 	if err != nil && !errors.As(err, &e) {
 		t.Fatal("failed to create a catalog dir.err=" + err.Error())
 		return

--- a/executor/instance.go
+++ b/executor/instance.go
@@ -70,7 +70,7 @@ func NewInstanceSetup(relRootDir string, rs ReplicationSender, tm []*trigger.Tri
 	if initCatalog {
 		ThisInstance.CatalogDir, err = catalog.NewDirectory(rootDir)
 		if err != nil {
-			var e *catalog.ErrCategoryFileNotFound
+			var e catalog.ErrCategoryFileNotFound
 			if errors.As(err, &e) {
 				log.Debug("new root directory found:" + rootDir)
 			} else {


### PR DESCRIPTION
## WHAT
- when `category_name` file is not found in a directory for a symbol, marketstore ignores the directory.

## WHY
- When a data directory is deleted manually or by Delete API, it's possible that only files (`category_name` and `****.bin`) are deleted and some directories (e.g. `/AAPL/1Sec/` directory in `AAPL/1Sec/TICK` data directory) remains. In that case, marketstore shows "category_name not found" error and hangs. This PR will ignore such partially deleted directories and continue other processes. 