### PR TITLE
fix: deprecate ioutil.ReadDir

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -63,7 +62,7 @@ func load(rootDmap *sync.Map, d *Directory, subPath, rootPath string) error {
 
 	// Load up the child directories
 	d.subDirs = make(map[string]*Directory)
-	dirlist, err := ioutil.ReadDir(subPath)
+	dirlist, err := os.ReadDir(subPath)
 	if err != nil {
 		return fmt.Errorf("read dir %s: %w", subPath, err)
 	}

--- a/contrib/ice/ftp/client_mock.go
+++ b/contrib/ice/ftp/client_mock.go
@@ -2,8 +2,8 @@ package ftp
 
 import (
 	"errors"
+	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 )
@@ -27,7 +27,22 @@ func (m MockFtpClient) Retrieve(path string, dest io.Writer) error {
 }
 
 func (m MockFtpClient) ReadDir(path string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir("." + path)
+	dirEntries, err := os.ReadDir("." + path)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert []fs.DirEntry to []os.FileInfo
+	fileInfos := make([]os.FileInfo, len(dirEntries))
+	for i, dirEntry := range dirEntries {
+		lf, err := dirEntry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("get file info for a dir entry: %w", err)
+		}
+		fileInfos[i] = lf
+	}
+
+	return fileInfos, nil
 }
 
 func (m MockFtpClient) Close() error {

--- a/contrib/ice/ftp/downloader.go
+++ b/contrib/ice/ftp/downloader.go
@@ -1,7 +1,7 @@
 package ftp
 
 import (
-	"io/ioutil"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,11 +51,22 @@ func (f *Downloader) getRemoteFiles() (FileInfoMap, error) {
 }
 
 func (f *Downloader) getLocalFiles() (FileInfoMap, error) {
-	localfiles, err := ioutil.ReadDir(f.storagePath)
+	localDirEntries, err := os.ReadDir(f.storagePath)
 	if err != nil {
 		return nil, err
 	}
-	return f.filter(localfiles), nil
+
+	// convert []fs.DirEntry to []os.FileInfo
+	localFiles := make([]os.FileInfo, len(localDirEntries))
+	for i, localDirEntry := range localDirEntries {
+		lf, err := localDirEntry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("get file info for a dir entry: %w", err)
+		}
+		localFiles[i] = lf
+	}
+
+	return f.filter(localFiles), nil
 }
 
 func (f *Downloader) filter(files []os.FileInfo) FileInfoMap {

--- a/contrib/ice/reorg/import.go
+++ b/contrib/ice/reorg/import.go
@@ -2,7 +2,6 @@ package reorg
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,14 +62,14 @@ func datePartOfFilename(filename string) string {
 }
 
 func fileList(path, prefix string, reimport bool) (out []string, err error) {
-	localfiles, err := ioutil.ReadDir(path)
+	localDirEntries, err := os.ReadDir(path)
 	if err == nil {
-		for _, file := range localfiles {
-			if !strings.HasPrefix(file.Name(), prefix) {
+		for _, dirEntry := range localDirEntries {
+			if !strings.HasPrefix(dirEntry.Name(), prefix) {
 				continue
 			}
-			if reimport || !strings.HasSuffix(file.Name(), enum.ProcessedFlag) {
-				out = append(out, file.Name())
+			if reimport || !strings.HasSuffix(dirEntry.Name(), enum.ProcessedFlag) {
+				out = append(out, dirEntry.Name())
 			}
 		}
 	}

--- a/executor/instance.go
+++ b/executor/instance.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -131,7 +130,7 @@ func NewInstanceSetup(relRootDir string, rs ReplicationSender, tm []*trigger.Tri
 			ignoreFile := ThisInstance.WALFile.FilePtr.Name()
 			myInstanceID := ThisInstance.WALFile.OwningInstanceID
 
-			finder := wal.NewFinder(ioutil.ReadDir)
+			finder := wal.NewFinder(os.ReadDir)
 			walFileAbsPaths, err := finder.Find(filepath.Clean(rootDir))
 			if err != nil {
 				walFileAbsPaths = []string{}

--- a/executor/wal/find.go
+++ b/executor/wal/find.go
@@ -2,24 +2,23 @@ package wal
 
 import (
 	"fmt"
-	"io/fs"
+	"os"
 	"path/filepath"
 
 	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 type Finder struct {
-	dirRead func(dir string) ([]fs.FileInfo, error)
+	dirRead func(name string) ([]os.DirEntry, error)
 }
 
-func NewFinder(dirRead func(dir string) ([]fs.FileInfo, error)) *Finder {
+func NewFinder(dirRead func(name string) ([]os.DirEntry, error)) *Finder {
 	return &Finder{dirRead: dirRead}
 }
 
 // Find returns all absolute paths to "*.walfile" files directly under the directory.
 func (f *Finder) Find(dir string) ([]string, error) {
 	var ret []string
-	// files, err := ioutil.ReadDir(rootDir)
 	files, err := f.dirRead(dir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read the directory %s: %w", dir, err)


### PR DESCRIPTION
As of go1.16, `io/ioutil` is deprecated.