### PR TITLE
fix(query): off-by-one bug in read size check after read

### DIFF
--- a/executor/scanner.go
+++ b/executor/scanner.go
@@ -587,7 +587,7 @@ func (ex *ioExec) readBackward(finalBuffer []byte, fp *ioFilePlan,
 		// Copy the found data into the final buffer in reverse order
 		if numRead != 0 {
 			bytesRead += numRead
-			if numRead <= bytesToRead {
+			if numRead < bytesToRead {
 				bytesToRead -= numRead
 				copy(finalBuffer[bytesToRead:], fileBuffer)
 			} else {


### PR DESCRIPTION
## WHAT
- Fixed a bug in the loop that reads a data file when it is queried.
If `numRead==bytesToRead`, read can be finished.

## WHY
- This bug causes high CPU usage issues.