### PR TITLE
refactor(error): remove log.fatal and add error handlings

### DIFF
--- a/contrib/ice/reorg/import.go
+++ b/contrib/ice/reorg/import.go
@@ -84,7 +84,10 @@ func readAnnouncements(path string) (*[]Announcement, error) {
 	}
 	content := string(buff)
 	var announcements = []Announcement{}
-	readRecords(content, &announcements)
+	err = readRecords(content, &announcements)
+	if err != nil {
+		return nil, fmt.Errorf("failed to readRecords: %w", err)
+	}
 	log.Info(fmt.Sprintf("Read %d records", len(announcements)))
 	return &announcements, nil
 }
@@ -125,8 +128,7 @@ func storeAnnouncements(notes []Announcement, cusipSymbolMap map[string]string, 
 			}
 			if symbol != "" {
 				if err := storeAnnouncement(symbol, &note); err != nil {
-					log.Fatal("Unable to store Announcement: %+v %+v", err, note)
-					return err
+					return fmt.Errorf("unable to store Announcement: %w %+v", err, note)
 				}
 			} else {
 				log.Warn("Cannot map CUSIP %s to Symbol", note.TargetCusip)

--- a/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
@@ -65,7 +65,8 @@ func TestAgg(t *testing.T) {
 	cs.AddColumn("Low", low)
 	cs.AddColumn("Close", close)
 
-	outCs := aggregate(cs, aggTbk, baseTbk, "TEST")
+	outCs, err := aggregate(cs, aggTbk, baseTbk, "TEST")
+	assert.Nil(t, err)
 	assert.Equal(t, outCs.Len(), 3)
 	assert.Equal(t, outCs.GetColumn("Open").([]float32)[0], float32(1.))
 	assert.Equal(t, outCs.GetColumn("High").([]float32)[1], float32(4.1))
@@ -90,7 +91,8 @@ func TestAgg(t *testing.T) {
 	cs.AddColumn("Low", low)
 	cs.AddColumn("Close", close)
 
-	outCs = aggregate(cs, aggTbk, baseTbk, "TEST")
+	outCs, err = aggregate(cs, aggTbk, baseTbk, "TEST")
+	assert.Nil(t, err)
 	assert.Equal(t, outCs.Len(), 2)
 	d1 := time.Date(2017, 12, 15, 0, 0, 0, 0, utils.InstanceConfig.Timezone)
 	d2 := time.Date(2017, 12, 16, 0, 0, 0, 0, utils.InstanceConfig.Timezone)

--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -103,11 +103,13 @@ func main() {
 	}()
 
 	if apiKey == "" {
-		log.Fatal("[polygon] api key is required")
+		log.Error("[polygon] api key is required")
+		os.Exit(1)
 	}
 
 	if noIngest && cacheDir == "" {
-		log.Fatal("[polygon] no-ingest should only be specified when cache-dir is set")
+		log.Error("[polygon] no-ingest should only be specified when cache-dir is set")
+		os.Exit(1)
 	}
 	backfill.NoIngest = noIngest
 
@@ -115,33 +117,39 @@ func main() {
 
 	start, err := time.Parse(format, from)
 	if err != nil {
-		log.Fatal("[polygon] failed to parse from timestamp (%v)", err)
+		log.Error("[polygon] failed to parse from timestamp (%v)", err)
+		os.Exit(1)
 	}
 
 	end, err := time.Parse(format, to)
 	if err != nil {
-		log.Fatal("[polygon] failed to parse to timestamp (%v)", err)
+		log.Error("[polygon] failed to parse to timestamp (%v)", err)
+		os.Exit(1)
 	}
 
 	tradePeriodDuration, err := parseAndValidateDuration(tradePeriod, 60*24*time.Hour, 24*time.Hour)
 	if err != nil {
-		log.Fatal("[polygon] failed to parse trade-period duration (%v)", err)
+		log.Error("[polygon] failed to parse trade-period duration (%v)", err)
+		os.Exit(1)
 	}
 
 	quotePeriodDuration, err := parseAndValidateDuration(quotePeriod, 60*24*time.Hour, 24*time.Hour)
 	if err != nil {
-		log.Fatal("[polygon] failed to parse trade-period duration (%v)", err)
+		log.Error("[polygon] failed to parse trade-period duration (%v)", err)
+		os.Exit(1)
 	}
 
 	barPeriodDuration, err := parseAndValidateDuration(barPeriod, 60*24*time.Hour, 24*time.Hour)
 	if err != nil {
-		log.Fatal("[polygon] failed to parse trade-period duration (%v)", err)
+		log.Error("[polygon] failed to parse trade-period duration (%v)", err)
+		os.Exit(1)
 	}
 
 	if cacheDir != "" {
 		err = os.MkdirAll(cacheDir, 0777)
 		if err != nil {
-			log.Fatal("[polygon] cannot create json dump directory (%v)", err)
+			log.Error("[polygon] cannot create json dump directory (%v)", err)
+			os.Exit(1)
 		}
 		log.Info("[polygon] using %s to dump polygon's replies", cacheDir)
 		api.CacheDir = cacheDir
@@ -169,7 +177,8 @@ func main() {
 	symbolList = unique(symbolList)
 	sort.Strings(symbolList)
 	if len(symbolList) == 0 {
-		log.Fatal("no symbol selected")
+		log.Error("no symbol selected")
+		os.Exit(1)
 	}
 	log.Info("[polygon] selected %v symbols", len(symbolList))
 
@@ -178,7 +187,8 @@ func main() {
 		for _, exchangeIDStr := range strings.Split(exchanges, ",") {
 			exchangeIDInt, err := strconv.Atoi(exchangeIDStr)
 			if err != nil {
-				log.Fatal("Invalid exchange ID: %v", exchangeIDStr)
+				log.Error("Invalid exchange ID: %v", exchangeIDStr)
+				os.Exit(1)
 			}
 
 			exchangeIDs = append(exchangeIDs, exchangeIDInt)

--- a/models/bar.go
+++ b/models/bar.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"math"
 	"time"
 
@@ -187,7 +188,7 @@ func conditionToUpdateInfo(conditions []enum.TradeCondition) ConsolidatedUpdateI
 	return r
 }
 
-func FromTrades(trades *Trade, symbol string, timeframe string) *Bar {
+func FromTrades(trades *Trade, symbol string, timeframe string) (*Bar, error) {
 	bar := NewBar(symbol, timeframe, len(trades.Epoch))
 
 	var bucketDuration time.Duration
@@ -201,8 +202,7 @@ func FromTrades(trades *Trade, symbol string, timeframe string) *Bar {
 	case "1D":
 		bucketDuration = 24 * time.Hour
 	default:
-		log.Fatal("unsupported timeframe: %v", timeframe)
-		return nil
+		return nil, fmt.Errorf("unsupported timeframe: %v", timeframe)
 	}
 
 	var epoch int64
@@ -302,5 +302,5 @@ func FromTrades(trades *Trade, symbol string, timeframe string) *Bar {
 		bar.Add(epoch, open, high, low, close_, volume)
 	}
 
-	return bar
+	return bar, nil
 }

--- a/models/bar_test.go
+++ b/models/bar_test.go
@@ -35,7 +35,8 @@ func TestFromTradesFieldExcludes(t *testing.T) {
 	)
 
 	// When converted to bars
-	bars := FromTrades(trades, symbol, "1Min")
+	bars, err := FromTrades(trades, symbol, "1Min")
+	assert.Nil(t, err)
 
 	assert.NotNil(t, bars)
 	assert.Len(t, bars.Epoch, 2)
@@ -85,7 +86,8 @@ func TestFromTradesDailyRollup(t *testing.T) {
 	)
 
 	// When converted to bars
-	bars := FromTrades(trades, symbol, "1D")
+	bars, err := FromTrades(trades, symbol, "1D")
+	assert.Nil(t, err)
 
 	// Then the daily close price should match to the specified
 	assert.NotNil(t, bars)

--- a/utils/config.go
+++ b/utils/config.go
@@ -135,7 +135,7 @@ func (m *MktsConfig) Parse(data []byte) (*MktsConfig, error) {
 
 	// GRPC is optional for now
 	// if aux.GRPCListenPort == "" {
-	// 	log.Fatal("Invalid GRPC listen port.")
+	// 	log.Error("Invalid GRPC listen port.")
 	// 	return errors.New("Invalid GRPC listen port.")
 	// }
 	if aux.GRPCMaxSendMsgSize == 0 {

--- a/utils/test/setup.go
+++ b/utils/test/setup.go
@@ -89,6 +89,7 @@ func makeYearFiles(root string, years []string, withdata bool, withGaps bool, tf
 		checkfail(err, "Unable to write header to: "+filename)
 		if withdata {
 			(*itemsWritten)[filename], err = WriteDummyData(file, year, tf, withGaps, isStock)
+			checkfail(err, "Unable to write dummy data")
 			//			fmt.Printf("File: %s Number: %d\n", filename, (*itemsWritten)[filename])
 		}
 	}
@@ -190,7 +191,7 @@ func WriteDummyData(f *os.File, year, tf string, makeGap, isStock bool) (int, er
 	var yr int
 	n, err := fmt.Sscanf(year, "%d", &yr)
 	if n != 1 || err != nil {
-		log.Fatal("Failed to convert string year to int - Error: %v", err)
+		return 0, fmt.Errorf("failed to convert string year=%s to int: %w", year, err)
 	}
 	var candlesCurrency []ohlc
 	var candlesStock []ohlcv


### PR DESCRIPTION
## WHAT
- replace `log.Fatal` to `log.Error` + appropriate error handling

## WHY
- `log.Fatal` shutdowns the marketstore process, which causes unexpected operation issues