### PR TITLE
bugfix(cli): CSV import via remote marketstore connection

### DIFF
--- a/cmd/connect/main.go
+++ b/cmd/connect/main.go
@@ -3,6 +3,8 @@ package connect
 import (
 	"errors"
 
+	"github.com/alpacahq/marketstore/v4/frontend/client"
+
 	"github.com/spf13/cobra"
 
 	"github.com/alpacahq/marketstore/v4/cmd/connect/session"
@@ -86,7 +88,13 @@ func executeConnect(cmd *cobra.Command, args []string) error {
 
 	// Attempt remote mode.
 	if len(url) != 0 {
-		conn, err = session.NewRemoteAPIClient(url)
+		// Attempt connection to remote host.
+		rpcClient, err := client.NewClient(url)
+		if err != nil {
+			return err
+		}
+
+		conn, err = session.NewRemoteAPIClient(url, rpcClient)
 		if err != nil {
 			return err
 		}
@@ -96,13 +104,8 @@ func executeConnect(cmd *cobra.Command, args []string) error {
 		utils.InstanceConfig.DisableVariableCompression = true
 	}
 
-	c = session.NewClient(conn)
-
 	// Initialize connection.
-	err = c.Connect()
-	if err != nil {
-		return err
-	}
+	c = session.NewClient(conn)
 
 	// Enter command loop
 	err = c.Read()

--- a/cmd/connect/session/client.go
+++ b/cmd/connect/session/client.go
@@ -44,8 +44,6 @@ type Client struct {
 type APIClient interface {
 	// PrintConnectInfo prints connection information to stdout.
 	PrintConnectInfo()
-	// Connect initializes a client connection.
-	Connect() error
 	// Create creates a new bucket in the marketstore server
 	Create(reqs *frontend.MultiCreateRequest, responses *frontend.MultiServerResponse) error
 	// Write executes a write operation to the marketstore server.
@@ -58,10 +56,6 @@ type APIClient interface {
 	GetBucketInfo(reqs *frontend.MultiKeyRequest, responses *frontend.MultiGetInfoResponse) error
 	// SQL executes the specified sql statement
 	SQL(line string) (cs *dbio.ColumnSeries, err error)
-}
-
-func (c *Client) Connect() error {
-	return c.apiClient.Connect()
 }
 
 // RPCClient is a marketstore API client interface.

--- a/cmd/connect/session/local_api_client.go
+++ b/cmd/connect/session/local_api_client.go
@@ -49,10 +49,6 @@ type LocalAPIClient struct {
 func (lc *LocalAPIClient) PrintConnectInfo() {
 	fmt.Fprintf(os.Stderr, "Connected to local instance at path: %v\n", lc.dir)
 }
-func (lc *LocalAPIClient) Connect() error {
-	// Nothing to do here yet..
-	return nil
-}
 
 func (lc *LocalAPIClient) Write(reqs *frontend.MultiWriteRequest, responses *frontend.MultiServerResponse) error {
 	ds := frontend.NewDataService(lc.dir, lc.catalogDir, lc.aggRunner, lc.writer, lc.query)

--- a/cmd/connect/session/mock/client.go
+++ b/cmd/connect/session/mock/client.go
@@ -8,50 +8,35 @@ import (
 	reflect "reflect"
 	time "time"
 
-	gomock "github.com/golang/mock/gomock"
-
 	frontend "github.com/alpacahq/marketstore/v4/frontend"
 	io "github.com/alpacahq/marketstore/v4/utils/io"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockAPIClient is a mock of APIClient interface
+// MockAPIClient is a mock of APIClient interface.
 type MockAPIClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIClientMockRecorder
 }
 
-// MockAPIClientMockRecorder is the mock recorder for MockAPIClient
+// MockAPIClientMockRecorder is the mock recorder for MockAPIClient.
 type MockAPIClientMockRecorder struct {
 	mock *MockAPIClient
 }
 
-// NewMockAPIClient creates a new mock instance
+// NewMockAPIClient creates a new mock instance.
 func NewMockAPIClient(ctrl *gomock.Controller) *MockAPIClient {
 	mock := &MockAPIClient{ctrl: ctrl}
 	mock.recorder = &MockAPIClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPIClient) EXPECT() *MockAPIClientMockRecorder {
 	return m.recorder
 }
 
-// Connect mocks base method
-func (m *MockAPIClient) Connect() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Connect")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Connect indicates an expected call of Connect
-func (mr *MockAPIClientMockRecorder) Connect() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockAPIClient)(nil).Connect))
-}
-
-// Create mocks base method
+// Create mocks base method.
 func (m *MockAPIClient) Create(arg0 *frontend.MultiCreateRequest, arg1 *frontend.MultiServerResponse) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
@@ -59,13 +44,13 @@ func (m *MockAPIClient) Create(arg0 *frontend.MultiCreateRequest, arg1 *frontend
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockAPIClientMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockAPIClient)(nil).Create), arg0, arg1)
 }
 
