### PR TITLE
fix: lint issues

### DIFF
--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -103,7 +103,7 @@ func TestPathToFileInfo(t *testing.T) {
 	mypath := rootDir + "/EURUSD/1Min/OHLC/2001.bin"
 	fileInfo, err = catalogDir.PathToTimeBucketInfo(mypath)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, fileInfo.Path, mypath)
@@ -119,7 +119,7 @@ func TestAddFile(t *testing.T) {
 	// fmt.Println(filePath)
 	subDir, err := catalogDir.GetOwningSubDirectory(filePath)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.Nil(t, err)
 	// fmt.Println(subDir.GetPath())
@@ -129,7 +129,7 @@ func TestAddFile(t *testing.T) {
 	// latestFile, err := subDir.GetLatestYearFile()
 	// fmt.Println(latestFile.Path)
 	if _, err = subDir.AddFile(int16(2016)); err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.Nil(t, err)
 	_, err = subDir.GetLatestYearFile()
@@ -170,7 +170,7 @@ func TestAddAndRemoveDataItem(t *testing.T) {
 
 	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.Nil(t, err)
 	catList = catalogDir.GatherCategoriesAndItems()
@@ -262,7 +262,7 @@ func TestAddAndRemoveDataItemFromEmptyDirectory(t *testing.T) {
 	// Sometimes people may call AddTimeBucket with an empty directory, let's test that
 	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.Nil(t, err)
 	err = catalogDir.AddTimeBucket(tbk, tbinfo)
@@ -271,12 +271,12 @@ func TestAddAndRemoveDataItemFromEmptyDirectory(t *testing.T) {
 	// Let's try two subsequent RemoveTimeBucket calls, the first should work, the second should err
 	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.Nil(t, err)
 	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.NotNil(t, err)
 }

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -253,7 +253,7 @@ func TestAddAndRemoveDataItemFromEmptyDirectory(t *testing.T) {
 	// Now let's remove the symbol and then re-add it - should work
 	err = catalogDir.RemoveTimeBucket(tbk)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.Nil(t, err)
 	err = catalogDir.AddTimeBucket(tbk, tbinfo)

--- a/cmd/connect/loader/read.go
+++ b/cmd/connect/loader/read.go
@@ -17,6 +17,7 @@ func readTimeColumns(csvData [][]string, columnIndex []int, conf *CSVConfig) (ep
 	mustComposeEpoch := columnIndex[2] == -1
 	if mustComposeEpoch {
 		if columnIndex[0] == -1 || columnIndex[1] == -1 {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Println("Unable to build Epoch time from mapping - need both a date and time")
 			return nil, nil
 		}
@@ -30,6 +31,7 @@ func readTimeColumns(csvData [][]string, columnIndex []int, conf *CSVConfig) (ep
 	if len(conf.Timezone) != 0 {
 		tzLoc, err = time.LoadLocation(conf.Timezone)
 		if err != nil {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Printf("Unable to parse timezone %s: %s\n", conf.Timezone, err.Error())
 			return nil, nil
 		}
@@ -57,7 +59,9 @@ func readTimeColumns(csvData [][]string, columnIndex []int, conf *CSVConfig) (ep
 			firstParse = false
 		}
 		if err != nil {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Printf("Error parsing Epoch column(s) from input data file: %s\n", err.Error())
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Printf("rowTime %v, mustComposeEpoch %v, dateTime %v, format %v, loc %v, fromAdj %v", rowTime, mustComposeEpoch, dateTime, conf.TimeFormat, tzLoc, formatAdj)
 			return nil, nil
 		}

--- a/cmd/connect/loader/read.go
+++ b/cmd/connect/loader/read.go
@@ -3,6 +3,8 @@ package loader
 import (
 	"fmt"
 	"time"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 // readTimeColumns returns the epoch and nano columns of a csv file.
@@ -17,8 +19,7 @@ func readTimeColumns(csvData [][]string, columnIndex []int, conf *CSVConfig) (ep
 	mustComposeEpoch := columnIndex[2] == -1
 	if mustComposeEpoch {
 		if columnIndex[0] == -1 || columnIndex[1] == -1 {
-			// nolint:forbidigo // CLI output needs fmt.Println
-			fmt.Println("Unable to build Epoch time from mapping - need both a date and time")
+			log.Info("Unable to build Epoch time from mapping - need both a date and time")
 			return nil, nil
 		}
 	}
@@ -31,8 +32,7 @@ func readTimeColumns(csvData [][]string, columnIndex []int, conf *CSVConfig) (ep
 	if len(conf.Timezone) != 0 {
 		tzLoc, err = time.LoadLocation(conf.Timezone)
 		if err != nil {
-			// nolint:forbidigo // CLI output needs fmt.Println
-			fmt.Printf("Unable to parse timezone %s: %s\n", conf.Timezone, err.Error())
+			log.Error(fmt.Sprintf("Unable to parse timezone %s: %s\n", conf.Timezone, err.Error()))
 			return nil, nil
 		}
 	}
@@ -59,10 +59,10 @@ func readTimeColumns(csvData [][]string, columnIndex []int, conf *CSVConfig) (ep
 			firstParse = false
 		}
 		if err != nil {
-			// nolint:forbidigo // CLI output needs fmt.Println
-			fmt.Printf("Error parsing Epoch column(s) from input data file: %s\n", err.Error())
-			// nolint:forbidigo // CLI output needs fmt.Println
-			fmt.Printf("rowTime %v, mustComposeEpoch %v, dateTime %v, format %v, loc %v, fromAdj %v", rowTime, mustComposeEpoch, dateTime, conf.TimeFormat, tzLoc, formatAdj)
+			log.Error(fmt.Sprintf("Error parsing Epoch column(s) from input data file: %s\n", err.Error()))
+			log.Error(fmt.Sprintf("rowTime %v, mustComposeEpoch %v, dateTime %v, format %v, loc %v, fromAdj %v",
+				rowTime, mustComposeEpoch, dateTime, conf.TimeFormat, tzLoc, formatAdj),
+			)
 			return nil, nil
 		}
 		epochCol[i] = rowTime.UTC().Unix()

--- a/cmd/connect/loader/utils.go
+++ b/cmd/connect/loader/utils.go
@@ -35,7 +35,7 @@ type CSVMetadata struct {
 
 func CSVtoNumpyMulti(csvReader *csv.Reader, tbk io.TimeBucketKey, cvm *CSVMetadata, chunkSize int,
 	isVariable bool) (npm *io.NumpyMultiDataset, endReached bool, err error) {
-	fmt.Println("Beginning parse...")
+あああ	fmt.Println("Beginning parse...")
 
 	csvChunk := make([][]string, 0)
 	var linesRead int

--- a/cmd/connect/loader/utils.go
+++ b/cmd/connect/loader/utils.go
@@ -23,10 +23,10 @@ type CSVConfig struct {
 }
 
 type CSVMetadata struct {
-	Config      *CSVConfig     // Configuration of the CSV file, including the names of the columns
+	Config *CSVConfig // Configuration of the CSV file, including the names of the columns
 	// DSV is data shapes inside this CSV file. The first 2 columns are "Epoch-date" and "Epoch-time".
 	// If the schema of existent bucket is "Epoch,Ask,Bid", DSV is ["Epoch-date", "Epoch-time", "Epoch", "Ask", "Bid"].
-	DSV         []io.DataShape
+	DSV []io.DataShape
 	// ColumnIndex maps the index of the columns in the CSV file to each time bucket in the DB.
 	// ColumnIndex[i+2]=-1 when the column of DSV[i] doesn't exist in the provided CSV file.
 	// e.g. when the bucket is "Epoch,Ask,Bid" and Column[3] = -1, it means the provided CSV doesn't have "Ask" column.
@@ -35,7 +35,7 @@ type CSVMetadata struct {
 
 func CSVtoNumpyMulti(csvReader *csv.Reader, tbk io.TimeBucketKey, cvm *CSVMetadata, chunkSize int,
 	isVariable bool) (npm *io.NumpyMultiDataset, endReached bool, err error) {
-あああ	fmt.Println("Beginning parse...")
+	log.Info("Beginning parse...")
 
 	csvChunk := make([][]string, 0)
 	var linesRead int
@@ -51,7 +51,7 @@ func CSVtoNumpyMulti(csvReader *csv.Reader, tbk io.TimeBucketKey, cvm *CSVMetada
 	if len(csvChunk) == 0 {
 		return nil, true, nil
 	}
-	fmt.Printf("Read next %d lines from CSV file...\n", linesRead)
+	log.Info("Read next %d lines from CSV file...\n", linesRead)
 
 	csm, err := convertCSVtoCSM(tbk, cvm, csvChunk)
 	if err != nil {
@@ -80,7 +80,7 @@ func CSVtoNumpyMulti(csvReader *csv.Reader, tbk io.TimeBucketKey, cvm *CSVMetada
 // ReadMetadata returns formatting info about the csv file containing
 // the data to be loaded into the database.
 func ReadMetadata(dataFD, controlFD *os.File, dbDataShapes []io.DataShape) (csvReader *csv.Reader, cvm *CSVMetadata, err error) {
-	fmt.Println("DB Data Shapes: ", dbDataShapes)
+	log.Info("DB Data Shapes: ", dbDataShapes)
 
 	cvm = &CSVMetadata{}
 
@@ -95,7 +95,7 @@ func ReadMetadata(dataFD, controlFD *os.File, dbDataShapes []io.DataShape) (csvR
 
 	var inputColNames []string
 	if dataFD == nil {
-		fmt.Println("Failed to open data file for loading")
+		log.Error("Failed to open data file for loading")
 		return nil, nil, err
 	}
 
@@ -142,7 +142,7 @@ func ReadMetadata(dataFD, controlFD *os.File, dbDataShapes []io.DataShape) (csvR
 	if cvm.Config.FirstRowHasColumnNames {
 		inputColNames, err = csvReader.Read() // Read the column names
 		if err != nil {
-			fmt.Println("Error reading first row of column names from data file: " + err.Error())
+			log.Error("Error reading first row of column names from data file: " + err.Error())
 			return nil, nil, err
 		}
 	}
@@ -170,7 +170,7 @@ func ReadMetadata(dataFD, controlFD *os.File, dbDataShapes []io.DataShape) (csvR
 		*/
 		if len(cvm.Config.ColumnNameMap) > len(inputColNames) {
 			err = fmt.Errorf("error: ColumnNameMap from conf file has more entries than the column names from the input file")
-			fmt.Println(err.Error())
+			log.Error(err.Error())
 			return nil, nil, err
 		}
 		for i, name := range cvm.Config.ColumnNameMap {
@@ -209,7 +209,7 @@ func ReadMetadata(dataFD, controlFD *os.File, dbDataShapes []io.DataShape) (csvR
 	for i := 2; i < len(cvm.ColumnIndex); i++ {
 		if cvm.ColumnIndex[i] == -1 {
 			fail = true
-			fmt.Printf("Unable to find a matching csv column for \"%s\"\n", cvm.DSV[i-2].Name)
+			log.Error(fmt.Sprintf("Unable to find a matching csv column for \"%s\"\n", cvm.DSV[i-2].Name))
 		}
 	}
 	if fail {
@@ -222,7 +222,7 @@ func ReadMetadata(dataFD, controlFD *os.File, dbDataShapes []io.DataShape) (csvR
 func convertCSVtoCSM(tbk io.TimeBucketKey, cvm *CSVMetadata, csvDataChunk [][]string) (csm io.ColumnSeriesMap, err error) {
 	epochCol, nanosCol := readTimeColumns(csvDataChunk, cvm.ColumnIndex, cvm.Config)
 	if epochCol == nil {
-		fmt.Println("Error building time columns from csv data")
+		log.Error("Error building time columns from csv data")
 		return
 	}
 

--- a/cmd/connect/loader/write.go
+++ b/cmd/connect/loader/write.go
@@ -105,7 +105,7 @@ func columnSeriesMapFromCSVData(csmInit io.ColumnSeriesMap, key io.TimeBucketKey
 
 func columnError(err error, name string) bool {
 	if err != nil {
-		fmt.Printf("Error obtaining column \"%s\" from csv data\n", name)
+		log.Error("Error obtaining column \"%s\" from csv data\n", name)
 		return true
 	}
 	return false

--- a/cmd/connect/session/client.go
+++ b/cmd/connect/session/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alpacahq/marketstore/v4/frontend"
 	"github.com/alpacahq/marketstore/v4/sqlparser"
 	dbio "github.com/alpacahq/marketstore/v4/utils/io"
+	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 func NewClient(ac APIClient) *Client {
@@ -181,7 +182,9 @@ func newReader() (*readline.Instance, error) {
 }
 
 func printHeaderLine(cs *dbio.ColumnSeries) {
+	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Print(formatHeader(cs, "="))
+	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Print("\n")
 }
 
@@ -191,6 +194,7 @@ func printColumnNames(cs *dbio.ColumnSeries) {
 		l := columnFormatLength(name, col)
 
 		if strings.EqualFold(name, "Epoch") {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Printf("%29s  ", name)
 		} else {
 			// if the column name is "Ask",
@@ -201,9 +205,11 @@ func printColumnNames(cs *dbio.ColumnSeries) {
 			}
 			sb.WriteString(name)
 			sb.WriteString("  ")
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Print(sb.String())
 		}
 	}
+	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Printf("\n")
 }
 
@@ -226,7 +232,7 @@ func printResult(queryText string, cs *dbio.ColumnSeries, optionalFile ...string
 	}
 
 	if cs == nil {
-		fmt.Println("no results returned from query")
+		log.Info("no results returned from query")
 		return nil
 	}
 	/*
@@ -324,10 +330,12 @@ func printResult(queryText string, cs *dbio.ColumnSeries, optionalFile ...string
 			if writer != nil {
 				row = append(row, strings.TrimSpace(element))
 			} else {
+				// nolint:forbidigo // CLI output needs fmt.Println
 				fmt.Printf("%s  ", element)
 			}
 		}
 		if writer == nil {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Printf("\n")
 		} else {
 			writer.Write(row)
@@ -335,6 +343,7 @@ func printResult(queryText string, cs *dbio.ColumnSeries, optionalFile ...string
 	}
 	if writer == nil {
 		printHeaderLine(cs)
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Printf("(%d rows * %d columns)\n", len(epoch), len(cs.GetColumnNames()))
 	} else {
 		writer.Flush()

--- a/cmd/connect/session/help.go
+++ b/cmd/connect/session/help.go
@@ -3,6 +3,8 @@ package session
 import (
 	"fmt"
 	"strings"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 // functionHelp prints helpful information about specific commands.
@@ -17,20 +19,24 @@ func (c *Client) functionHelp(line string) {
 	}
 	switch helpKey {
 	case "help":
+		// nolint:forbidigo // CLI output
 		fmt.Println(`
 		Usage: \help command_name
 
 		Available commands: o, timing, show, trim, gaps, load, create, destroy, feed`)
 
 	case "o":
+		// nolint:forbidigo // CLI output
 		fmt.Println(`
 		Sends output to the provided file name`)
 
 	case "timing":
+		// nolint:forbidigo // CLI output
 		fmt.Println(`
 		Toggles timing for commands`)
 
 	case "show", "trim", "gaps":
+		// nolint:forbidigo // CLI output
 		fmt.Println(`
 		Syntax: (same for show/trim/gaps):
 
@@ -49,6 +55,7 @@ func (c *Client) functionHelp(line string) {
 	gaps: finds gaps in data in the date range`)
 
 	case "load":
+		// nolint:forbidigo // CLI output
 		fmt.Println(`
 		The load command loads data into the DB from csv files.
 
@@ -75,6 +82,7 @@ func (c *Client) functionHelp(line string) {
 	`)
 
 	case "create", "destroy":
+		// nolint:forbidigo // CLI output
 		fmt.Println(`
 		The create command generates new subdirectories and buckets for a database, 
         and requires specially formatted schema keys as arguments.
@@ -108,6 +116,6 @@ func (c *Client) functionHelp(line string) {
 			<row-type> = variable`)
 
 	default:
-		fmt.Printf("No help available for %s\n", helpKey)
+		log.Error("No help available for %s\n", helpKey)
 	}
 }

--- a/cmd/connect/session/load.go
+++ b/cmd/connect/session/load.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/alpacahq/marketstore/v4/utils/log"
+
 	"github.com/alpacahq/marketstore/v4/cmd/connect/loader"
 	"github.com/alpacahq/marketstore/v4/frontend"
 	"github.com/alpacahq/marketstore/v4/utils/io"
@@ -26,17 +28,21 @@ func (c *Client) load(line string) {
 	args := strings.Split(line, " ")
 	args = args[1:]
 	if len(args) == 0 {
-		fmt.Println("Not enough arguments to load - try help")
+		log.Error("Not enough arguments to load - try help")
 		return
 	}
 
 	tbkP, dataFD, loaderFD, err := parseLoadArgs(args)
 	if err != nil {
-		fmt.Printf("Error while parsing arguments: %v\n", err)
+		log.Error("Error while parsing arguments: %v\n", err)
 		return
 	}
 	if dataFD != nil {
-		defer dataFD.Close()
+		defer func(dataFD *os.File) {
+			if err := dataFD.Close(); err != nil {
+				log.Error("failed to close a file to load: %v", err)
+			}
+		}(dataFD)
 	}
 
 	/*
@@ -44,17 +50,17 @@ func (c *Client) load(line string) {
 	*/
 	resp, err := c.GetBucketInfo(tbkP)
 	if err != nil {
-		fmt.Printf("Error finding existing bucket: %v\n", err)
+		log.Error("Error finding existing bucket: %v\n", err)
 		return
 	}
-	fmt.Printf("Latest Year: %v\n", resp.LatestYear)
+	log.Info("Latest Year: %v\n", resp.LatestYear)
 
 	/*
 		Read the metadata about the CSV file
 	*/
 	csvReader, cvm, err := loader.ReadMetadata(dataFD, loaderFD, resp.DSV)
 	if err != nil {
-		fmt.Println("Error: ", err.Error())
+		log.Error("Error: ", err.Error())
 		return
 	}
 
@@ -67,7 +73,7 @@ func (c *Client) load(line string) {
 
 		npm, endReached, err := loader.CSVtoNumpyMulti(csvReader, *tbkP, cvm, chunkSize, resp.RecordType == io.VARIABLE)
 		if err != nil {
-			fmt.Println("Error: ", err.Error())
+			log.Error("Error: ", err.Error())
 			return
 		}
 		if npm != nil { // npm will be empty if we've read the whole file in the last pass
@@ -86,7 +92,7 @@ func (c *Client) load(line string) {
 
 			err = writeNumpy(c, npm, resp.RecordType == io.VARIABLE)
 			if err != nil {
-				fmt.Println("Error: ", err.Error())
+				log.Error("Error: ", err.Error())
 				return
 			}
 			// LAL ================= DEBUG
@@ -137,7 +143,7 @@ func parseLoadArgs(args []string) (mk *io.TimeBucketKey, inputFD, controlFD *os.
 	var first, second bool
 	var tryFD *os.File
 	for _, arg := range args[1:] {
-		fmt.Printf("Opening %s as ", arg)
+		log.Info("Opening %s as ", arg)
 		tryFD, err = os.Open(arg)
 		if err != nil {
 			return nil, nil, nil, err
@@ -150,12 +156,12 @@ func parseLoadArgs(args []string) (mk *io.TimeBucketKey, inputFD, controlFD *os.
 			if first {
 				second = true
 				controlFD = tryFD
-				fmt.Printf("loader control (yaml) file.\n")
+				log.Info("loader control (yaml) file.\n")
 				break
 			} else {
 				first = true
 				inputFD = tryFD
-				fmt.Printf("data file.\n")
+				log.Info("data file.\n")
 			}
 			continue
 		} else {

--- a/cmd/connect/session/local_api_client.go
+++ b/cmd/connect/session/local_api_client.go
@@ -60,7 +60,7 @@ func (lc *LocalAPIClient) Write(reqs *frontend.MultiWriteRequest, responses *fro
 	// and it can't be updated by the CSV import using the local mode,
 	// the imported data is not returned to query responses until restart marketstore,
 	// the data is correctly written to the data file though.
-	fmt.Println("Note: The imported data won't be returned to query responses until restart marketstore" +
+	log.Info("Note: The imported data won't be returned to query responses until restart marketstore" +
 		" due to the cache of the marketstore process.")
 	return nil
 }
@@ -68,7 +68,7 @@ func (lc *LocalAPIClient) Write(reqs *frontend.MultiWriteRequest, responses *fro
 func (lc *LocalAPIClient) Show(tbk *io.TimeBucketKey, start, end *time.Time,
 ) (csm io.ColumnSeriesMap, err error) {
 	if start == nil && end == nil {
-		fmt.Println("No suitable date range supplied...")
+		log.Error("No suitable date range supplied...")
 		return
 	}
 	if start == nil {
@@ -77,7 +77,7 @@ func (lc *LocalAPIClient) Show(tbk *io.TimeBucketKey, start, end *time.Time,
 	if end == nil {
 		end = &planner.MaxTime
 	}
-	fmt.Printf("Query range: %v to %v\n", start, end)
+	log.Info("Query range: %v to %v\n", start, end)
 
 	qs := frontend.NewQueryService(lc.catalogDir)
 	csm, err = qs.ExecuteQuery(tbk, *start, *end, 0, false, nil)

--- a/cmd/connect/session/show.go
+++ b/cmd/connect/session/show.go
@@ -17,12 +17,12 @@ func (c *Client) show(line string) {
 	// need bucket name and date
 	const argLen = 1
 	if !(len(args) > argLen) {
-		fmt.Println("Not enough arguments, see \"\\help show\" ")
+		log.Error("Not enough arguments, see \"\\help show\" ")
 		return
 	}
 	tbk, start, end := c.parseQueryArgs(args)
 	if tbk == nil {
-		fmt.Println(`Could not parse arguments, see "\help show" `)
+		log.Error(`Could not parse arguments, see "\help show" `)
 		return
 	}
 
@@ -30,7 +30,7 @@ func (c *Client) show(line string) {
 
 	csm, err := c.apiClient.Show(tbk, start, end)
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err.Error())
 		return
 	}
 	elapsedTime := time.Since(timeStart)
@@ -38,27 +38,27 @@ func (c *Client) show(line string) {
 		Should only be one symbol / file in the result, so take the first
 	*/
 	if len(csm.GetMetadataKeys()) == 0 {
-		fmt.Println("No results")
+		log.Info("No results")
 		return
 	}
 	key := csm.GetMetadataKeys()[0]
 	if csm[key].Len() == 0 {
-		fmt.Println("No results")
+		log.Info("No results")
 		return
 	}
 
 	// print at the beginning if outputting to a file
 	if c.timing && c.target != "" {
-		fmt.Printf("Elapsed query time: %5.3f ms\n", 1000*elapsedTime.Seconds())
+		log.Info("Elapsed query time: %5.3f ms\n", 1000*elapsedTime.Seconds())
 	}
 
 	if err = printResult(line, csm[key], c.target); err != nil {
-		fmt.Println(err.Error())
+		log.Error(err.Error())
 	}
 
 	// print at the end if outputting to terminal
 	if c.timing && c.target == "" {
-		fmt.Printf("Elapsed query time: %5.3f ms\n", 1000*elapsedTime.Seconds())
+		log.Info("Elapsed query time: %5.3f ms\n", 1000*elapsedTime.Seconds())
 	}
 }
 
@@ -66,7 +66,7 @@ func (c *Client) parseQueryArgs(args []string) (tbk *io.TimeBucketKey, start, en
 	// args[0] must be "Symbol/Timeframe/AttributeGroup" format (e.g. "AAPL/1Min/OHLC" )
 	const itemKeyLen = 3
 	if itemKeys := strings.Split(args[0], "/"); len(itemKeys) != itemKeyLen {
-		fmt.Println(`Key is not in {Symbol/Timeframe/AttributeGroup} format (e.g. "AAPL/1Min/OHLCV)", see "\help show" `)
+		log.Error(`Key is not in {Symbol/Timeframe/AttributeGroup} format (e.g. "AAPL/1Min/OHLCV)", see "\help show" `)
 		return
 	}
 	tbk = io.NewTimeBucketKey(args[0])
@@ -82,7 +82,7 @@ func (c *Client) parseQueryArgs(args []string) (tbk *io.TimeBucketKey, start, en
 			t, err := parseTime(arg)
 			if err != nil {
 				log.Error("Invalid Symbol/Timeframe/recordFormat string %v", arg)
-				fmt.Printf("Invalid time string %v\n", arg)
+				log.Error("Invalid time string %v\n", arg)
 				return nil, nil, nil
 			}
 			if parsedTime {

--- a/cmd/connect/session/sql.go
+++ b/cmd/connect/session/sql.go
@@ -11,6 +11,7 @@ func (c *Client) sql(line string) {
 
 	cs, err := c.apiClient.SQL(line)
 	if err != nil {
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Println(err)
 		return
 	}
@@ -19,10 +20,12 @@ func (c *Client) sql(line string) {
 
 	err = printResult(line, cs, c.target)
 	if err != nil {
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Println(err.Error())
 	}
 
 	if c.timing {
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Printf("Elapsed query time: %5.3f ms\n", 1000*runTime.Seconds())
 	}
 }

--- a/cmd/connect/session/sql.go
+++ b/cmd/connect/session/sql.go
@@ -3,6 +3,8 @@ package session
 import (
 	"fmt"
 	"time"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 // sql executes a sql statement against the current db.
@@ -11,8 +13,7 @@ func (c *Client) sql(line string) {
 
 	cs, err := c.apiClient.SQL(line)
 	if err != nil {
-		// nolint:forbidigo // CLI output needs fmt.Println
-		fmt.Println(err)
+		log.Error(err.Error())
 		return
 	}
 
@@ -20,12 +21,10 @@ func (c *Client) sql(line string) {
 
 	err = printResult(line, cs, c.target)
 	if err != nil {
-		// nolint:forbidigo // CLI output needs fmt.Println
-		fmt.Println(err.Error())
+		log.Error(err.Error())
 	}
 
 	if c.timing {
-		// nolint:forbidigo // CLI output needs fmt.Println
-		fmt.Printf("Elapsed query time: %5.3f ms\n", 1000*runTime.Seconds())
+		log.Info(fmt.Sprintf("Elapsed query time: %5.3f ms\n", 1000*runTime.Seconds()))
 	}
 }

--- a/cmd/connect/session/trim.go
+++ b/cmd/connect/session/trim.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"fmt"
 	io2 "io"
 	"os"
 	"strings"
@@ -15,7 +14,7 @@ import (
 func (c *Client) trim(line string) {
 	cli, ok := c.apiClient.(*LocalAPIClient)
 	if !ok {
-		fmt.Printf("Trim command can be used only when '--dir' is specified to connect marketstore.")
+		log.Error("Trim command can be used only when '--dir' is specified to connect marketstore.")
 		return
 	}
 
@@ -24,7 +23,7 @@ func (c *Client) trim(line string) {
 	// need \trim {key} {date}
 	const argLen = 3
 	if len(args) < argLen {
-		fmt.Println("Not enough arguments - need \"trim key date\"")
+		log.Error("Not enough arguments - need \"trim key date\"")
 		return
 	}
 	trimDate, err := parseTime(args[len(args)-1])

--- a/cmd/estimate/main.go
+++ b/cmd/estimate/main.go
@@ -92,6 +92,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 		sizeBytes := math.Pow(10, float64((i+1)*3))
 
 		if totalBytes < (sizeBytes * 10000) {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Printf(
 				"Estimated space required for %d %s with %d %s of %s data: %.0f%s\n",
 				NumSymbols, symbolStr, NumYears, yearStr, Timeframe, totalBytes/sizeBytes, sizes[i],
@@ -101,6 +102,7 @@ func executeStart(cmd *cobra.Command, args []string) error {
 	}
 
 	// fallback message for ridiculously huge amounts
+	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Println("Estimated space required is more than 10,000EB")
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"fmt"
+	"github.com/alpacahq/marketstore/v4/utils/log"
 
 	"github.com/spf13/cobra"
 
@@ -24,9 +24,9 @@ func Execute() error {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Print version if specified.
 			if flagPrintVersion {
-				fmt.Printf("version: %+v\n", utils.Tag)
-				fmt.Printf("commit hash: %+v\n", utils.GitHash)
-				fmt.Printf("utc build time: %+v\n", utils.BuildStamp)
+				log.Info("version: %+v\n", utils.Tag)
+				log.Info("commit hash: %+v\n", utils.GitHash)
+				log.Info("utc build time: %+v\n", utils.BuildStamp)
 				return nil
 			}
 			// Print information regarding usage.

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -357,7 +357,7 @@ func initReplicationClient(ctx context.Context, masterHost, rootDir string, tlsE
 	go func() {
 		err = replication.NewRetryer(replicationReceiver.Run, retryInterval, retryBackoffCoeff).Run(ctx)
 		if err != nil {
-			fmt.Printf("failed to connect Master instance from Replica. err=%v\n", err)
+			log.Error("failed to connect Master instance from Replica. err=%v\n", err)
 		}
 	}()
 

--- a/cmd/tool/integrity/main.go
+++ b/cmd/tool/integrity/main.go
@@ -73,10 +73,12 @@ func init() {
 
 	rootDirPath = filepath.Clean(rootDirPath)
 	if !exists(rootDirPath) {
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Printf("Root directory: %s does not exist\n", rootDirPath)
 		os.Exit(0)
 	}
 	if !isDir(rootDirPath) {
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Printf("Root directory: %s is not a directory\n", rootDirPath)
 		os.Exit(0)
 	}
@@ -169,6 +171,7 @@ func cksumDataFiles(filePath string, fi os.FileInfo, pathErr error) (err error) 
 		size := fi.Size() - io.Headersize
 		// Size the chunk buffer to be a multiple of 8-bytes
 		chunkSize := io.AlignedSize(int(size/int64(numChunksPerFile) + size%int64(numChunksPerFile)))
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Println("Chunksize: ", chunkSize)
 
 		fp, err := os.Open(filePath)
@@ -238,12 +241,14 @@ func cksumDataFiles(filePath string, fi os.FileInfo, pathErr error) (err error) 
 		wg.Wait()
 		fp.Close()
 
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Printf("%30s", filechunks[0])
 		for i, sum := range cksums {
 			//			if sum != 0 {
 			if sum < 0 {
 				sum = -sum
 			}
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Printf(",%3s %4d", chunkNames[i], sum%10000)
 			//			}
 		}
@@ -296,6 +301,7 @@ func fixKnownHeaderProblems(buffer []byte, filePath string) {
 		Check for OHLC with elementTypes = {1,1,1,1}
 	*/
 	if planner.ElementsEqual(tbinfo.GetElementTypes(), []io.EnumElementType{io.INT32, io.INT32, io.INT32, io.INT32}) {
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Println("found/fixing OHLC type error for ", filePath)
 		tbinfo.SetElementTypes([]io.EnumElementType{io.FLOAT32, io.FLOAT32, io.FLOAT32, io.FLOAT32})
 	}
@@ -306,6 +312,7 @@ func fixKnownHeaderProblems(buffer []byte, filePath string) {
 	const allowAll = 0o777
 	fp, err := os.OpenFile(filePath, os.O_WRONLY, allowAll)
 	if err != nil {
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Println("Unable to write new header to file, terminating...")
 		os.Exit(1)
 	}

--- a/cmd/tool/integrity/main.go
+++ b/cmd/tool/integrity/main.go
@@ -73,13 +73,11 @@ func init() {
 
 	rootDirPath = filepath.Clean(rootDirPath)
 	if !exists(rootDirPath) {
-		// nolint:forbidigo // CLI output needs fmt.Println
-		fmt.Printf("Root directory: %s does not exist\n", rootDirPath)
+		log.Error(fmt.Sprintf("Root directory: %s does not exist\n", rootDirPath))
 		os.Exit(0)
 	}
 	if !isDir(rootDirPath) {
-		// nolint:forbidigo // CLI output needs fmt.Println
-		fmt.Printf("Root directory: %s is not a directory\n", rootDirPath)
+		log.Error("Root directory: %s is not a directory\n", rootDirPath)
 		os.Exit(0)
 	}
 
@@ -171,8 +169,7 @@ func cksumDataFiles(filePath string, fi os.FileInfo, pathErr error) (err error) 
 		size := fi.Size() - io.Headersize
 		// Size the chunk buffer to be a multiple of 8-bytes
 		chunkSize := io.AlignedSize(int(size/int64(numChunksPerFile) + size%int64(numChunksPerFile)))
-		// nolint:forbidigo // CLI output needs fmt.Println
-		fmt.Println("Chunksize: ", chunkSize)
+		log.Info("Chunksize: ", chunkSize)
 
 		fp, err := os.Open(filePath)
 		if err != nil {
@@ -252,6 +249,7 @@ func cksumDataFiles(filePath string, fi os.FileInfo, pathErr error) (err error) 
 			fmt.Printf(",%3s %4d", chunkNames[i], sum%10000)
 			//			}
 		}
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Printf("\n")
 	}
 	return nil

--- a/contrib/bitmexfeeder/bitmexfeeder.go
+++ b/contrib/bitmexfeeder/bitmexfeeder.go
@@ -234,5 +234,6 @@ func main() {
 	client := bitmex.NewBitmexClient(&http.Client{})
 	start := time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)
 	res, err := client.GetBuckets("XBTUSD", start, "5m")
+	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Println(res, err)
 }

--- a/contrib/bitmexfeeder/bitmexfeeder_test.go
+++ b/contrib/bitmexfeeder/bitmexfeeder_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -59,10 +58,10 @@ func TestNew(t *testing.T) {
 	config["httpClient"] = hc // inject http client
 	ret, err = NewBgWorker(config)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	worker = ret.(*BitmexFetcher)
-	fmt.Printf("%v", worker)
+	t.Logf("%v", worker)
 	assert.Nil(t, err)
 	assert.Equal(t, worker.queryStart.IsZero(), false)
 }

--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -85,10 +85,10 @@ func TestTickCandler(t *testing.T) {
 	assert.Equal(t, tsa[0], tbase)
 	assert.Equal(t, rows.GetColumn("Ask_AVG"), []float64{200, 200, 200, 200})
 	/*
-		fmt.Println("Ask_SUM", rows.GetColumn("Ask_SUM"))
-		fmt.Println("Bid_SUM", rows.GetColumn("Bid_SUM"))
-		fmt.Println("Ask_AVG", rows.GetColumn("Ask_AVG"))
-		fmt.Println("Bid_AVG", rows.GetColumn("Bid_AVG"))
+		t.Log("Ask_SUM", rows.GetColumn("Ask_SUM"))
+		t.Log("Bid_SUM", rows.GetColumn("Bid_SUM"))
+		t.Log("Ask_AVG", rows.GetColumn("Ask_AVG"))
+		t.Log("Bid_AVG", rows.GetColumn("Bid_AVG"))
 	*/
 
 	/*

--- a/contrib/gdaxfeeder/gdaxfeeder.go
+++ b/contrib/gdaxfeeder/gdaxfeeder.go
@@ -257,5 +257,6 @@ func main() {
 		Granularity: 60,
 	}
 	res, err := client.GetHistoricRates("BTC-USD", params)
+	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Println(res, err)
 }

--- a/contrib/ice/cmd/reorg/show.go
+++ b/contrib/ice/cmd/reorg/show.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/alpacahq/marketstore/v4/utils/log"
+
 	"github.com/spf13/cobra"
 
 	"github.com/alpacahq/marketstore/v4/catalog"
@@ -63,8 +65,7 @@ func showRecords(cusip string, catalogDir *catalog.Directory) {
 		} else if status == enum.DeletedAnnouncement {
 			ref = ca.Rows.DeleteTextNumbers[i]
 		}
-		// nolint:forbidigo // CLI output needs fmt.Println
-		fmt.Printf("%c %c %c\tTEXTNUM: %d\tENT: %s, EFF: %s, REC: %s, EXP: %s\tRATE: %.4f, REF: %d\n",
+		log.Info("%c %c %c\tTEXTNUM: %d\tENT: %s, EFF: %s, REC: %s, EXP: %s\tRATE: %.4f, REF: %d\n",
 			ca.Rows.Statuses[i],
 			ca.Rows.SecurityTypes[i],
 			ca.Rows.NotificationTypes[i],
@@ -80,7 +81,6 @@ func showRecords(cusip string, catalogDir *catalog.Directory) {
 	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Println("----- effective rate changes ---")
 	for _, r := range rateChanges {
-		// nolint:forbidigo // CLI output needs fmt.Println
-		fmt.Printf("DATE: %s, TEXTNUM: %d, RATE: %.4f\n", time.Unix(r.Epoch, 0).Format("2006-01-02"), r.Textnumber, r.Rate)
+		log.Info("DATE: %s, TEXTNUM: %d, RATE: %.4f\n", time.Unix(r.Epoch, 0).Format("2006-01-02"), r.Textnumber, r.Rate)
 	}
 }

--- a/contrib/ice/cmd/reorg/show.go
+++ b/contrib/ice/cmd/reorg/show.go
@@ -48,6 +48,7 @@ var ShowRecordsCmd = &cobra.Command{
 func showRecords(cusip string, catalogDir *catalog.Directory) {
 	ca := adjust.NewCorporateActions(cusip)
 	_ = ca.Load(catalogDir)
+	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Println("----- stored announcements ------")
 	for i := 0; i < len(ca.Rows.EntryDates); i++ {
 		ent := time.Unix(ca.Rows.EntryDates[i], 0)
@@ -62,7 +63,7 @@ func showRecords(cusip string, catalogDir *catalog.Directory) {
 		} else if status == enum.DeletedAnnouncement {
 			ref = ca.Rows.DeleteTextNumbers[i]
 		}
-
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Printf("%c %c %c\tTEXTNUM: %d\tENT: %s, EFF: %s, REC: %s, EXP: %s\tRATE: %.4f, REF: %d\n",
 			ca.Rows.Statuses[i],
 			ca.Rows.SecurityTypes[i],
@@ -76,8 +77,10 @@ func showRecords(cusip string, catalogDir *catalog.Directory) {
 			ref)
 	}
 	rateChanges := ca.RateChangeEvents(true, true)
+	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Println("----- effective rate changes ---")
 	for _, r := range rateChanges {
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Printf("DATE: %s, TEXTNUM: %d, RATE: %.4f\n", time.Unix(r.Epoch, 0).Format("2006-01-02"), r.Textnumber, r.Rate)
 	}
 }

--- a/contrib/ice/cmd/sirs/show.go
+++ b/contrib/ice/cmd/sirs/show.go
@@ -48,6 +48,7 @@ var ShowSecurityMasterCmd = &cobra.Command{
 		}
 		sort.Strings(symbols)
 		for _, symbol := range symbols {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Println(symbol, cusips[symbol])
 		}
 		return nil

--- a/contrib/ice/reorg/convert.go
+++ b/contrib/ice/reorg/convert.go
@@ -146,9 +146,11 @@ func convert(input, format, def string, v reflect.Value) {
 				log.Error("type conversion error: %+v, %s\n", err, input)
 			}
 		} else {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			println("converter not found for", input, v.Type().Name(), "kind:", iv.Kind())
 		}
 	} else {
+		// nolint:forbidigo // CLI output needs fmt.Println
 		println("value is read only!!!! ", input, " to ", v.Type().Name())
 	}
 }

--- a/contrib/iex/iex.go
+++ b/contrib/iex/iex.go
@@ -411,10 +411,12 @@ func main() {
 
 	for symbol, chart := range *resp {
 		for _, bar := range chart.Chart {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Printf("symbol: %v bar: %v\n", symbol, bar)
 		}
 	}
 
+	// nolint:forbidigo // CLI output needs fmt.Println
 	fmt.Printf("-------------------\n\n")
 	resp, err = api.GetBars([]string{"AMPY", "MSFT", "DVCR"}, oneDay, nil, retryNum)
 
@@ -424,6 +426,7 @@ func main() {
 
 	for symbol, chart := range *resp {
 		for _, bar := range chart.Chart {
+			// nolint:forbidigo // CLI output needs fmt.Println
 			fmt.Printf("symbol: %v bar: %v\n", symbol, bar)
 		}
 	}

--- a/contrib/ondiskagg/aggtrigger/accum.go
+++ b/contrib/ondiskagg/aggtrigger/accum.go
@@ -2,6 +2,7 @@ package aggtrigger
 
 import (
 	"fmt"
+	"github.com/alpacahq/marketstore/v4/utils/log"
 
 	"github.com/alpacahq/marketstore/v4/contrib/ondiskagg/aggtrigger/functions"
 	"github.com/alpacahq/marketstore/v4/utils/io"
@@ -93,7 +94,7 @@ func newAccumulator(cs *io.ColumnSeries, param accumParam) *accumulator {
 			ifunc = functions.FirstUint64
 			iout = make([]uint64, 0)
 		default:
-			fmt.Printf("no compatible function\n")
+			log.Error("no compatible function")
 			return nil
 		}
 	case "max":
@@ -136,7 +137,7 @@ func newAccumulator(cs *io.ColumnSeries, param accumParam) *accumulator {
 			ifunc = functions.MaxUint64
 			iout = make([]uint64, 0)
 		default:
-			fmt.Printf("no compatible function\n")
+			log.Error("no compatible function")
 			return nil
 		}
 	case "min":
@@ -179,7 +180,7 @@ func newAccumulator(cs *io.ColumnSeries, param accumParam) *accumulator {
 			ifunc = functions.MinUint64
 			iout = make([]uint64, 0)
 		default:
-			fmt.Printf("no compatible function\n")
+			log.Error("no compatible function")
 			return nil
 		}
 	case "last":
@@ -222,7 +223,7 @@ func newAccumulator(cs *io.ColumnSeries, param accumParam) *accumulator {
 			ifunc = functions.LastUint64
 			iout = make([]uint64, 0)
 		default:
-			fmt.Printf("no compatible function\n")
+			log.Error("no compatible function")
 			return nil
 		}
 	case "sum":
@@ -265,7 +266,7 @@ func newAccumulator(cs *io.ColumnSeries, param accumParam) *accumulator {
 			ifunc = functions.SumUint64
 			iout = make([]uint64, 0)
 		default:
-			fmt.Printf("no compatible function\n")
+			log.Error("no compatible function")
 			return nil
 		}
 	}

--- a/contrib/polyiex/polyiex.go
+++ b/contrib/polyiex/polyiex.go
@@ -86,6 +86,7 @@ func main() {
 	conf["api_key"] = os.Getenv("POLYIEX_API_KEY")
 	if len(os.Args) < 2 {
 		progname := path.Base(os.Args[0])
+		// nolint:forbidigo // CLI output needs fmt.Println
 		fmt.Printf("Usage: %s <base_url>\n", progname)
 		return
 	}

--- a/contrib/stream/shelf/shelf.go
+++ b/contrib/stream/shelf/shelf.go
@@ -112,6 +112,7 @@ func (p *Package) Start(tbk *io.TimeBucketKey, h ShelfHandler) {
 		case <-p.ctx.Done():
 			if !p.stopped.Load().(bool) {
 				if err := (*h)(*tbk, p.Data); err != nil {
+					// nolint:forbidigo // CLI output needs fmt.Println
 					fmt.Printf("failed to expire data package (%v)\n", err)
 				}
 			}

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -56,7 +56,7 @@ func TestAddDir(t *testing.T) {
 	tbk := NewTimeBucketKey("TEST/1Min/TICKS")
 	tf, err := tbk.GetTimeFrame()
 	if err != nil {
-		fmt.Println(err.Error())
+		t.Log(err.Error())
 		return
 	}
 	rt := EnumRecordTypeByName("variable")
@@ -248,7 +248,7 @@ func TestWriteVariable(t *testing.T) {
 	csm, err = reader.Read()
 	assert.Nil(t, err)
 	for _, cs := range csm {
-		fmt.Println("Results: ", cs)
+		t.Log("Results: ", cs)
 		assert.Equal(t, cs.Len(), 10)
 		assert.Equal(t, cs.GetEpoch()[9], row.Epoch)
 		nanos, _ := cs.GetByName("Nanoseconds").([]int32)
@@ -264,11 +264,11 @@ func TestWriteVariable(t *testing.T) {
 	csm, err = reader.Read()
 	assert.Nil(t, err)
 	for _, cs := range csm {
-		fmt.Println("Results: ", cs)
+		t.Log("Results: ", cs)
 		assert.Equal(t, cs.Len(), 10)
 		assert.Equal(t, cs.GetEpoch()[9], row.Epoch)
 		nanos := cs.GetByName("Nanoseconds").([]int32)
-		fmt.Println("Nanos: ", nanos)
+		t.Log("Nanos: ", nanos)
 		assert.True(t, math.Abs(float64(nanos[9]-505000000)) < 50., true)
 		break
 	}
@@ -432,7 +432,7 @@ func TestSortedFiles(t *testing.T) {
 	}
 	scanner, err := executor.NewReader(parsed)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.Nil(t, err)
 	// Sum up the total number of items in the query set for validation
@@ -796,7 +796,7 @@ func forwardBackwardScan(t *testing.T, numRecs int, d *Directory) {
 			for i, r_ts := range r_epoch {
 				tstamp1 := time.Unix(r_ts, 0).UTC().Format(time.UnixDate)
 				tstamp2 := time.Unix(epoch[i], 0).UTC().Format(time.UnixDate)
-				fmt.Println("Should be: ", tstamp1, " Is: ", tstamp2)
+				t.Log("Should be: ", tstamp1, " Is: ", tstamp2)
 			}
 		}
 	}

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -183,7 +183,7 @@ func TestWriteVariable(t *testing.T) {
 			checkSecs := inputTime[i].Unix()
 			checkNanos := inputTime[i].Nanosecond()
 			secs := nearestSecond(ep, nanos[i])
-			// fmt.Println("ep, nanos, checkSecs, checkNanos =", ep, nanos[i], checkSecs, checkNanos)
+			// t.Log("ep, nanos, checkSecs, checkNanos =", ep, nanos[i], checkSecs, checkNanos)
 			assert.Equal(t, checkSecs, secs)
 			assert.True(t, math.Abs(float64(int32(checkNanos)-nanos[i])) < 100)
 		}
@@ -215,7 +215,7 @@ func TestWriteVariable(t *testing.T) {
 			checkSecs := inputTime[2+i].Unix()
 			checkNanos := inputTime[2+i].Nanosecond()
 			secs := nearestSecond(ep, nanos[i])
-			//			fmt.Println("check, secs, nanos[i]: ", check, secs, nanos[i])
+			//	t.Log("check, secs, nanos[i]: ", check, secs, nanos[i])
 			assert.Equal(t, checkSecs, secs)
 			assert.True(t, math.Abs(float64(int32(checkNanos)-nanos[i])) < 100)
 		}
@@ -305,7 +305,7 @@ func TestFileRead(t *testing.T) {
 				minYear = year
 			}
 			if year == 2001 {
-				// fmt.Printf("File: %s Year: %d Number Written: %d\n", fp.FullPath, year, s.ItemsWritten[fp.FullPath])
+				// t.Logf("File: %s Year: %d Number Written: %d\n", fp.FullPath, year, s.ItemsWritten[fp.FullPath])
 				nitems += itemsWritten[fp.FullPath]
 				recordlen = int(iop.RecordLen)
 			}
@@ -315,7 +315,7 @@ func TestFileRead(t *testing.T) {
 		/*
 			for _, cs := range csm {
 				epoch := cs.GetEpoch()
-				fmt.Println("ResultSet Count, nitems, recordLen:", len(epoch), nitems, recordlen)
+				t.Log("ResultSet Count, nitems, recordLen:", len(epoch), nitems, recordlen)
 				printoutCandles(cs, 0, 0)
 			}
 		*/
@@ -408,7 +408,7 @@ func asserter(t *testing.T, err error, shouldBeNil bool) {
 	t.Helper()
 
 	if err != nil {
-		fmt.Println("error: ", err.Error())
+		t.Log("error: ", err.Error())
 	}
 	assert.Equal(t, err == nil, shouldBeNil)
 }
@@ -478,7 +478,7 @@ func TestSortedFiles(t *testing.T) {
 		// length := len(epoch)
 		// printoutCandles(cs, length-1, length-1)
 
-		// fmt.Printf("Length: %d\n", length)
+		// t.Logf("Length: %d\n", length)
 		assert.Len(t, epoch, 200)
 	}
 

--- a/executor/ticks_test.go
+++ b/executor/ticks_test.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -24,7 +23,7 @@ func TestTimeToIntervals(t *testing.T) {
 
 	// 20161230 21:59:20 383000
 	t1 := time.Date(2016, 12, 30, 21, 59, 20, 383000000, time.UTC)
-	fmt.Println("LAL t1 = ", t1)
+	t.Log("LAL t1 = ", t1)
 
 	// Check the 1Min interval
 	utils.InstanceConfig.Timezone = time.UTC
@@ -37,24 +36,24 @@ func TestTimeToIntervals(t *testing.T) {
 	assert.Equal(t, o_t1.Second(), 0)
 
 	o_t1 = io.IndexToTimeDepr(index, 1440, 2016)
-	fmt.Println("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
+	t.Log("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
 	assert.Equal(t, o_t1.Hour(), 21)
 	assert.Equal(t, o_t1.Minute(), 59)
 	assert.Equal(t, o_t1.Second(), 0)
 
 	ticks := io.GetIntervalTicks32Bit(t1, index, 1440)
-	fmt.Printf("Interval ticks = \t\t\t\t %d\n", int(ticks))
+	t.Logf("Interval ticks = \t\t\t\t %d\n", int(ticks))
 
 	seconds := t1.Second()
 	nanos := t1.Nanosecond()
 	fractionalSeconds := float64(seconds) + float64(nanos)/1000000000.
 	fractionalInterval := fractionalSeconds / 60.
 	intervalTicks := uint32(fractionalInterval * math.MaxUint32)
-	fmt.Printf("Manual calculation of interval ticks = \t\t %d\t%f\t%f\n", int(intervalTicks), fractionalSeconds, fractionalInterval)
+	t.Logf("Manual calculation of interval ticks = \t\t %d\t%f\t%f\n", int(intervalTicks), fractionalSeconds, fractionalInterval)
 	// Now let's build up a timestamp from the interval ticks
 	fSec1 := 60. * (float64(intervalTicks) / float64(math.MaxUint32))
 	fSec := 60. * (float64(ticks) / float64(math.MaxUint32))
-	fmt.Printf("Fractional seconds from reconstruction: %f, from calc: %f\n", fSec1, fSec)
+	t.Logf("Fractional seconds from reconstruction: %f, from calc: %f\n", fSec1, fSec)
 	assert.Equal(t, math.Abs(fSec-20.383) < 0.0000001, true)
 
 	assert.Equal(t, math.Abs(float64(intervalTicks)-float64(ticks)) < 2., true)

--- a/executor/wal_test.go
+++ b/executor/wal_test.go
@@ -2,7 +2,6 @@ package executor_test
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -34,7 +33,7 @@ func TestWALWrite(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 
-	queryFiles, err := addTGData(metadata.CatalogDir, metadata.WALFile, 1000, false)
+	queryFiles, err := addTGData(t, metadata.CatalogDir, metadata.WALFile, 1000, false)
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
@@ -44,27 +43,27 @@ func TestWALWrite(t *testing.T) {
 
 	err = metadata.WALFile.FlushToWAL()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	// Verify that the file contents have not changed
 	assert.True(t, compareFileToBuf(t, originalFileContents, queryFiles))
 
 	err = metadata.WALFile.CreateCheckpoint()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	// Verify that the file contents have not changed
 	assert.True(t, compareFileToBuf(t, originalFileContents, queryFiles))
 
 	// Add some mixed up data to the cache
-	queryFiles, err = addTGData(metadata.CatalogDir, metadata.WALFile, 200, true)
+	queryFiles, err = addTGData(t, metadata.CatalogDir, metadata.WALFile, 200, true)
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
 
 	err = metadata.WALFile.FlushToWAL()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 	assert.Nil(t, err)
 
@@ -78,7 +77,7 @@ func TestWALWrite(t *testing.T) {
 	assert.Nil(t, err)
 	metadata.WALFile.WriteStatus(wal.OPEN, wal.REPLAYED)
 
-	metadata.WALFile.Delete(mockInstanceID)
+	_ = metadata.WALFile.Delete(mockInstanceID)
 
 	assert.False(t, metadata.WALFile.IsOpen())
 }
@@ -90,7 +89,7 @@ func TestBrokenWAL(t *testing.T) {
 	var err error
 
 	// Add some mixed up data to the cache
-	_, err = addTGData(metadata.CatalogDir, metadata.WALFile, 1000, true)
+	_, err = addTGData(t, metadata.CatalogDir, metadata.WALFile, 1000, true)
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
@@ -101,7 +100,7 @@ func TestBrokenWAL(t *testing.T) {
 
 	err = metadata.WALFile.FlushToWAL()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 
 	// Save the WALFile contents after WAL flush, but before flush to primary
@@ -114,7 +113,7 @@ func TestBrokenWAL(t *testing.T) {
 
 	err = metadata.WALFile.CreateCheckpoint()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 
 	// Now we have a completed WALFile, we can write some degraded files for testing
@@ -134,13 +133,13 @@ func TestBrokenWAL(t *testing.T) {
 	BrokenWALFileName := "BrokenWAL"
 	BrokenWALFilePath := rootDir + "/" + BrokenWALFileName
 
-	os.Remove(BrokenWALFilePath)
+	_ = os.Remove(BrokenWALFilePath)
 	fp, err := os.OpenFile(BrokenWALFilePath, os.O_CREATE|os.O_RDWR, 0o600)
 	assert.Nil(t, err)
 	_, err = fp.Write(BrokenWAL)
 	assert.Nil(t, err)
 	io.Syncfs()
-	fp.Close()
+	_ = fp.Close()
 
 	// Take over the broken WALFile and replay it
 	WALFile, err := executor.TakeOverWALFile(filepath.Join(rootDir, BrokenWALFileName))
@@ -160,7 +159,7 @@ func TestWALReplay(t *testing.T) {
 
 	var err error
 
-	allQueryFiles, err := addTGData(metadata.CatalogDir, metadata.WALFile, 1000, true)
+	allQueryFiles, err := addTGData(t, metadata.CatalogDir, metadata.WALFile, 1000, true)
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
@@ -184,7 +183,7 @@ func TestWALReplay(t *testing.T) {
 
 	err = metadata.WALFile.FlushToWAL()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
 
 	// Save the WALFile contents after WAL flush, but before checkpoint
@@ -197,7 +196,7 @@ func TestWALReplay(t *testing.T) {
 
 	err = metadata.WALFile.CreateCheckpoint()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 		t.FailNow()
 	}
 	// Put the modified files into a buffer and then verify the state of the files
@@ -219,7 +218,7 @@ func TestWALReplay(t *testing.T) {
 	// Write a WAL file with the pre-flushed state - we will replay this to get the modified files
 	newWALFileName := "ReplayWAL"
 	newWALFilePath := rootDir + "/" + newWALFileName
-	os.Remove(newWALFilePath) // Remove it if it exists
+	_ = os.Remove(newWALFilePath) // Remove it if it exists
 	fp, err := os.OpenFile(newWALFilePath, os.O_CREATE|os.O_RDWR, 0o600)
 	assert.Nil(t, err)
 	// Replace PID with a bogus PID
@@ -235,7 +234,7 @@ func TestWALReplay(t *testing.T) {
 	WALFile, err := executor.TakeOverWALFile(filepath.Join(rootDir, newWALFileName))
 	assert.Nil(t, err)
 	data, _ := ioutil.ReadFile(newWALFilePath)
-	ioutil.WriteFile("/tmp/wal", data, 0o644)
+	_ = ioutil.WriteFile("/tmp/wal", data, 0o644)
 	newTGC := executor.NewTransactionPipe()
 	assert.NotNil(t, newTGC)
 	// Verify that our files are in original state prior to replay
@@ -254,9 +253,9 @@ func TestWALReplay(t *testing.T) {
 			if !bytes.Equal(buf, postReplayFileContents[key]) {
 				for i, val := range buf {
 					if val != buf2[i] {
-						fmt.Println("Diff: pre/post:", buf[i:i+8], buf2[i:i+8])
-						fmt.Println("Diff: pre/post int64:", io.ToInt64(buf[i:i+8]), io.ToInt64(buf2[i:i+8]))
-						fmt.Println("Diff: pre/post float32:", io.ToFloat32(buf[i:i+4]), io.ToFloat32(buf2[i:i+4]))
+						t.Log("Diff: pre/post:", buf[i:i+8], buf2[i:i+8])
+						t.Log("Diff: pre/post int64:", io.ToInt64(buf[i:i+8]), io.ToInt64(buf2[i:i+8]))
+						t.Log("Diff: pre/post float32:", io.ToFloat32(buf[i:i+4]), io.ToFloat32(buf2[i:i+4]))
 						assert.Fail(t, "diff")
 					}
 				}
@@ -289,7 +288,7 @@ func createBufferFromFiles(t *testing.T, queryFiles []string) (originalFileConte
 		_, err = fp.Read(originalFileContents[filePath])
 		assert.Nil(t, err)
 		//		fmt.Println("Read file ", filePath, " Size: ", n)
-		fp.Close()
+		_ = fp.Close()
 	}
 	return originalFileContents
 }
@@ -305,7 +304,7 @@ func rewriteFilesFromBuffer(t *testing.T, originalFileContents map[string][]byte
 		assert.Nil(t, err)
 		assert.Len(t, originalFileContents[filePath], n)
 		//		fmt.Println("Read file ", filePath, " Size: ", n)
-		fp.Close()
+		_ = fp.Close()
 	}
 }
 
@@ -322,7 +321,7 @@ func compareFileToBuf(t *testing.T, originalFileContents map[string][]byte, quer
 		_, err = fp.Read(content)
 		assert.Nil(t, err)
 		//		fmt.Println("Read original file ", filePath, " Size: ", n)
-		fp.Close()
+		_ = fp.Close()
 		if !bytes.Equal(content, originalFileContents[filePath]) {
 			return false
 		}
@@ -330,9 +329,11 @@ func compareFileToBuf(t *testing.T, originalFileContents map[string][]byte, quer
 	return true
 }
 
-func addTGData(root *catalog.Directory, walFile *executor.WALFileType,
+func addTGData(t *testing.T, root *catalog.Directory, walFile *executor.WALFileType,
 	number int, mixup bool,
 ) (queryFiles []string, err error) {
+	t.Helper()
+
 	// Create some data via a query
 	symbols := []string{"NZDUSD", "USDJPY", "EURUSD"}
 	tbiByKey := make(map[io.TimeBucketKey]*io.TimeBucketInfo)
@@ -349,13 +350,13 @@ func addTGData(root *catalog.Directory, walFile *executor.WALFileType,
 		parsed, _ := q.Parse()
 		scanner, err := executor.NewReader(parsed)
 		if err != nil {
-			fmt.Printf("Failed to create a new reader")
+			t.Log("Failed to create a new reader")
 			return nil, err
 		}
 
 		csmSym, err := scanner.Read()
 		if err != nil {
-			fmt.Printf("scanner.Read failed: Err: %s", err)
+			t.Logf("scanner.Read failed: Err: %s", err)
 			return nil, err
 		}
 
@@ -364,13 +365,13 @@ func addTGData(root *catalog.Directory, walFile *executor.WALFileType,
 			csm[key] = cs
 			tbi, err := root.GetLatestTimeBucketInfoFromKey(&key)
 			if err != nil {
-				fmt.Printf("Failed to GetLatestTimeBucketInfoFromKey")
+				t.Log("Failed to GetLatestTimeBucketInfoFromKey")
 				return nil, err
 			}
 			tbiByKey[key] = tbi
 			writerByKey[key], err = executor.NewWriter(root, walFile)
 			if err != nil {
-				fmt.Printf("Failed to create a new writer")
+				t.Log("Failed to create a new writer")
 				return nil, err
 			}
 		}
@@ -387,7 +388,7 @@ func addTGData(root *catalog.Directory, walFile *executor.WALFileType,
 		open := cs.GetByName("Open").([]float32)
 		high := cs.GetByName("High").([]float32)
 		low := cs.GetByName("Low").([]float32)
-		close := cs.GetByName("Close").([]float32)
+		clos := cs.GetByName("Close").([]float32)
 		// If we have the mixup flag set, change the data
 		if mixup {
 			asize := len(epoch)
@@ -397,7 +398,7 @@ func addTGData(root *catalog.Directory, walFile *executor.WALFileType,
 				open[i] = float32(-1 * i)
 				high[i] = float32(-2 * ii)
 				low[i] = -3
-				close[i] = -4
+				clos[i] = -4
 			}
 		}
 		timestamps := make([]time.Time, len(epoch))
@@ -408,9 +409,9 @@ func addTGData(root *catalog.Directory, walFile *executor.WALFileType,
 			buffer = append(buffer, io.DataToByteSlice(open[i])...)
 			buffer = append(buffer, io.DataToByteSlice(high[i])...)
 			buffer = append(buffer, io.DataToByteSlice(low[i])...)
-			buffer = append(buffer, io.DataToByteSlice(close[i])...)
+			buffer = append(buffer, io.DataToByteSlice(clos[i])...)
 		}
-		writerByKey[key].WriteRecords(timestamps, buffer, tbiByKey[key].GetDataShapesWithEpoch(), tbiByKey[key])
+		_ = writerByKey[key].WriteRecords(timestamps, buffer, tbiByKey[key].GetDataShapesWithEpoch(), tbiByKey[key])
 	}
 
 	return queryFiles, nil

--- a/executor/wal_test.go
+++ b/executor/wal_test.go
@@ -205,12 +205,12 @@ func TestWALReplay(t *testing.T) {
 
 	// Verify that the file contents have changed for year 2002
 	for key, buf := range fileContentsOriginal2002 {
-		// fmt.Println("Key:", key, "Len1: ", len(buf), " Len2: ", len(modifiedFileContents[key]))
+		// t.Log("Key:", key, "Len1: ", len(buf), " Len2: ", len(modifiedFileContents[key]))
 		assert.False(t, bytes.Equal(buf, modifiedFileContents[key]))
 	}
 
 	// Re-write the original files
-	// fmt.Println("Rewrite")
+	// t.Log("Rewrite")
 	rewriteFilesFromBuffer(t, fileContentsOriginal2002)
 	// At this point, we should have our original files
 	assert.True(t, compareFileToBuf(t, fileContentsOriginal2002, queryFiles2002))
@@ -249,7 +249,7 @@ func TestWALReplay(t *testing.T) {
 	for key, buf := range modifiedFileContents {
 		if filepath.Base(key) == "2002.bin" {
 			buf2 := postReplayFileContents[key]
-			// fmt.Println("Key:", key, "Len1: ", len(buf), " Len2: ", len(buf2))
+			// t.Log("Key:", key, "Len1: ", len(buf), " Len2: ", len(buf2))
 			if !bytes.Equal(buf, postReplayFileContents[key]) {
 				for i, val := range buf {
 					if val != buf2[i] {
@@ -287,7 +287,7 @@ func createBufferFromFiles(t *testing.T, queryFiles []string) (originalFileConte
 		originalFileContents[filePath] = make([]byte, size)
 		_, err = fp.Read(originalFileContents[filePath])
 		assert.Nil(t, err)
-		//		fmt.Println("Read file ", filePath, " Size: ", n)
+		//	t.Log("Read file ", filePath, " Size: ", n)
 		_ = fp.Close()
 	}
 	return originalFileContents
@@ -303,7 +303,7 @@ func rewriteFilesFromBuffer(t *testing.T, originalFileContents map[string][]byte
 		n, err := fp.WriteAt(originalFileContents[filePath], 0)
 		assert.Nil(t, err)
 		assert.Len(t, originalFileContents[filePath], n)
-		//		fmt.Println("Read file ", filePath, " Size: ", n)
+		//	t.Log("Read file ", filePath, " Size: ", n)
 		_ = fp.Close()
 	}
 }
@@ -320,7 +320,7 @@ func compareFileToBuf(t *testing.T, originalFileContents map[string][]byte, quer
 		content := make([]byte, size)
 		_, err = fp.Read(content)
 		assert.Nil(t, err)
-		//		fmt.Println("Read original file ", filePath, " Size: ", n)
+		//	t.Log("Read original file ", filePath, " Size: ", n)
 		_ = fp.Close()
 		if !bytes.Equal(content, originalFileContents[filePath]) {
 			return false

--- a/frontend/query_test.go
+++ b/frontend/query_test.go
@@ -76,21 +76,21 @@ func _TestQueryCustomTimeframes(t *testing.T) {
 	assert.Len(t, response.Responses[2].Result.StartIndex, 1)
 	csm, err := response.Responses[0].Result.ToColumnSeriesMap()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 		t.Fail()
 	}
 	assert.Len(t, csm, 2)
 
 	csm, err = response.Responses[1].Result.ToColumnSeriesMap()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 		t.Fail()
 	}
 	assert.Len(t, csm, 2)
 
 	csm, err = response.Responses[2].Result.ToColumnSeriesMap()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 		t.Fail()
 	}
 	assert.Len(t, csm, 1)
@@ -240,7 +240,7 @@ func TestQueryNpyMulti(t *testing.T) {
 	assert.Len(t, response.Responses[0].Result.StartIndex, 2)
 	csm, err := response.Responses[0].Result.ToColumnSeriesMap()
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 		t.Fail()
 	}
 	for _, cs := range csm {
@@ -341,7 +341,7 @@ func TestFunctions(t *testing.T) {
 	call := "candlecandler('1Min',Open,High,Low,Close,Sum::Volume)"
 	_, _, _, err := sqlparser.ParseFunctionCall(call)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 		t.FailNow()
 	}
 	//	printFuncParams(fname, l_list, p_list)
@@ -349,7 +349,7 @@ func TestFunctions(t *testing.T) {
 	call = "FuncName (P1, 'Lit1', P2,P3,P4, 'Lit2' , Sum::P5, Avg::P6)"
 	fname, l_list, p_list, err := sqlparser.ParseFunctionCall(call)
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 		t.FailNow()
 	}
 	//	printFuncParams(fname, l_list, p_list)

--- a/frontend/write_test.go
+++ b/frontend/write_test.go
@@ -1,7 +1,6 @@
 package frontend_test
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -52,7 +51,7 @@ func TestWrite(t *testing.T) {
 
 	csm2, _ := qresponse.Responses[0].Result.ToColumnSeriesMap()
 	for _, cs := range csm2 {
-		//		fmt.Println("LAL cs len:", cs.Len())
+		//	t.Log("LAL cs len:", cs.Len())
 		assert.Equal(t, cs.Len(), 201)
 	}
 
@@ -72,7 +71,7 @@ func TestWrite(t *testing.T) {
 
 	for _, resp := range response.Responses {
 		if len(resp.Error) != 0 {
-			fmt.Printf("Error: %s\n", resp.Error)
+			t.Logf("Error: %s\n", resp.Error)
 			t.FailNow()
 		}
 	}

--- a/plugins/load_test.go
+++ b/plugins/load_test.go
@@ -48,7 +48,7 @@ func main() {}
 		testFilePath)
 
 	if err := cmd.Run(); err != nil {
-		fmt.Println(err)
+		t.Log(err)
 		t.Skip("Unable to build test plugin ** is go version > 1.9 in your path?")
 	}
 

--- a/sqlparser/selectrelation.go
+++ b/sqlparser/selectrelation.go
@@ -224,8 +224,8 @@ func (sr *SelectRelation) Materialize(aggRunner *AggRunner, catDir *catalog.Dire
 		removalBitmap := make([]bool, totalLength) // true means we ditch the value, default is keep
 		for _, name := range outputColumnSeries.GetColumnNames() {
 			if sp, ok := sr.StaticPredicates[name]; ok {
-				i_col := outputColumnSeries.GetColumn(name)
-				switch col := i_col.(type) {
+				iCol := outputColumnSeries.GetColumn(name)
+				switch col := iCol.(type) {
 				case []float32:
 					if sp.ContentsEnum.IsSet(EQUALITY) {
 						eqval, _ := io.GetValueAsFloat64(sp.equal)

--- a/uda/avg/avg.go
+++ b/uda/avg/avg.go
@@ -1,8 +1,9 @@
 package avg
 
 import (
-	"fmt"
 	"time"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
 
 	"github.com/alpacahq/marketstore/v4/uda"
 	"github.com/alpacahq/marketstore/v4/utils/functions"
@@ -14,9 +15,9 @@ var (
 		{Name: "*", Type: io.FLOAT32},
 	}
 
-	optionalColumns = []io.DataShape{}
+	optionalColumns []io.DataShape
 
-	initArgs = []io.DataShape{}
+	initArgs []io.DataShape
 )
 
 type Avg struct {
@@ -48,7 +49,7 @@ func (a *Avg) Accum(_ io.TimeBucketKey, argMap *functions.ArgumentMap, cols io.C
 	inputColName := inputColDSV[0].Name
 	inputCol, err := uda.ColumnToFloat32(cols, inputColName)
 	if err != nil {
-		fmt.Println("COLS: ", cols)
+		log.Debug("COLS: ", cols)
 		return nil, err
 	}
 

--- a/utils/functions/all_test.go
+++ b/utils/functions/all_test.go
@@ -1,7 +1,6 @@
 package functions
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +28,7 @@ func TestParameters(t *testing.T) {
 	idList := []string{"A::i", "B::j", "C::k", "D::l"}
 	err := argMap.PrepareArguments(idList)
 	if err != nil {
-		fmt.Println("Error: ", err)
+		t.Log("Error: ", err)
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, argMap.nameMap["A"][0].Name, "i")
@@ -44,7 +43,7 @@ func TestParameters(t *testing.T) {
 	idList = []string{"A::i", "B::j", "C::k", "D::l", "E::m", "F::n"}
 	err = argMap.PrepareArguments(idList)
 	if err != nil {
-		fmt.Println("Error: ", err)
+		t.Log("Error: ", err)
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, argMap.nameMap["A"][0].Name, "i")
@@ -61,7 +60,7 @@ func TestParameters(t *testing.T) {
 	idList = []string{"A::i", "j", "k", "D::l"}
 	err = argMap.PrepareArguments(idList)
 	if err != nil {
-		fmt.Println("Error: ", err)
+		t.Log("Error: ", err)
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, argMap.nameMap["A"][0].Name, "i")
@@ -76,7 +75,7 @@ func TestParameters(t *testing.T) {
 	idList = []string{"A::i1", "A::i2", "j", "k", "D::l1", "D::l2", "D::l3"}
 	err = argMap.PrepareArguments(idList)
 	if err != nil {
-		fmt.Println("Error: ", err)
+		t.Log("Error: ", err)
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, argMap.nameMap["A"][0].Name, "i1")
@@ -94,7 +93,7 @@ func TestParameters(t *testing.T) {
 	idList = []string{"A::i1", "A::i2", "j", "k", "D::l1", "D::l2", "D::l3", "m", "n"}
 	err = argMap.PrepareArguments(idList)
 	if err != nil {
-		fmt.Println("Error: ", err)
+		t.Log("Error: ", err)
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, argMap.nameMap["A"][0].Name, "i1")
@@ -114,7 +113,7 @@ func TestParameters(t *testing.T) {
 	idList = []string{"A::i", "j", "D::l"}
 	err = argMap.PrepareArguments(idList)
 	if err != nil {
-		fmt.Println("Error: ", err)
+		t.Log("Error: ", err)
 	}
 	assert.NotNil(t, err)
 }

--- a/utils/io/all_test.go
+++ b/utils/io/all_test.go
@@ -83,12 +83,12 @@ func TestVariableBoundaryCases(t *testing.T) {
 
 	*/
 	t1 := time.Date(2008, time.January, 3, 16, 24, 3, 1000*255970, time.UTC)
-	// fmt.Println("Test Time:  ", t1, " Minutes: ", t1.Minute(), " Seconds: ", t1.Second())
+	// t.Log("Test Time:  ", t1, " Minutes: ", t1.Minute(), " Seconds: ", t1.Second())
 
 	// Check the 1Min interval
 	index := TimeToIndex(t1, time.Minute)
 	o_t1 := IndexToTime(index, time.Minute, 2008)
-	// fmt.Println("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
+	// t.Log("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
 	assert.Equal(t, o_t1.Minute(), 24)
 	assert.Equal(t, o_t1.Second(), 0)
 	ticks := GetIntervalTicks32Bit(t1, index, 1440)
@@ -97,14 +97,14 @@ func TestVariableBoundaryCases(t *testing.T) {
 	fractionalSeconds := float64(seconds) + float64(nanos)/1000000000.
 	fractionalInterval := fractionalSeconds / 60.
 	intervalTicks := uint32(fractionalInterval * math.MaxUint32)
-	// fmt.Println("Interval Ticks: ", intervalTicks)
+	// t.Log("Interval Ticks: ", intervalTicks)
 	assert.Equal(t, intervalTicks, ticks)
 
 	t1 = time.Date(2008, time.January, 3, 16, 24, 59, 1000*839106, time.UTC)
 
 	index = TimeToIndex(t1, time.Minute)
 	o_t1 = IndexToTime(index, time.Minute, 2008)
-	// fmt.Println("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
+	// t.Log("Index Time: ", o_t1, " Minutes: ", o_t1.Minute(), " Seconds: ", o_t1.Second())
 	assert.Equal(t, o_t1.Minute(), 24)
 	assert.Equal(t, o_t1.Second(), 0)
 	ticks = GetIntervalTicks32Bit(t1, index, 1440)
@@ -113,7 +113,7 @@ func TestVariableBoundaryCases(t *testing.T) {
 	fractionalSeconds = float64(seconds) + float64(nanos)/1000000000.
 	fractionalInterval = fractionalSeconds / 60.
 	intervalTicks = uint32(fractionalInterval * math.MaxUint32)
-	// fmt.Println("Interval Ticks: ", intervalTicks, " Ticks: ", ticks)
+	// t.Log("Interval Ticks: ", intervalTicks, " Ticks: ", ticks)
 	diff := int64(intervalTicks) - int64(ticks)
 	if diff < 0 {
 		diff = -diff

--- a/utils/io/datashape.go
+++ b/utils/io/datashape.go
@@ -44,7 +44,6 @@ func DataShapesFromInputString(inputStr string) (dsa []DataShape, err error) {
 		twoParts := strings.Split(group, "/")
 		if len(twoParts) != 2 {
 			err = fmt.Errorf("error: %s: Data shape is not described by a list of column names followed by type.", group)
-			fmt.Println(err.Error())
 			return nil, err
 		}
 		elementNames := strings.Split(twoParts[0], ",")
@@ -52,7 +51,6 @@ func DataShapesFromInputString(inputStr string) (dsa []DataShape, err error) {
 		eType := EnumElementTypeFromName(elementType)
 		if eType == NONE {
 			err = fmt.Errorf("error: %s: Data type is not a supported type", group)
-			fmt.Println(err.Error())
 			return nil, err
 		}
 		for _, name := range elementNames {


### PR DESCRIPTION
replaced almost all `fmt.Print{f/ln}` to `t.Log` or `logger.{Error/Info}`