### PR TITLE
add: read size check after read

### DIFF
--- a/executor/scanner.go
+++ b/executor/scanner.go
@@ -590,6 +590,11 @@ func (ex *ioExec) readBackward(finalBuffer []byte, fp *ioFilePlan,
 			if numRead <= bytesToRead {
 				bytesToRead -= numRead
 				copy(finalBuffer[bytesToRead:], fileBuffer)
+
+				// read enough data
+				if bytesToRead == 0 {
+					break
+				}
 			} else {
 				copy(finalBuffer, fileBuffer[numRead-bytesToRead:])
 				bytesToRead = 0


### PR DESCRIPTION
## WHAT
- Fixed a bug in the loop that reads a data file when it is queried.
There was no check about if enough data has been read immediately after reading the data, which was causing entire file scan.

## WHY
- This bug causes high CPU usage issues.