-// Destroy mocks base method
+// Destroy mocks base method.
 func (m *MockAPIClient) Destroy(arg0 *frontend.MultiKeyRequest, arg1 *frontend.MultiServerResponse) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Destroy", arg0, arg1)
@@ -73,13 +58,13 @@ func (m *MockAPIClient) Destroy(arg0 *frontend.MultiKeyRequest, arg1 *frontend.M
 	return ret0
 }
 
-// Destroy indicates an expected call of Destroy
+// Destroy indicates an expected call of Destroy.
 func (mr *MockAPIClientMockRecorder) Destroy(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockAPIClient)(nil).Destroy), arg0, arg1)
 }
 
-// GetBucketInfo mocks base method
+// GetBucketInfo mocks base method.
 func (m *MockAPIClient) GetBucketInfo(arg0 *frontend.MultiKeyRequest, arg1 *frontend.MultiGetInfoResponse) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBucketInfo", arg0, arg1)
@@ -87,25 +72,25 @@ func (m *MockAPIClient) GetBucketInfo(arg0 *frontend.MultiKeyRequest, arg1 *fron
 	return ret0
 }
 
-// GetBucketInfo indicates an expected call of GetBucketInfo
+// GetBucketInfo indicates an expected call of GetBucketInfo.
 func (mr *MockAPIClientMockRecorder) GetBucketInfo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketInfo", reflect.TypeOf((*MockAPIClient)(nil).GetBucketInfo), arg0, arg1)
 }
 
-// PrintConnectInfo mocks base method
+// PrintConnectInfo mocks base method.
 func (m *MockAPIClient) PrintConnectInfo() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "PrintConnectInfo")
 }
 
-// PrintConnectInfo indicates an expected call of PrintConnectInfo
+// PrintConnectInfo indicates an expected call of PrintConnectInfo.
 func (mr *MockAPIClientMockRecorder) PrintConnectInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrintConnectInfo", reflect.TypeOf((*MockAPIClient)(nil).PrintConnectInfo))
 }
 
-// SQL mocks base method
+// SQL mocks base method.
 func (m *MockAPIClient) SQL(arg0 string) (*io.ColumnSeries, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SQL", arg0)
@@ -114,13 +99,13 @@ func (m *MockAPIClient) SQL(arg0 string) (*io.ColumnSeries, error) {
 	return ret0, ret1
 }
 
-// SQL indicates an expected call of SQL
+// SQL indicates an expected call of SQL.
 func (mr *MockAPIClientMockRecorder) SQL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SQL", reflect.TypeOf((*MockAPIClient)(nil).SQL), arg0)
 }
 
-// Show mocks base method
+// Show mocks base method.
 func (m *MockAPIClient) Show(arg0 *io.TimeBucketKey, arg1, arg2 *time.Time) (io.ColumnSeriesMap, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Show", arg0, arg1, arg2)
@@ -129,13 +114,13 @@ func (m *MockAPIClient) Show(arg0 *io.TimeBucketKey, arg1, arg2 *time.Time) (io.
 	return ret0, ret1
 }
 
-// Show indicates an expected call of Show
+// Show indicates an expected call of Show.
 func (mr *MockAPIClientMockRecorder) Show(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Show", reflect.TypeOf((*MockAPIClient)(nil).Show), arg0, arg1, arg2)
 }
 
-// Write mocks base method
+// Write mocks base method.
 func (m *MockAPIClient) Write(arg0 *frontend.MultiWriteRequest, arg1 *frontend.MultiServerResponse) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0, arg1)
