### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/catalog/catalog_test.go
+++ b/catalog/catalog_test.go
@@ -2,7 +2,6 @@ package catalog_test
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -16,31 +15,28 @@ import (
 	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string,
-) (tearDown func(), rootDir string, catalogDir *catalog.Directory) {
+func setup(t *testing.T) (rootDir string, catalogDir *catalog.Directory) {
 	t.Helper()
 
-	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("catalog_test-%s", testName))
+	rootDir = t.TempDir()
 	test.MakeDummyCurrencyDir(rootDir, false, false)
 	catalogDir, err := catalog.NewDirectory(rootDir)
 	if err != nil {
 		t.Fatal("failed to create a catalog dir.err=" + err.Error())
 	}
 
-	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, catalogDir
+	return rootDir, catalogDir
 }
 
 func TestGetCatList(t *testing.T) {
-	tearDown, _, catalogDir := setup(t, "TestGetCatList")
-	defer tearDown()
+	_, catalogDir := setup(t)
 
 	CatList := catalogDir.GatherCategoriesFromCache()
 	assert.Len(t, CatList, 4)
 }
 
 func TestGetCatItemMap(t *testing.T) {
-	tearDown, _, catalogDir := setup(t, "TestGetCatItemMap")
-	defer tearDown()
+	_, catalogDir := setup(t)
 
 	catList := catalogDir.GatherCategoriesAndItems()
 	/*
@@ -61,16 +57,14 @@ func TestGetCatItemMap(t *testing.T) {
 }
 
 func TestGetDirList(t *testing.T) {
-	tearDown, _, catalogDir := setup(t, "TestGetDirList")
-	defer tearDown()
+	_, catalogDir := setup(t)
 
 	dirList := catalogDir.GatherDirectories()
 	assert.Len(t, dirList, 40)
 }
 
 func TestGatherFilePaths(t *testing.T) {
-	tearDown, _, catalogDir := setup(t, "TestGatherFilePaths")
-	defer tearDown()
+	_, catalogDir := setup(t)
 
 	filePathList := catalogDir.GatherFilePaths()
 	//	for _, filePath := range filePathList {
@@ -80,8 +74,7 @@ func TestGatherFilePaths(t *testing.T) {
 }
 
 func TestGatherFileInfo(t *testing.T) {
-	tearDown, _, catalogDir := setup(t, "TestGatherFileInfo")
-	defer tearDown()
+	_, catalogDir := setup(t)
 
 	fileInfoList := catalogDir.GatherTimeBucketInfo()
 	// for _, fileInfo := range fileInfoList {
@@ -91,8 +84,7 @@ func TestGatherFileInfo(t *testing.T) {
 }
 
 func TestPathToFileInfo(t *testing.T) {
-	tearDown, rootDir, catalogDir := setup(t, "TestPathToFileInfo")
-	defer tearDown()
+	rootDir, catalogDir := setup(t)
 
 	fileInfo, err := catalogDir.PathToTimeBucketInfo("nil")
 	var targetErr catalog.NotFoundError
@@ -110,8 +102,7 @@ func TestPathToFileInfo(t *testing.T) {
 }
 
 func TestAddFile(t *testing.T) {
-	tearDown, _, catalogDir := setup(t, "TestAddFile")
-	defer tearDown()
+	_, catalogDir := setup(t)
 
 	// Get the owning subdirectory for a test file path
 	filePathList := catalogDir.GatherFilePaths()
@@ -138,8 +129,7 @@ func TestAddFile(t *testing.T) {
 }
 
 func TestAddAndRemoveDataItem(t *testing.T) {
-	tearDown, rootDir, catalogDir := setup(t, "TestPathToFileInfo")
-	defer tearDown()
+	rootDir, catalogDir := setup(t)
 
 	catKey := "Symbol/Timeframe/AttributeGroup"
 	dataItemKey := "TEST/1Min/OHLCV"
@@ -189,15 +179,13 @@ func TestAddAndRemoveDataItem(t *testing.T) {
 }
 
 func TestAddAndRemoveDataItemFromEmptyDirectory(t *testing.T) {
-	rootDir, _ := os.MkdirTemp("", "catalog_test-TestAddAndRemoveDataItemFromEmptyDirectory")
+	rootDir := t.TempDir()
 	catalogDir, err := catalog.NewDirectory(rootDir)
 	var e catalog.ErrCategoryFileNotFound
 	if err != nil && !errors.As(err, &e) {
 		t.Fatal("failed to create a catalog dir.err=" + err.Error())
 		return
 	}
-
-	defer test.CleanupDummyDataDir(rootDir)
 
 	catKey := "Symbol/Timeframe/AttributeGroup"
 	dataItemKey := "TEST/1Min/OHLCV"
@@ -282,8 +270,7 @@ func TestAddAndRemoveDataItemFromEmptyDirectory(t *testing.T) {
 }
 
 func TestCreateNewDirectory(t *testing.T) {
-	tearDown, rootDir, catalogDir := setup(t, "TestPathToFileInfo")
-	defer tearDown()
+	rootDir, catalogDir := setup(t)
 
 	catKey := "Symbol/Timeframe/AttributeGroup"
 	dataItemKey := "TEST/1Min/OHLCV"

--- a/contrib/alpaca/handlers/handlers_test.go
+++ b/contrib/alpaca/handlers/handlers_test.go
@@ -1,26 +1,21 @@
 package handlers_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alpacahq/marketstore/v4/contrib/alpaca/handlers"
 	"github.com/alpacahq/marketstore/v4/executor"
-	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string) (tearDown func()) {
+func setup(t *testing.T) {
 	t.Helper()
 
-	rootDir, _ := os.MkdirTemp("", fmt.Sprintf("handlers_test-%s", testName))
+	rootDir := t.TempDir()
 	_, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
 		executor.BackgroundSync(false), executor.WALBypass(true)) // WAL Bypass
 	assert.Nil(t, err)
-
-	return func() { test.CleanupDummyDataDir(rootDir) }
 }
 
 func getTestTrade() []byte {
@@ -42,8 +37,7 @@ func getTestAggregate() []byte {
 }
 
 func TestHandlers(t *testing.T) {
-	tearDown := setup(t, "TestHandlers")
-	defer tearDown()
+	setup(t)
 
 	// trade
 	handlers.MessageHandler(getTestTrade())

--- a/contrib/candler/candlecandler/all_test.go
+++ b/contrib/candler/candlecandler/all_test.go
@@ -1,8 +1,6 @@
 package candlecandler_test
 
 import (
-	"fmt"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -17,21 +15,19 @@ import (
 	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string,
-) (tearDown func(), rootDir string, itemsWritten map[string]int, metadata *executor.InstanceMetadata) {
+func setup(t *testing.T) (rootDir string, itemsWritten map[string]int, metadata *executor.InstanceMetadata) {
 	t.Helper()
 
-	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("candlecandler_test-%s", testName))
+	rootDir = t.TempDir()
 	itemsWritten = test.MakeDummyStockDir(rootDir, true, false)
 	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5)
 	assert.Nil(t, err)
 
-	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, itemsWritten, metadata
+	return rootDir, itemsWritten, metadata
 }
 
 func TestCandleCandler(t *testing.T) {
-	tearDown, _, _, metadata := setup(t, "TestCandleCandler")
-	defer tearDown()
+	_, _, metadata := setup(t)
 
 	c := candlecandler.CandleCandler{}
 	am := functions.NewArgumentMap(c.GetRequiredArgs(), c.GetOptionalArgs()...)

--- a/contrib/candler/tickcandler/all_test.go
+++ b/contrib/candler/tickcandler/all_test.go
@@ -1,8 +1,6 @@
 package tickcandler_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -18,21 +16,19 @@ import (
 	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string,
-) (tearDown func(), rootDir string, itemsWritten map[string]int, metadata *executor.InstanceMetadata) {
+func setup(t *testing.T) (rootDir string, itemsWritten map[string]int, metadata *executor.InstanceMetadata) {
 	t.Helper()
 
-	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("tickcandler_test-%s", testName))
+	rootDir = t.TempDir()
 	itemsWritten = test.MakeDummyCurrencyDir(rootDir, true, false)
 	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5)
 	assert.Nil(t, err)
 
-	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, itemsWritten, metadata
+	return rootDir, itemsWritten, metadata
 }
 
 func TestTickCandler(t *testing.T) {
-	tearDown, rootDir, _, metadata := setup(t, "TestTickCandler")
-	defer tearDown()
+	rootDir, _, metadata := setup(t)
 
 	tc := tickcandler.TickCandler{}
 	am := functions.NewArgumentMap(tc.GetRequiredArgs(), tc.GetOptionalArgs()...)

--- a/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger_test.go
@@ -2,7 +2,6 @@ package aggtrigger
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,6 @@ import (
 	"github.com/alpacahq/marketstore/v4/plugins/trigger"
 	"github.com/alpacahq/marketstore/v4/utils"
 	"github.com/alpacahq/marketstore/v4/utils/io"
-	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 func getConfig(t *testing.T, data string) (ret map[string]interface{}) {
@@ -111,14 +109,7 @@ func TestFireBars(t *testing.T) {
 	// background writer
 	utils.InstanceConfig.Timezone, _ = time.LoadLocation("America/New_York")
 
-	tempDir, _ := os.MkdirTemp("", "aggtrigger.TestFireBars")
-	defer func(path string) {
-		if err := os.RemoveAll(path); err != nil {
-			log.Error(fmt.Sprintf("failed to remove all files under:%s", path), err.Error())
-		}
-	}(tempDir)
-
-	rootDir := filepath.Join(tempDir, "mktsdb")
+	rootDir := filepath.Join(t.TempDir(), "mktsdb")
 	_ = os.MkdirAll(rootDir, 0o777)
 	_, _, _, err := executor.NewInstanceSetup(
 		rootDir, nil, nil,

--- a/contrib/polygon/handlers/handlers_test.go
+++ b/contrib/polygon/handlers/handlers_test.go
@@ -2,8 +2,6 @@ package handlers_test
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -12,19 +10,15 @@ import (
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/api"
 	"github.com/alpacahq/marketstore/v4/contrib/polygon/handlers"
 	"github.com/alpacahq/marketstore/v4/executor"
-	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string,
-) (tearDown func()) {
+func setup(t *testing.T) {
 	t.Helper()
 
-	rootDir, _ := os.MkdirTemp("", fmt.Sprintf("handlers_test-%s", testName))
+	rootDir := t.TempDir()
 	_, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
 		executor.BackgroundSync(false), executor.WALBypass(true))
 	assert.Nil(t, err)
-
-	return func() { test.CleanupDummyDataDir(rootDir) }
 }
 
 func getTestTradeArray() []api.PolyTrade {
@@ -53,8 +47,7 @@ func getTestQuoteArray() []api.PolyQuote {
 }
 
 func TestHandlers(t *testing.T) {
-	tearDown := setup(t, "TestHandlers")
-	defer tearDown()
+	setup(t)
 
 	// trade
 	{

--- a/executor/all_test.go
+++ b/executor/all_test.go
@@ -3,7 +3,6 @@ package executor_test
 import (
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -22,25 +21,24 @@ import (
 	. "github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string) (tearDown func(), rootDir string, itemsWritten map[string]int,
+func setup(t *testing.T) (rootDir string, itemsWritten map[string]int,
 	metadata *executor.InstanceMetadata, shutdownPending *bool,
 ) {
 	t.Helper()
 
-	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("executor_test-%s", testName))
+	rootDir = t.TempDir()
 	itemsWritten = MakeDummyCurrencyDir(rootDir, true, false)
 	metadata, shutdownPending, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
 		executor.BackgroundSync(false))
 	assert.Nil(t, err)
 
-	return func() { CleanupDummyDataDir(rootDir) }, rootDir, itemsWritten, metadata, shutdownPending
+	return rootDir, itemsWritten, metadata, shutdownPending
 }
 
 func TestAddDir(t *testing.T) {
 	// --- given ---
 	// make temporary catalog directory
-	tempRootDir, _ := os.MkdirTemp("", "executor_test-TestAddDir")
-	defer os.RemoveAll(tempRootDir)
+	tempRootDir := t.TempDir()
 
 	// make catelog directory
 	catDir, err := NewDirectory(tempRootDir)
@@ -77,8 +75,7 @@ func TestAddDir(t *testing.T) {
 }
 
 func TestQueryMulti(t *testing.T) {
-	tearDown, rootDir, _, metadata, _ := setup(t, "TestQueryMulti")
-	defer tearDown()
+	rootDir, _, metadata, _ := setup(t)
 
 	// Create a new variable data bucket
 	tbk := NewTimeBucketKey("AAPL/1Min/OHLCV")
@@ -125,8 +122,7 @@ func TestQueryMulti(t *testing.T) {
 }
 
 func TestWriteVariable(t *testing.T) {
-	tearDown, rootDir, _, metadata, _ := setup(t, "TestWriteVariable")
-	defer tearDown()
+	rootDir, _, metadata, _ := setup(t)
 
 	// Create a new variable data bucket
 	tbk := NewTimeBucketKey("TEST-WV/1Min/TICK-BIDASK")
@@ -278,8 +274,7 @@ func TestWriteVariable(t *testing.T) {
 }
 
 func TestFileRead(t *testing.T) {
-	tearDown, _, itemsWritten, metadata, _ := setup(t, "TestFileRead")
-	defer tearDown()
+	_, itemsWritten, metadata, _ := setup(t)
 
 	q := NewQuery(metadata.CatalogDir)
 	q.AddRestriction("Symbol", "NZDUSD")
@@ -327,8 +322,7 @@ func TestFileRead(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	tearDown, _, _, metadata, _ := setup(t, "TestDelete")
-	defer tearDown()
+	_, _, metadata, _ := setup(t)
 
 	NY, _ := time.LoadLocation("America/New_York")
 	// First write some data we can delete
@@ -417,8 +411,7 @@ func asserter(t *testing.T, err error, shouldBeNil bool) {
 }
 
 func TestSortedFiles(t *testing.T) {
-	tearDown, _, itemsWritten, metadata, _ := setup(t, "TestSortedFiles")
-	defer tearDown()
+	_, itemsWritten, metadata, _ := setup(t)
 
 	q := NewQuery(metadata.CatalogDir)
 	q.AddRestriction("Symbol", "NZDUSD")
@@ -528,8 +521,7 @@ func TestSortedFiles(t *testing.T) {
 }
 
 func TestCrossYear(t *testing.T) {
-	tearDown, _, _, metadata, _ := setup(t, "TestCrossYear")
-	defer tearDown()
+	_, _, metadata, _ := setup(t)
 
 	// Test data range query - across year
 	q := NewQuery(metadata.CatalogDir)
@@ -555,8 +547,7 @@ func TestCrossYear(t *testing.T) {
 }
 
 func TestLastN(t *testing.T) {
-	tearDown, _, _, metadata, _ := setup(t, "TestLastN")
-	defer tearDown()
+	_, _, metadata, _ := setup(t)
 
 	q := NewQuery(metadata.CatalogDir)
 	q.AddRestriction("Symbol", "NZDUSD")
@@ -662,8 +653,7 @@ func TestLastN(t *testing.T) {
 }
 
 func TestAddSymbolThenWrite(t *testing.T) {
-	tearDown, _, _, metadata, _ := setup(t, "TestAddSymbolThenWrite")
-	defer tearDown()
+	_, _, metadata, _ := setup(t)
 
 	dataItemKey := "TEST/1Min/OHLCV"
 	dataItemPath := filepath.Join(metadata.CatalogDir.GetPath(), dataItemKey)
@@ -719,8 +709,7 @@ func TestAddSymbolThenWrite(t *testing.T) {
 }
 
 func TestWriter(t *testing.T) {
-	tearDown, _, _, metadata, _ := setup(t, "TestWriter")
-	defer tearDown()
+	_, _, metadata, _ := setup(t)
 
 	dataItemKey := "TEST/1Min/OHLCV"
 	tbk := NewTimeBucketKey(dataItemKey)

--- a/executor/buffile/buffile_test.go
+++ b/executor/buffile/buffile_test.go
@@ -1,7 +1,6 @@
 package buffile_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,14 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alpacahq/marketstore/v4/executor/buffile"
-	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
 func TestBufferedFile(t *testing.T) {
-	tempDir, _ := os.MkdirTemp("", fmt.Sprintf("plugins_test-%s", "TestBufferedFile"))
-	defer test.CleanupDummyDataDir(tempDir)
-
-	filePath := filepath.Join(tempDir, "test.bin")
+	filePath := filepath.Join(t.TempDir(), "test.bin")
 	fp, err := os.OpenFile(filePath, os.O_CREATE|os.O_RDWR, 0o700)
 	assert.Nil(t, err)
 	err = fp.Truncate(1024 * 1024)

--- a/executor/wal_test.go
+++ b/executor/wal_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestWALWrite(t *testing.T) {
-	tearDown, rootDir, _, metadata, shutdownPending := setup(t, "TestWALWrite")
-	defer tearDown()
+	rootDir, _, metadata, shutdownPending := setup(t)
 
 	var err error
 	mockInstanceID := time.Now().UTC().UnixNano()
@@ -82,8 +81,7 @@ func TestWALWrite(t *testing.T) {
 }
 
 func TestBrokenWAL(t *testing.T) {
-	tearDown, rootDir, _, metadata, _ := setup(t, "TestBrokenWAL")
-	defer tearDown()
+	rootDir, _, metadata, _ := setup(t)
 
 	var err error
 
@@ -153,8 +151,7 @@ func TestBrokenWAL(t *testing.T) {
 }
 
 func TestWALReplay(t *testing.T) {
-	tearDown, rootDir, _, metadata, _ := setup(t, "TestWALReplay")
-	defer tearDown()
+	rootDir, _, metadata, _ := setup(t)
 
 	var err error
 

--- a/frontend/query_test.go
+++ b/frontend/query_test.go
@@ -1,9 +1,7 @@
 package frontend_test
 
 import (
-	"fmt"
 	"math"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,13 +15,13 @@ import (
 	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string,
-) (tearDown func(), rootDir string, metadata *executor.InstanceMetadata, writer *executor.Writer,
+func setup(t *testing.T,
+) (rootDir string, metadata *executor.InstanceMetadata, writer *executor.Writer,
 	q frontend.QueryInterface,
 ) {
 	t.Helper()
 
-	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("frontend_test-%s", testName))
+	rootDir = t.TempDir()
 	test.MakeDummyCurrencyDir(rootDir, true, false)
 	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, executor.BackgroundSync(false))
 	assert.Nil(t, err)
@@ -31,12 +29,11 @@ func setup(t *testing.T, testName string,
 
 	qs := frontend.NewQueryService(metadata.CatalogDir)
 	writer, _ = executor.NewWriter(metadata.CatalogDir, metadata.WALFile)
-	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, metadata, writer, qs
+	return rootDir, metadata, writer, qs
 }
 
 func _TestQueryCustomTimeframes(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "_TestQueryCustomTimeframes")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	// TODO: Support custom timeframes
 	service := frontend.NewDataService(rootDir, metadata.CatalogDir, sqlparser.NewAggRunner(nil), writer, q)
@@ -97,8 +94,7 @@ func _TestQueryCustomTimeframes(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "TestQuery")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	service := frontend.NewDataService(rootDir, metadata.CatalogDir, sqlparser.NewAggRunner(nil), writer, q)
 	service.Init()
@@ -133,8 +129,7 @@ func TestQuery(t *testing.T) {
 }
 
 func TestQueryFirstN(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "TestQueryFirstN")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	service := frontend.NewDataService(rootDir, metadata.CatalogDir, sqlparser.NewAggRunner(nil), writer, q)
 	service.Init()
@@ -167,8 +162,7 @@ func TestQueryFirstN(t *testing.T) {
 }
 
 func TestQueryRange(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "TestQueryRange")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	service := frontend.NewDataService(rootDir, metadata.CatalogDir, sqlparser.NewAggRunner(nil), writer, q)
 	service.Init()
@@ -217,8 +211,7 @@ func TestQueryRange(t *testing.T) {
 }
 
 func TestQueryNpyMulti(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "TestQueryNpyMulti")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	service := frontend.NewDataService(rootDir, metadata.CatalogDir, sqlparser.NewAggRunner(nil), writer, q)
 	service.Init()
@@ -250,8 +243,7 @@ func TestQueryNpyMulti(t *testing.T) {
 }
 
 func TestQueryMulti(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "TestQueryMulti")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	service := frontend.NewDataService(rootDir, metadata.CatalogDir, sqlparser.NewAggRunner(nil), writer, q)
 	service.Init()
@@ -294,8 +286,7 @@ func TestQueryMulti(t *testing.T) {
 }
 
 func TestListSymbols(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "TestListSymbols")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	service := frontend.NewDataService(rootDir, metadata.CatalogDir, sqlparser.NewAggRunner(nil), writer, q)
 	service.Init()
@@ -330,8 +321,7 @@ func TestListSymbols(t *testing.T) {
 }
 
 func TestFunctions(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "TestFunctions")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	service := frontend.NewDataService(rootDir, metadata.CatalogDir,
 		sqlparser.NewDefaultAggRunner(metadata.CatalogDir), writer, q,

--- a/frontend/server_test.go
+++ b/frontend/server_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestNewServer(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "TestNewServer")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	serv, _ := frontend.NewServer(rootDir, metadata.CatalogDir, sqlparser.NewAggRunner(nil), writer, q)
 	assert.True(t, serv.HasMethod("DataService.Query"))

--- a/frontend/stream/stream_test.go
+++ b/frontend/stream/stream_test.go
@@ -1,11 +1,9 @@
 package stream_test
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -18,24 +16,19 @@ import (
 	"github.com/alpacahq/marketstore/v4/frontend/stream"
 	"github.com/alpacahq/marketstore/v4/utils/io"
 	"github.com/alpacahq/marketstore/v4/utils/log"
-	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string,
-) (tearDown func()) {
+func setup(t *testing.T) {
 	t.Helper()
 
-	rootDir, _ := os.MkdirTemp("", fmt.Sprintf("stream_test-%s", testName))
+	rootDir := t.TempDir()
 	_, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5, executor.BackgroundSync(false))
 	assert.Nil(t, err)
 	stream.Initialize()
-
-	return func() { test.CleanupDummyDataDir(rootDir) }
 }
 
 func TestStream(t *testing.T) {
-	tearDown := setup(t, "TestStream")
-	defer tearDown()
+	setup(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(stream.Handler))
 

--- a/frontend/write_test.go
+++ b/frontend/write_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestWrite(t *testing.T) {
-	tearDown, rootDir, metadata, writer, q := setup(t, "TestWrite")
-	defer tearDown()
+	rootDir, metadata, writer, q := setup(t)
 
 	service := frontend.NewDataService(rootDir, metadata.CatalogDir, sqlparser.NewAggRunner(nil), writer, q)
 	service.Init()

--- a/metrics/du_test.go
+++ b/metrics/du_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alpacahq/marketstore/v4/metrics"
-	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
 type mockMetricsSetter struct {
@@ -47,7 +46,7 @@ func TestStartDiskUsageMonitor(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			// --- given ---
-			rootDir, _ := os.MkdirTemp("", "diskUsage-monitor-test")
+			rootDir := t.TempDir()
 			err := tt.setFilesFunc(tt, rootDir)
 			assert.Nil(t, err)
 			m := mockMetricsSetter{}
@@ -58,9 +57,6 @@ func TestStartDiskUsageMonitor(t *testing.T) {
 
 			// --- then ---
 			assert.Equal(t, tt.expMetric, m.value)
-
-			// --- tearDown ---
-			test.CleanupDummyDataDir(rootDir)
 		})
 	}
 }

--- a/planner/planner_test.go
+++ b/planner/planner_test.go
@@ -1,8 +1,6 @@
 package planner_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -13,23 +11,21 @@ import (
 	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string,
-) (tearDown func(), rootDir string, catalogDir *catalog.Directory) {
+func setup(t *testing.T) (rootDir string, catalogDir *catalog.Directory) {
 	t.Helper()
 
-	rootDir, _ = os.MkdirTemp("", fmt.Sprintf("planner_test-%s", testName))
+	rootDir = t.TempDir()
 	test.MakeDummyCurrencyDir(rootDir, false, false)
 	catalogDir, err := catalog.NewDirectory(rootDir)
 	if err != nil {
 		t.Fatal("failed to create a catalog dir.err=" + err.Error())
 	}
 
-	return func() { test.CleanupDummyDataDir(rootDir) }, rootDir, catalogDir
+	return rootDir, catalogDir
 }
 
 func TestQuery(t *testing.T) {
-	tearDown, _, catalogDir := setup(t, "TestQuery")
-	defer tearDown()
+	_, catalogDir := setup(t)
 
 	q := planner.NewQuery(catalogDir)
 	q.AddRestriction("Symbol", "NZDUSD")

--- a/plugins/load_test.go
+++ b/plugins/load_test.go
@@ -1,7 +1,6 @@
 package plugins_test
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,13 +11,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/alpacahq/marketstore/v4/plugins"
-	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string) (tearDown func(), testPluginLib, oldGoPath, absTestPluginLib string) {
+func setup(t *testing.T) (tearDown func(), testPluginLib, oldGoPath, absTestPluginLib string) {
 	t.Helper()
 
-	dirName, _ := os.MkdirTemp("", fmt.Sprintf("plugins_test-%s", testName))
+	dirName := t.TempDir()
 
 	if osType := runtime.GOOS; osType != "linux" {
 		t.Skip("Only linux runs plugins")
@@ -58,8 +56,6 @@ func main() {}
 	os.Setenv("GOPATH", newGoPath)
 
 	return func() {
-		test.CleanupDummyDataDir(dirName)
-
 		if oldGoPath != "" {
 			os.Setenv("GOPATH", oldGoPath)
 		}
@@ -67,7 +63,7 @@ func main() {}
 }
 
 func TestLoadFromGOPATH(t *testing.T) {
-	tearDown, testPluginLib, _, absTestPluginLib := setup(t, "TestLoadFromGOPATH")
+	tearDown, testPluginLib, _, absTestPluginLib := setup(t)
 	defer tearDown()
 
 	var pi *plugin.Plugin

--- a/uda/adjust/adjust_test.go
+++ b/uda/adjust/adjust_test.go
@@ -1,9 +1,7 @@
 package adjust
 
 import (
-	"fmt"
 	"math"
-	"os"
 	"testing"
 	"time"
 
@@ -13,21 +11,18 @@ import (
 	"github.com/alpacahq/marketstore/v4/executor"
 	"github.com/alpacahq/marketstore/v4/utils/functions"
 	"github.com/alpacahq/marketstore/v4/utils/io"
-	"github.com/alpacahq/marketstore/v4/utils/test"
 )
 
-func setup(t *testing.T, testName string,
-) (tearDown func(), metadata *executor.InstanceMetadata) {
+func setup(t *testing.T) (metadata *executor.InstanceMetadata) {
 	t.Helper()
 
 	rounderNum = math.Pow(10, 3)
 
-	rootDir, _ := os.MkdirTemp("", fmt.Sprintf("adjust_test-%s", testName))
-	metadata, _, _, err := executor.NewInstanceSetup(rootDir, nil, nil, 5,
+	metadata, _, _, err := executor.NewInstanceSetup(t.TempDir(), nil, nil, 5,
 		executor.BackgroundSync(false), executor.WALBypass(true))
 	assert.Nil(t, err)
 
-	return func() { test.CleanupDummyDataDir(rootDir) }, metadata
+	return metadata
 }
 
 type price struct {
@@ -162,8 +157,7 @@ var testDifferentEvents = []AdjustTestCase{
 }
 
 func TestCase1(t *testing.T) {
-	tearDown, _ := setup(t, "TestCase1")
-	defer tearDown()
+	setup(t)
 
 	for _, testCase := range testDifferentEvents {
 		testCase := testCase
@@ -221,8 +215,7 @@ var testDifferentDates = []AdjustTestCase{
 }
 
 func TestCase2(t *testing.T) {
-	tearDown, _ := setup(t, "TestCase1")
-	defer tearDown()
+	setup(t)
 
 	for _, testCase := range testDifferentDates {
 		testCase := testCase
@@ -353,8 +346,7 @@ var testMultipleEventsOnDifferentDates = []AdjustTestCase{
 }
 
 func TestMultipleEventsOnDifferentDates(t *testing.T) {
-	tearDown, _ := setup(t, "TestMultipleEventsOnDifferentDates")
-	defer tearDown()
+	setup(t)
 
 	for _, testCase := range testMultipleEventsOnDifferentDates {
 		testCase := testCase

--- a/uda/adjust/caloader_test.go
+++ b/uda/adjust/caloader_test.go
@@ -238,8 +238,7 @@ var filteringFixtures = []struct {
 }
 
 func TestRateChangeEventsFiltering(t *testing.T) {
-	tearDown, _ := setup(t, "TestRateChangeEventsFiltering")
-	defer tearDown()
+	setup(t)
 
 	for _, tt := range filteringFixtures {
 		ca := defineCorporateActions(tt.in...)
@@ -371,8 +370,7 @@ var statusHandlingFixtures = []struct {
 }
 
 func TestRateChangeEventsAnnouncementStatusHandling(t *testing.T) {
-	tearDown, _ := setup(t, "TestRateChangeEventsFiltering")
-	defer tearDown()
+	setup(t)
 
 	for _, tt := range statusHandlingFixtures {
 		ca := defineCorporateActions(tt.in...)
@@ -428,8 +426,7 @@ var sortingFixtures = []struct {
 }
 
 func TestRateChangeEventsProperSorting(t *testing.T) {
-	tearDown, _ := setup(t, "TestRateChangeEventsProperSorting")
-	t.Cleanup(tearDown)
+	setup(t)
 
 	for _, tt := range sortingFixtures {
 		ca := defineCorporateActions(tt.in...)
@@ -439,8 +436,7 @@ func TestRateChangeEventsProperSorting(t *testing.T) {
 }
 
 func TestCache(t *testing.T) {
-	tearDown, metadata := setup(t, "TestCache")
-	t.Cleanup(tearDown)
+	metadata := setup(t)
 
 	// GetRateChange should create a separate cache entry for each parameter combination
 	rateChangeCache = map[CacheKey]RateChangeCache{}

--- a/utils/io/all_test.go
+++ b/utils/io/all_test.go
@@ -180,8 +180,7 @@ func TestSerializeColumnsToRows(t *testing.T) {
 
 func TestTimeBucketInfo(t *testing.T) {
 	t.Parallel()
-	tempDir, _ := os.MkdirTemp("", "io.TestTimeBucketInfo")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	timeframe := utils.NewTimeframe("1Min")
 	filePath := filepath.Join(tempDir, "2018.bin")


### PR DESCRIPTION
A small testing enhancement here.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir
Signed-off-by: Eng Zer Jun <engzerjun@gmail.com>