### PR TITLE
refactor(tbk): unexport Key parameter of TimeBucketKey struct.

### DIFF
--- a/cmd/connect/session/create.go
+++ b/cmd/connect/session/create.go
@@ -43,8 +43,7 @@ func (c *Client) getinfo(line string) {
 		fmt.Printf("Failed to convert argument to key: %s\n", args[0])
 		return
 	}
-	tbk := *tbk_p
-	resp, err := c.GetBucketInfo(tbk)
+	resp, err := c.GetBucketInfo(tbk_p)
 	if err != nil {
 		fmt.Printf("Failed with error: %s\n", err.Error())
 		return
@@ -181,7 +180,7 @@ func (c *Client) destroy(line string) {
 	fmt.Printf("Successfully removed catalog entry for key: %s\n", args[0])
 }
 
-func (c *Client) GetBucketInfo(key io.TimeBucketKey) (resp *frontend.GetInfoResponse, err error) {
+func (c *Client) GetBucketInfo(key *io.TimeBucketKey) (resp *frontend.GetInfoResponse, err error) {
 	req := frontend.KeyRequest{Key: key.String()}
 	reqs := &frontend.MultiKeyRequest{
 		Requests: []frontend.KeyRequest{req},

--- a/cmd/connect/session/create_test.go
+++ b/cmd/connect/session/create_test.go
@@ -111,7 +111,7 @@ func TestClient_GetBucketInfo(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		key      io.TimeBucketKey
+		key      *io.TimeBucketKey
 		resp     *frontend.MultiGetInfoResponse
 		err      error
 		wantResp *frontend.GetInfoResponse
@@ -119,34 +119,34 @@ func TestClient_GetBucketInfo(t *testing.T) {
 	}{
 		{
 			name:     "success/bucket info returned",
-			key:      io.TimeBucketKey{Key: "TEST/1Min/TICK"},
+			key:      io.NewTimeBucketKey("TEST/1Min/TICK"),
 			resp:     &frontend.MultiGetInfoResponse{Responses: []frontend.GetInfoResponse{testGetInfoResponse}},
 			wantResp: &testGetInfoResponse,
 		},
 		{
 			name:     "error/no bucket info is returned",
-			key:      io.TimeBucketKey{Key: "TEST/1Min/TICK"},
+			key:      io.NewTimeBucketKey("TEST/1Min/TICK"),
 			resp:     &frontend.MultiGetInfoResponse{Responses: []frontend.GetInfoResponse{}}, // empty
 			wantResp: nil,
 			wantErr:  true,
 		},
 		{
 			name:     "error/nil response is returned",
-			key:      io.TimeBucketKey{Key: "TEST/1Min/TICK"},
+			key:      io.NewTimeBucketKey("TEST/1Min/TICK"),
 			resp:     nil,
 			wantResp: nil,
 			wantErr:  true,
 		},
 		{
 			name:     "error/error is passed",
-			key:      io.TimeBucketKey{Key: "TEST/1Min/TICK"},
+			key:      io.NewTimeBucketKey("TEST/1Min/TICK"),
 			err:      errors.New("error"),
 			wantResp: nil,
 			wantErr:  true,
 		},
 		{
 			name:     "error/error in Server Response struct is passed",
-			key:      io.TimeBucketKey{Key: "TEST/1Min/TICK"},
+			key:      io.NewTimeBucketKey("TEST/1Min/TICK"),
 			resp:     &frontend.MultiGetInfoResponse{Responses: []frontend.GetInfoResponse{testGetInfoErrResponse}},
 			wantResp: nil,
 			wantErr:  true,

--- a/cmd/connect/session/load.go
+++ b/cmd/connect/session/load.go
@@ -39,12 +39,11 @@ func (c *Client) load(line string) {
 	if dataFD != nil {
 		defer dataFD.Close()
 	}
-	tbk := *tbk_p
 
 	/*
 		Verify the presence of a bucket with the input key
 	*/
-	resp, err := c.GetBucketInfo(tbk)
+	resp, err := c.GetBucketInfo(tbk_p)
 	if err != nil {
 		fmt.Printf("Error finding existing bucket: %v\n", err)
 		return
@@ -67,7 +66,7 @@ func (c *Client) load(line string) {
 		chunkSize := 1000000
 		// chunkSize := 100
 
-		npm, endReached, err := loader.CSVtoNumpyMulti(csvReader, tbk, cvm, chunkSize, resp.RecordType == io.VARIABLE)
+		npm, endReached, err := loader.CSVtoNumpyMulti(csvReader, *tbk_p, cvm, chunkSize, resp.RecordType == io.VARIABLE)
 		if err != nil {
 			fmt.Println("Error: ", err.Error())
 			return

--- a/contrib/xignitefeeder/writer/bar_writer_test.go
+++ b/contrib/xignitefeeder/writer/bar_writer_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/alpacahq/marketstore/v4/contrib/xignitefeeder/api"
 	"github.com/alpacahq/marketstore/v4/contrib/xignitefeeder/internal"
-	"github.com/alpacahq/marketstore/v4/utils/io"
 )
 
 var (
@@ -79,10 +78,10 @@ func TestBarWriterImpl_Write(t *testing.T) {
 	}
 
 	// Time Bucket Key Name check
-	timeBucketKeyStr := string(m.WrittenCSM.GetMetadataKeys()[0].Key)
-	if timeBucketKeyStr != "1234/5Min/OHLCV:"+io.DefaultTimeBucketSchema {
+	timeBucketKeyStr := m.WrittenCSM.GetMetadataKeys()[0].GetItemKey()
+	if timeBucketKeyStr != "1234/5Min/OHLCV" {
 		t.Errorf("TimeBucketKey name is invalid. got=%v, want = %v",
-			timeBucketKeyStr, "1234/5Min/OHLCV:"+io.DefaultTimeBucketSchema)
+			timeBucketKeyStr, "1234/5Min/OHLCV")
 	}
 }
 

--- a/contrib/xignitefeeder/writer/quotes_range_writer_test.go
+++ b/contrib/xignitefeeder/writer/quotes_range_writer_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/alpacahq/marketstore/v4/contrib/xignitefeeder/api"
 	"github.com/alpacahq/marketstore/v4/contrib/xignitefeeder/internal"
-	"github.com/alpacahq/marketstore/v4/utils/io"
 )
 
 func TestQuotesRangeWriterImpl_Write(t *testing.T) {
@@ -69,10 +68,10 @@ func TestQuotesRangeWriterImpl_Write(t *testing.T) {
 	}
 
 	// Time Bucket Key Name check
-	timeBucketKeyStr := string(m.WrittenCSM.GetMetadataKeys()[0].Key)
-	if timeBucketKeyStr != "1234/1D/OHLCV:"+io.DefaultTimeBucketSchema {
+	timeBucketKeyStr := m.WrittenCSM.GetMetadataKeys()[0].GetItemKey()
+	if timeBucketKeyStr != "1234/1D/OHLCV" {
 		t.Errorf("TimeBucketKey name is invalid. got=%v, want = %v",
-			timeBucketKeyStr, "1234/1D/OHLCV:"+io.DefaultTimeBucketSchema)
+			timeBucketKeyStr, "1234/1D/OHLCV")
 	}
 }
 

--- a/contrib/xignitefeeder/writer/quotes_writer_test.go
+++ b/contrib/xignitefeeder/writer/quotes_writer_test.go
@@ -83,17 +83,17 @@ func TestQuotesWriterImpl_Write(t *testing.T) {
 	keys := m.WrittenCSM.GetMetadataKeys()
 	keyStrings := make([]string, len(keys))
 	for i, key := range keys {
-		keyStrings[i] = string(key.Key)
+		keyStrings[i] = key.GetItemKey()
 	}
 	sort.Strings(keyStrings)
 	timeBucketKeyStr := keyStrings[0]
-	if timeBucketKeyStr != "1234/1Sec/TICK:"+io.DefaultTimeBucketSchema {
+	if timeBucketKeyStr != "1234/1Sec/TICK" {
 		t.Errorf("TimeBucketKey for the first data is invalid. got=%v, want = %v",
-			timeBucketKeyStr, "1234/1Sec/TICK:"+io.DefaultTimeBucketSchema)
+			timeBucketKeyStr, "1234/1Sec/TICK")
 	}
 
 	// epoch time check
-	epochTime := m.WrittenCSM[io.TimeBucketKey{Key: timeBucketKeyStr}].GetColumn("Epoch").([]int64)[0]
+	epochTime := m.WrittenCSM[*io.NewTimeBucketKey(timeBucketKeyStr)].GetColumn("Epoch").([]int64)[0]
 	epoch := time.Unix(epochTime, 0)
 	if !epoch.Equal(May2nd) {
 		t.Errorf("The newer of Ask and Bid Datetimes should be used for the Epoch column.")
@@ -138,10 +138,10 @@ func TestQuotesWriterImpl_TimeLocation(t *testing.T) {
 	}
 
 	// Time Bucket Key
-	key := m.WrittenCSM.GetMetadataKeys()[0].Key
+	key := m.WrittenCSM.GetMetadataKeys()[0].GetItemKey()
 
 	// epoch time check
-	epochTime := m.WrittenCSM[io.TimeBucketKey{Key: key}].GetColumn("Epoch").([]int64)[0]
+	epochTime := m.WrittenCSM[*io.NewTimeBucketKey(key)].GetColumn("Epoch").([]int64)[0]
 	epoch := time.Unix(epochTime, 0)
 	if !epoch.Equal(May1st.Add(-3 * time.Hour)) { // = AskDateTime - UTCOffset
 		t.Errorf("Epoch value should be considered the UTCOffset.")

--- a/replication/replay_test.go
+++ b/replication/replay_test.go
@@ -102,7 +102,7 @@ func TestReplayerImpl_Replay(t *testing.T) {
 			writeErr: false,
 			wantCSM: io.ColumnSeriesMap(
 				map[io.TimeBucketKey]*io.ColumnSeries{
-					{Key: "AMZN/1Min/OHLC:Symbol/Timeframe/AttributeGroup"}: makeMockOHLCColumnSeries(
+					*io.NewTimeBucketKey("AMZN/1Min/OHLC"): makeMockOHLCColumnSeries(
 						time.Date(2020, 01, 01, 00, 00, 00, 0, time.UTC),
 						1, 2, 3, 4,
 					),
@@ -134,7 +134,7 @@ func TestReplayerImpl_Replay(t *testing.T) {
 			writeErr: false,
 			wantCSM: io.ColumnSeriesMap(
 				map[io.TimeBucketKey]*io.ColumnSeries{
-					{Key: "AMZN/1Sec/OHLC:Symbol/Timeframe/AttributeGroup"}: makeMockOHLCColumnSeries(variableRecordDate, 1, 2, 3, 4),
+					*io.NewTimeBucketKey("AMZN/1Sec/OHLC"): makeMockOHLCColumnSeries(variableRecordDate, 1, 2, 3, 4),
 				},
 			),
 			wantIsVariableLength: true,

--- a/utils/io/keytypes.go
+++ b/utils/io/keytypes.go
@@ -13,7 +13,9 @@ import (
 )
 
 type TimeBucketKey struct {
-	Key string `msgpack:"key"` // Key is the appended form, suitable for exported usage
+	// Key is the appended form, suitable for exported usage
+	// e.g. Key="AAPL/1Min/OHLC:Symbol/Timeframe/AttributeGroup"
+	key string `msgpack:"key"`
 	/*
 		itemKey     string
 		categoryKey string
@@ -66,20 +68,20 @@ func (mk *TimeBucketKey) String() (stringKey string) {
 	/*
 		return mk.itemKey + ":" + mk.categoryKey
 	*/
-	return mk.Key
+	return mk.key
 }
 func (mk *TimeBucketKey) GetCatKey() (catKey string) {
 	/*
 		return mk.categoryKey
 	*/
-	splitKey := strings.Split(mk.Key, ":")
+	splitKey := strings.Split(mk.key, ":")
 	return splitKey[1]
 }
 func (mk *TimeBucketKey) GetItemKey() (itemKey string) {
 	/*
 		return mk.itemKey
 	*/
-	splitKey := strings.Split(mk.Key, ":")
+	splitKey := strings.Split(mk.key, ":")
 	return splitKey[0]
 }
 func (mk *TimeBucketKey) GetCategories() (cats []string) {
@@ -141,7 +143,7 @@ func (mk *TimeBucketKey) SetItemInCategory(catName string, itemName string) {
 			itemKey += "/"
 		}
 	}
-	mk.Key = itemKey + ":" + mk.GetCatKey()
+	mk.key = itemKey + ":" + mk.GetCatKey()
 }
 
 func (mk *TimeBucketKey) GetTimeFrame() (tf *utils.Timeframe, err error) {

--- a/utils/io/keytypes_test.go
+++ b/utils/io/keytypes_test.go
@@ -1,7 +1,6 @@
 package io_test
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -19,9 +18,7 @@ func TestNewTimeBucketKeyFromWalKeyPath(t *testing.T) {
 		{
 			name:       "Success",
 			walKeyPath: "/project/marketstore/data/AMZN/1Min/TICK/2017.bin",
-			wantTbk: &io.TimeBucketKey{
-				Key: fmt.Sprintf("AMZN/1Min/TICK:%s", io.DefaultTimeBucketSchema),
-			},
+			wantTbk: io.NewTimeBucketKey("AMZN/1Min/TICK"),
 			wantYear: 2017,
 			wantErr:  false,
 		},


### PR DESCRIPTION
## WHAT
- unexport the Key parameter of TimeBucketKey

## WHY
- some implementations were assuming TimeBucketKey.Key parameter as "AAPL/1Min/OHLC" format, some were "AAPL/1Min/OHLC:Symbol/Timeframe/AttributeGroup" format. To avoid the confusion, unexport the parameter and ask the users of this struct to explicitly use `tbk.GetItemKey()` function to get "AAPL/1Min/OHLC" part.