@@ -143,7 +128,7 @@ func (m *MockAPIClient) Write(arg0 *frontend.MultiWriteRequest, arg1 *frontend.M
 	return ret0
 }
 
-// Write indicates an expected call of Write
+// Write indicates an expected call of Write.
 func (mr *MockAPIClientMockRecorder) Write(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockAPIClient)(nil).Write), arg0, arg1)

--- a/cmd/connect/session/remote_api_client_test.go
+++ b/cmd/connect/session/remote_api_client_test.go
@@ -1,0 +1,86 @@
+package session_test
+
+import (
+	"errors"
+	"github.com/alpacahq/marketstore/v4/cmd/connect/session"
+	"github.com/alpacahq/marketstore/v4/frontend"
+	"github.com/alpacahq/marketstore/v4/utils/io"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var exampleGetInfoResponse = frontend.GetInfoResponse{
+	LatestYear: 2021,
+	TimeFrame:  1 * time.Second,
+	DSV:        []io.DataShape{},
+	RecordType: io.FIXED,
+}
+
+type mockRpcClient struct {
+	resp interface{}
+	err  error
+}
+
+func (mc mockRpcClient) DoRPC(_ string, args interface{}) (response interface{}, err error) {
+	return mc.resp, mc.err
+}
+
+func TestRemoteAPIClient_GetBucketInfo(t *testing.T) {
+	tests := []struct {
+		name          string
+		rpcClient     session.RPCClient
+		reqs          *frontend.MultiKeyRequest
+		wantResponses *frontend.MultiGetInfoResponse
+		wantErr       bool
+	}{
+		{
+			name: "Success",
+			rpcClient: mockRpcClient{
+				resp: &frontend.MultiGetInfoResponse{
+					Responses: []frontend.GetInfoResponse{exampleGetInfoResponse},
+				}, err: nil,
+			},
+			wantResponses: &frontend.MultiGetInfoResponse{
+				Responses: []frontend.GetInfoResponse{exampleGetInfoResponse},
+			},
+			wantErr: false,
+		},
+		{
+			name:          "error/unexpected interface returned from DoRPC",
+			rpcClient:     mockRpcClient{resp: "aaaaa", err: nil},
+			wantResponses: &frontend.MultiGetInfoResponse{},
+			wantErr:       true,
+		},
+		{
+			name:          "error/error returned from DoRPC",
+			rpcClient:     mockRpcClient{resp: nil, err: errors.New("some error")},
+			wantResponses: &frontend.MultiGetInfoResponse{},
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// --- given ---
+			rc, err := session.NewRemoteAPIClient("exampleurl:1234", tt.rpcClient)
+			assert.Nil(t, err)
+
+			// --- when ---
+			responses := &frontend.MultiGetInfoResponse{}
+			err = rc.GetBucketInfo(tt.reqs, responses)
+
+			// --- then ---
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetBucketInfo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !reflect.DeepEqual(responses, tt.wantResponses) {
+				t.Errorf("GetBucketInfo() got = %v, want %v", responses, tt.wantResponses)
+			}
+		})
+	}
+}

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -271,7 +271,7 @@ func (q *query) Parse() (pr *ParseResult, err error) {
 	*/
 	getFileList(q.DataDir, &pr.QualifiedFiles, "", "")
 	if len(pr.QualifiedFiles) == 0 {
-		return pr, fmt.Errorf("no files returned from query parse. query restrictions=%v", q.Restriction)
+		return pr, fmt.Errorf("No files returned from query parse")
 	}
 
 	/*

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -271,7 +271,7 @@ func (q *query) Parse() (pr *ParseResult, err error) {
 	*/
 	getFileList(q.DataDir, &pr.QualifiedFiles, "", "")
 	if len(pr.QualifiedFiles) == 0 {
-		return pr, fmt.Errorf("No files returned from query parse")
+		return pr, fmt.Errorf("no files returned from query parse. query restrictions=%v", q.Restriction)
 	}
 
 	/*


### PR DESCRIPTION
## WHAT
- fix a bug that CSV import through a remote marketstore connection using `marketstore connect --url {hostname}:{port}` always fails.

## WHY
- bug fix.