### PR TITLE
refactor(log): avoid using fatal log

### DIFF
--- a/cmd/tool/integrity/main.go
+++ b/cmd/tool/integrity/main.go
@@ -93,12 +93,14 @@ func init() {
 		monthEnd = 10000
 	} else {
 		if monthEnd < 1 || monthEnd > 12 {
-			log.Fatal("Ending month must be in the range 1-12")
+			log.Error("Ending month must be in the range 1-12")
+			os.Exit(1)
 		}
 	}
 	if monthStart != 0 {
 		if monthStart < 1 || monthStart > 12 {
-			log.Fatal("Start month must be in the range 1-12")
+			log.Error("Start month must be in the range 1-12")
+			os.Exit(1)
 		}
 	}
 

--- a/contrib/calendar/calendar.go
+++ b/contrib/calendar/calendar.go
@@ -69,7 +69,7 @@ func New(calendarJSON string) *Calendar {
 	cmap := calendarJson{}
 	err := json.Unmarshal([]byte(calendarJSON), &cmap)
 	if err != nil {
-		log.Fatal(fmt.Sprintf("failed to unmarshal calendarJson:%s", calendarJSON))
+		log.Error(fmt.Sprintf("failed to unmarshal calendarJson:%s", calendarJSON))
 		return nil
 	}
 	for _, dateString := range cmap.NonTradingDays {

--- a/contrib/ice/cmd/reorg/import.go
+++ b/contrib/ice/cmd/reorg/import.go
@@ -44,7 +44,10 @@ var ImportCmd = &cobra.Command{
 			return fmt.Errorf("failed to create new instance setup for Import: %w", err)
 		}
 
-		reorg.Import(reorgDir, reimport, storeWithoutSymbols)
+		err = reorg.Import(reorgDir, reimport, storeWithoutSymbols)
+		if err != nil {
+			return fmt.Errorf("failed to import: %w", err)
+		}
 		return nil
 	},
 }

--- a/contrib/iex/backfill/backfill.go
+++ b/contrib/iex/backfill/backfill.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"sort"
 	"strings"
@@ -46,12 +47,14 @@ func main() {
 
 	start, err := time.Parse(format, from)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Error(err.Error())
+		os.Exit(1)
 	}
 
 	end, err := time.Parse(format, to)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Error(err.Error())
+		os.Exit(1)
 	}
 
 	log.Info("backfilling from %v to %v", start.Format(format), end.Format(format))

--- a/contrib/ondiskagg/aggtrigger/aggtrigger.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger.go
@@ -93,7 +93,7 @@ func NewTrigger(conf map[string]interface{}) (trigger.Trigger, error) {
 	for _, dest := range config.Destinations {
 		tf := utils.TimeframeFromString(dest)
 		if tf == nil {
-			log.Fatal("invalid destination: %s", dest)
+			log.Error("invalid destination: %s", dest)
 			return nil, errors.New("please specify valid timeframe for 'destinations' " +
 				"in the aggtrigger config. dest=" + dest)
 		}

--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -256,13 +256,13 @@ func main() {
 func initConfig() (rootDir string, triggers []*utils.TriggerSetting, walRotateInterval int) {
 	data, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
-		log.Fatal("failed to read configuration file error: %s", err.Error())
+		log.Error("failed to read configuration file error: %s", err.Error())
 		os.Exit(1)
 	}
 
 	config, err := utils.InstanceConfig.Parse(data)
 	if err != nil {
-		log.Fatal("failed to parse configuration file error: %v", err.Error())
+		log.Error("failed to parse configuration file error: %v", err.Error())
 		os.Exit(1)
 	}
 

--- a/executor/instance.go
+++ b/executor/instance.go
@@ -113,9 +113,10 @@ func NewInstanceSetup(relRootDir string, rs ReplicationSender, tm []*trigger.Tri
 
 			c := NewWALCleaner(ignoreFile, myInstanceID)
 			err = c.CleanupOldWALFiles(walFileAbsPaths)
-			// err = ThisInstance.WALFile.cleanupOldWALFiles(rootDir)
 			if err != nil {
-				log.Fatal("Unable to startup Cache and WAL:" + err.Error())
+				log.Error("Unable to startup Cache and WAL:" + err.Error())
+				return nil, nil, nil,
+					fmt.Errorf("unable to startup Cache and WAL:%w", err)
 			}
 		}
 		if backgroundSync {

--- a/utils/config.go
+++ b/utils/config.go
@@ -155,8 +155,8 @@ func (m *MktsConfig) Parse(data []byte) (*MktsConfig, error) {
 	// Giving "" to LoadLocation will be UTC anyway, which is our default too.
 	m.Timezone, err = time.LoadLocation(aux.Timezone)
 	if err != nil {
-		log.Fatal("Invalid timezone.")
-		return nil, errors.New("Invalid timezone")
+		log.Error("Invalid timezone.")
+		return nil, fmt.Errorf("invalid timezone:%s", aux.Timezone)
 	}
 
 	if aux.WALRotateInterval == 0 {


### PR DESCRIPTION
## WHAT
- replace `log.Fatal` to `log.Error` + appropriate error handling

## WHY
- `log.Fatal` shutdowns the marketstore process, which causes unexpected operation issues