### PR TITLE
fix: deprecate io/ioutil

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -55,7 +55,7 @@ func load(rootDmap *sync.Map, d *Directory, subPath, rootPath string) error {
 	d.pathToItemName = filepath.Clean(subPath)
 	// Read the category name for the child directory items
 	catFilePath := subPath + "/" + "category_name"
-	catname, err := ioutil.ReadFile(catFilePath)
+	catname, err := os.ReadFile(catFilePath)
 	if err != nil {
 		return ErrCategoryFileNotFound{filePath: catFilePath, msg: io.GetCallerFileContext(0) + err.Error()}
 	}
@@ -127,7 +127,7 @@ func writeCategoryNameFile(catName, dirName string) error {
 	catNameFile := filepath.Join(dirName, "category_name")
 
 	if fileExists(catNameFile) {
-		buffer, err := ioutil.ReadFile(catNameFile)
+		buffer, err := os.ReadFile(catNameFile)
 		if err != nil {
 			return err
 		}

--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -3,7 +3,6 @@ package catalog_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -21,7 +20,7 @@ func setup(t *testing.T, testName string,
 ) (tearDown func(), rootDir string, catalogDir *catalog.Directory) {
 	t.Helper()
 
-	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("catalog_test-%s", testName))
+	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("catalog_test-%s", testName))
 	test.MakeDummyCurrencyDir(rootDir, false, false)
 	catalogDir, err := catalog.NewDirectory(rootDir)
 	if err != nil {
@@ -189,7 +188,7 @@ func TestAddAndRemoveDataItem(t *testing.T) {
 }
 
 func TestAddAndRemoveDataItemFromEmptyDirectory(t *testing.T) {
-	rootDir, _ := ioutil.TempDir("", "catalog_test-TestAddAndRemoveDataItemFromEmptyDirectory")
+	rootDir, _ := os.MkdirTemp("", "catalog_test-TestAddAndRemoveDataItemFromEmptyDirectory")
 	catalogDir, err := catalog.NewDirectory(rootDir)
 	var e catalog.ErrCategoryFileNotFound
 	if err != nil && !errors.As(err, &e) {

--- a/cmd/create/bindata.go
+++ b/cmd/create/bindata.go
@@ -8,7 +8,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -210,7 +209,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/cmd/create/main.go
+++ b/cmd/create/main.go
@@ -3,7 +3,6 @@
 package create
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -40,7 +39,7 @@ func executeInit(*cobra.Command, []string) error {
 		return err
 	}
 	// write mkts.yml to current directory.
-	err = ioutil.WriteFile("mkts.yml", data, 0o644)
+	err = os.WriteFile("mkts.yml", data, 0o644)
 	if err != nil {
 		return err
 	}

--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -72,7 +71,7 @@ func executeStart(cmd *cobra.Command, _ []string) error {
 	defer globalCancel()
 
 	// Attempt to read config file.
-	data, err := ioutil.ReadFile(configFilePath)
+	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to read configuration file error: %w", err)
 	}

--- a/contrib/alpaca/handlers/handlers_test.go
+++ b/contrib/alpaca/handlers/handlers_test.go
@@ -2,7 +2,7 @@ package handlers_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +15,7 @@ import (
 func setup(t *testing.T, testName string) (tearDown func()) {
 	t.Helper()
 
-	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("handlers_test-%s", testName))
+	rootDir, _ := os.MkdirTemp("", fmt.Sprintf("handlers_test-%s", testName))
 	_, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
 		executor.BackgroundSync(false), executor.WALBypass(true)) // WAL Bypass
 	assert.Nil(t, err)

--- a/contrib/bitmexfeeder/api/api.go
+++ b/contrib/bitmexfeeder/api/api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -106,7 +106,7 @@ func (c *BitmexClient) GetBuckets(symbol string, from time.Time, binSize string)
 	}
 	defer res.Body.Close()
 	if res.StatusCode >= http.StatusMultipleChoices {
-		body, err2 := ioutil.ReadAll(res.Body)
+		body, err2 := io.ReadAll(res.Body)
 		if err2 != nil {
 			return nil, err2
 		}

--- a/contrib/bitmexfeeder/bitmexfeeder_test.go
+++ b/contrib/bitmexfeeder/bitmexfeeder_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestNew(t *testing.T) {
 	hc := NewTestClient(func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(getInstrumentsResponseMock))),
+			Body:       io.NopCloser(bytes.NewBuffer([]byte(getInstrumentsResponseMock))),
 			Header:     make(http.Header),
 		}
 	})

--- a/contrib/candler/candlecandler/all_test.go
+++ b/contrib/candler/candlecandler/all_test.go
@@ -2,7 +2,7 @@ package candlecandler_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -21,7 +21,7 @@ func setup(t *testing.T, testName string,
 ) (tearDown func(), rootDir string, itemsWritten map[string]int, metadata *executor.InstanceMetadata) {
 	t.Helper()
 
-	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("candlecandler_test-%s", testName))
+	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("candlecandler_test-%s", testName))
 	itemsWritten = test.MakeDummyStockDir(rootDir, true, false)
 	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5)
 	assert.Nil(t, err)

