### PR TITLE
feat(show): print the number of rows and columns at show cmd

### DIFF
--- a/cmd/connect/session/client.go
+++ b/cmd/connect/session/client.go
@@ -328,6 +328,7 @@ func printResult(queryText string, cs *dbio.ColumnSeries, optionalFile ...string
 	}
 	if writer == nil {
 		printHeaderLine(cs)
+		fmt.Printf("(%d rows * %d columns)\n", len(epoch), len(cs.GetColumnNames()))
 	} else {
 		writer.Flush()
 	}


### PR DESCRIPTION
## WHAT
- `\show` command prints `(%d rows * %d columns)` at the bottom
e.g.
```
\show MTB_quote_iex/1Sec/Tick 1970-01-01
(...skipping...)
2021-11-26 17:56:36 +0000 UTC      153.79      153.87   245917352  
2021-11-26 17:56:36 +0000 UTC      153.79      153.87   257680785  
2021-11-26 17:57:49 +0000 UTC      154.23      154.33   497324555  
2021-11-26 17:58:00 +0000 UTC      154.21      154.35   198279300  
2021-11-26 17:59:58 +0000 UTC      154.01      154.18   461854806  
2021-11-26 17:59:58 +0000 UTC      154.01      154.18   931088122  
=============================  ==========  ==========  ==========  
(2850 rows * 4 columns)
```

## WHY
- inspired by MySQL and other SQL CLIs. helpful for debugging.