--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -2,7 +2,7 @@ package tickcandler_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -22,7 +22,7 @@ func setup(t *testing.T, testName string,
 ) (tearDown func(), rootDir string, itemsWritten map[string]int, metadata *executor.InstanceMetadata) {
 	t.Helper()
 
-	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("tickcandler_test-%s", testName))
+	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("tickcandler_test-%s", testName))
 	itemsWritten = test.MakeDummyCurrencyDir(rootDir, true, false)
 	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5)
 	assert.Nil(t, err)

--- a/contrib/ice/reorg/import.go
+++ b/contrib/ice/reorg/import.go
@@ -78,12 +78,12 @@ func fileList(path, prefix string, reimport bool) (out []string, err error) {
 }
 
 func readAnnouncements(path string) (*[]Announcement, error) {
-	buff, err := ioutil.ReadFile(path)
+	buff, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 	content := string(buff)
-	announcements := []Announcement{}
+	var announcements []Announcement
 	err = readRecords(content, &announcements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to readRecords: %w", err)

--- a/contrib/iex/api/api.go
+++ b/contrib/iex/api/api.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -164,7 +163,7 @@ func GetBars(symbols []string, barRange string, limit *int, retries int) (*GetBa
 
 	var resp GetBarsResponse
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +250,7 @@ func ListSymbols() (*ListSymbolsResponse, error) {
 
 	var resp ListSymbolsResponse
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
@@ -2,11 +2,13 @@ package aggtrigger
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/alpacahq/marketstore/v4/utils/log"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -110,8 +112,12 @@ func TestFireBars(t *testing.T) {
 	// background writer
 	utils.InstanceConfig.Timezone, _ = time.LoadLocation("America/New_York")
 
-	tempDir, _ := ioutil.TempDir("", "aggtrigger.TestFireBars")
-	defer os.RemoveAll(tempDir)
+	tempDir, _ := os.MkdirTemp("", "aggtrigger.TestFireBars")
+	defer func(path string) {
+		if err := os.RemoveAll(path); err != nil {
+			log.Error(fmt.Sprintf("failed to remove all files under:%s", path), err.Error())
+		}
+	}(tempDir)
 
 	rootDir := filepath.Join(tempDir, "mktsdb")
 	_ = os.MkdirAll(rootDir, 0o777)

--- a/contrib/polygon/api/api.go
+++ b/contrib/polygon/api/api.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -392,7 +391,7 @@ func request(client *http.Client, url string) ([]byte, error) {
 		reader = resp.Body
 	}
 
-	body, err := ioutil.ReadAll(reader)
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +439,7 @@ func readFromCache(filename string) (bytes []byte, err error) {
 	}
 	defer reader.Close()
 
-	bytes, err = ioutil.ReadAll(reader)
+	bytes, err = io.ReadAll(reader)
 	if err != nil {
 		log.Warn("[polygon] failed to read file: %s (%v)", filename, err)
 		return nil, err

--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"runtime"
@@ -280,7 +279,7 @@ func main() {
 }
 
 func initConfig() (rootDir string, triggers []*utils.TriggerSetting, walRotateInterval int) {
-	data, err := ioutil.ReadFile(configFilePath)
+	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		log.Error("failed to read configuration file error: %s", err.Error())
 		os.Exit(1)

--- a/contrib/polygon/handlers/handlers_test.go
+++ b/contrib/polygon/handlers/handlers_test.go
@@ -3,7 +3,7 @@ package handlers_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -19,7 +19,7 @@ func setup(t *testing.T, testName string,
 ) (tearDown func()) {
 	t.Helper()
 
-	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("handlers_test-%s", testName))
+	rootDir, _ := os.MkdirTemp("", fmt.Sprintf("handlers_test-%s", testName))
 	_, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
 		executor.BackgroundSync(false), executor.WALBypass(true))
 	assert.Nil(t, err)

--- a/contrib/xignitefeeder/api/client.go
+++ b/contrib/xignitefeeder/api/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -301,7 +301,7 @@ func (c *DefaultClient) execute(req *http.Request, responsePtr interface{}) erro
 	}()
 
 	// read the response body and parse to a json
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to read the response body. resp=%v", resp))
 	}

--- a/contrib/xignitefeeder/api/client_test.go
+++ b/contrib/xignitefeeder/api/client_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -38,7 +38,7 @@ func NewMockClient(t *testing.T, expectedResponse interface{}) *http.Client {
 	returnNormal := func(req *http.Request) *http.Response {
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(bytes.NewBuffer(NewTestResponseBody(t, expectedResponse))),
+			Body:       io.NopCloser(bytes.NewBuffer(NewTestResponseBody(t, expectedResponse))),
 			Header:     make(http.Header),
 		}
 	}

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -2,7 +2,6 @@ package executor_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -28,7 +27,7 @@ func setup(t *testing.T, testName string) (tearDown func(), rootDir string, item
 ) {
 	t.Helper()
 
-	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("executor_test-%s", testName))
+	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("executor_test-%s", testName))
 	itemsWritten = MakeDummyCurrencyDir(rootDir, true, false)
 	metadata, shutdownPending, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
 		executor.BackgroundSync(false))
@@ -40,7 +39,7 @@ func setup(t *testing.T, testName string) (tearDown func(), rootDir string, item
 func TestAddDir(t *testing.T) {
 	// --- given ---
 	// make temporary catalog directory
-	tempRootDir, _ := ioutil.TempDir("", "executor_test-TestAddDir")
+	tempRootDir, _ := os.MkdirTemp("", "executor_test-TestAddDir")
 	defer os.RemoveAll(tempRootDir)
 
 	// make catelog directory

--- a/executor/buffile/buffile_test.go
+++ b/executor/buffile/buffile_test.go
@@ -2,7 +2,6 @@ package buffile_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestBufferedFile(t *testing.T) {
-	tempDir, _ := ioutil.TempDir("", fmt.Sprintf("plugins_test-%s", "TestBufferedFile"))
+	tempDir, _ := os.MkdirTemp("", fmt.Sprintf("plugins_test-%s", "TestBufferedFile"))
 	defer test.CleanupDummyDataDir(tempDir)
 
 	filePath := filepath.Join(tempDir, "test.bin")

--- a/executor/wal_test.go
+++ b/executor/wal_test.go
@@ -2,7 +2,6 @@ package executor_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -233,8 +232,8 @@ func TestWALReplay(t *testing.T) {
 	// Take over the new WALFile and replay it into a new TG cache
 	WALFile, err := executor.TakeOverWALFile(filepath.Join(rootDir, newWALFileName))
 	assert.Nil(t, err)
-	data, _ := ioutil.ReadFile(newWALFilePath)
-	_ = ioutil.WriteFile("/tmp/wal", data, 0o644)
+	data, _ := os.ReadFile(newWALFilePath)
+	_ = os.WriteFile("/tmp/wal", data, 0o644)
 	newTGC := executor.NewTransactionPipe()
 	assert.NotNil(t, newTGC)
 	// Verify that our files are in original state prior to replay

--- a/frontend/client/client.go
+++ b/frontend/client/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	goio "io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -71,7 +70,7 @@ func (cl *Client) DoRPC(functionName string, args interface{}) (response interfa
 
 	// Handle any error in the RPC call
 	if resp.StatusCode != 200 {
-		bodyBytes, err2 := ioutil.ReadAll(resp.Body)
+		bodyBytes, err2 := goio.ReadAll(resp.Body)
 		var errText string
 		if err2 != nil {
 			errText = err2.Error()

--- a/frontend/query_test.go
+++ b/frontend/query_test.go
@@ -2,8 +2,8 @@ package frontend_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -23,7 +23,7 @@ func setup(t *testing.T, testName string,
 ) {
 	t.Helper()
 
-	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("frontend_test-%s", testName))
+	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("frontend_test-%s", testName))
 	test.MakeDummyCurrencyDir(rootDir, true, false)
 	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, executor.BackgroundSync(false))
 	assert.Nil(t, err)

--- a/frontend/stream/stream_test.go
+++ b/frontend/stream/stream_test.go
@@ -2,10 +2,10 @@ package stream_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -25,7 +25,7 @@ func setup(t *testing.T, testName string,
 ) (tearDown func()) {
 	t.Helper()
 
-	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("stream_test-%s", testName))
+	rootDir, _ := os.MkdirTemp("", fmt.Sprintf("stream_test-%s", testName))
 	_, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, executor.BackgroundSync(false))
 	assert.Nil(t, err)
 	stream.Initialize()

--- a/metrics/du_test.go
+++ b/metrics/du_test.go
@@ -1,7 +1,6 @@
 package metrics_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -48,7 +47,7 @@ func TestStartDiskUsageMonitor(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			// --- given ---
-			rootDir, _ := ioutil.TempDir("", "diskUsage-monitor-test")
+			rootDir, _ := os.MkdirTemp("", "diskUsage-monitor-test")
 			err := tt.setFilesFunc(tt, rootDir)
 			assert.Nil(t, err)
 			m := mockMetricsSetter{}

--- a/planner/planner_test.go
+++ b/planner/planner_test.go
@@ -2,7 +2,7 @@ package planner_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -17,7 +17,7 @@ func setup(t *testing.T, testName string,
 ) (tearDown func(), rootDir string, catalogDir *catalog.Directory) {
 	t.Helper()
 
-	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("planner_test-%s", testName))
+	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("planner_test-%s", testName))
 	test.MakeDummyCurrencyDir(rootDir, false, false)
 	catalogDir, err := catalog.NewDirectory(rootDir)
 	if err != nil {

--- a/plugins/load_test.go
+++ b/plugins/load_test.go
@@ -2,7 +2,6 @@ package plugins_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,7 +18,7 @@ import (
 func setup(t *testing.T, testName string) (tearDown func(), testPluginLib, oldGoPath, absTestPluginLib string) {
 	t.Helper()
 
-	dirName, _ := ioutil.TempDir("", fmt.Sprintf("plugins_test-%s", testName))
+	dirName, _ := os.MkdirTemp("", fmt.Sprintf("plugins_test-%s", testName))
 
 	if osType := runtime.GOOS; osType != "linux" {
 		t.Skip("Only linux runs plugins")

--- a/sqlparser/all_test.go
+++ b/sqlparser/all_test.go
@@ -2,7 +2,7 @@ package sqlparser_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -21,7 +21,7 @@ func setup(t *testing.T, testName string,
 ) (tearDown func(), metadata *executor.InstanceMetadata) {
 	t.Helper()
 
-	rootDir, _ := ioutil.TempDir("", fmt.Sprintf("sqlparser_test-%s", testName))
+	rootDir, _ := os.MkdirTemp("", fmt.Sprintf("sqlparser_test-%s", testName))
 	test.MakeDummyStockDir(rootDir, true, false)
 	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, executor.BackgroundSync(false))
 	assert.Nil(t, err)

--- a/uda/adjust/adjust_test.go
+++ b/uda/adjust/adjust_test.go
@@ -2,8 +2,8 @@ package adjust
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 	"time"
 
@@ -22,7 +22,7 @@ func setup(t *testing.T, testName string,
 
 	rounderNum = math.Pow(10, 3)
 
-	rootDir, _ = ioutil.TempDir("", fmt.Sprintf("adjust_test-%s", testName))
+	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("adjust_test-%s", testName))
 	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
 		executor.BackgroundSync(false), executor.WALBypass(true))
 	assert.Nil(t, err)

--- a/utils/io/all_test.go
+++ b/utils/io/all_test.go
@@ -1,7 +1,6 @@
 package io
 
 import (
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -235,7 +234,7 @@ func TestSerializeColumnsToRows(t *testing.T) {
 
 func TestTimeBucketInfo(t *testing.T) {
 	t.Parallel()
-	tempDir, _ := ioutil.TempDir("", "io.TestTimeBucketInfo")
+	tempDir, _ := os.MkdirTemp("", "io.TestTimeBucketInfo")
 	defer os.RemoveAll(tempDir)
 
 	timeframe := utils.NewTimeframe("1Min")


### PR DESCRIPTION
- As of Go 1.16, `io/ioutil` is deprecated
- ioutil.ReadDir will be replace by another PR as there is an interface change and we need an extra code update