### PR TITLE
feat(alpacabkfeeder): add columns to store

### DIFF
--- a/contrib/alpacabkfeeder/writer/snapshot_writer.go
+++ b/contrib/alpacabkfeeder/writer/snapshot_writer.go
@@ -46,8 +46,22 @@ func (q *SnapshotWriterImpl) convertToCSM(snapshots map[string]*v2.Snapshot) io.
 		}
 
 		// adjust the time to UTC and set the timezone the same way as the marketstore config
-		latestTime := snapshot.LatestQuote.Timestamp.In(q.Timezone)
+		latestTime := latestTime(
+			snapshot.LatestQuote.Timestamp,
+			snapshot.LatestTrade.Timestamp,
+		).In(q.Timezone)
 
+		// These additional fields are not always provided.
+		// fill empty data to keep the number of columns in the CSM
+		if snapshot.DailyBar == nil {
+			snapshot.DailyBar = &v2.Bar{}
+		}
+		if snapshot.PrevDailyBar == nil {
+			snapshot.PrevDailyBar = &v2.Bar{}
+		}
+		if snapshot.MinuteBar == nil {
+			snapshot.MinuteBar = &v2.Bar{}
+		}
 		cs := q.newColumnSeries(latestTime.Unix(), snapshot)
 		tbk := io.NewTimeBucketKey(symbol + "/" + q.Timeframe + "/TICK")
 		csm.AddColumnSeries(*tbk, cs)
@@ -56,12 +70,41 @@ func (q *SnapshotWriterImpl) convertToCSM(snapshots map[string]*v2.Snapshot) io.
 	return csm
 }
 
+func latestTime(time1, time2 time.Time) time.Time {
+	if time1.After(time2) {
+		return time1
+	}
+	return time2
+}
+
 func (q SnapshotWriterImpl) newColumnSeries(epoch int64, ss *v2.Snapshot) *io.ColumnSeries {
 	cs := io.NewColumnSeries()
 	cs.AddColumn("Epoch", []int64{epoch})
+	cs.AddColumn("QuoteTimestamp", []int64{ss.LatestQuote.Timestamp.In(q.Timezone).Unix()})
 	cs.AddColumn("Ask", []float64{ss.LatestQuote.AskPrice})
 	cs.AddColumn("AskSize", []uint32{ss.LatestQuote.AskSize})
 	cs.AddColumn("Bid", []float64{ss.LatestQuote.BidPrice})
 	cs.AddColumn("BidSize", []uint32{ss.LatestQuote.BidSize})
+	cs.AddColumn("TradeTimestamp", []int64{ss.LatestTrade.Timestamp.In(q.Timezone).Unix()})
+	cs.AddColumn("Price", []float64{ss.LatestTrade.Price})
+	cs.AddColumn("Size", []uint32{ss.LatestTrade.Size})
+	cs.AddColumn("DailyTimestamp", []int64{ss.DailyBar.Timestamp.In(q.Timezone).Unix()})
+	cs.AddColumn("Open", []float64{ss.DailyBar.Open})
+	cs.AddColumn("High", []float64{ss.DailyBar.High})
+	cs.AddColumn("Low", []float64{ss.DailyBar.Low})
+	cs.AddColumn("Close", []float64{ss.DailyBar.Close})
+	cs.AddColumn("Volume", []uint64{ss.DailyBar.Volume})
+	cs.AddColumn("MinuteTimestamp", []int64{ss.MinuteBar.Timestamp.In(q.Timezone).Unix()})
+	cs.AddColumn("MinuteOpen", []float64{ss.MinuteBar.Open})
+	cs.AddColumn("MinuteHigh", []float64{ss.MinuteBar.High})
+	cs.AddColumn("MinuteLow", []float64{ss.MinuteBar.Low})
+	cs.AddColumn("MinuteClose", []float64{ss.MinuteBar.Close})
+	cs.AddColumn("MinuteVolume", []uint64{ss.MinuteBar.Volume})
+	cs.AddColumn("PreviousTimestamp", []int64{ss.PrevDailyBar.Timestamp.In(q.Timezone).Unix()})
+	cs.AddColumn("PreviousOpen", []float64{ss.PrevDailyBar.Open})
+	cs.AddColumn("PreviousHigh", []float64{ss.PrevDailyBar.High})
+	cs.AddColumn("PreviousLow", []float64{ss.PrevDailyBar.Low})
+	cs.AddColumn("PreviousClose", []float64{ss.PrevDailyBar.Close})
+	cs.AddColumn("PreviousVolume", []uint64{ss.PrevDailyBar.Volume})
 	return cs
 }

--- a/contrib/alpacabkfeeder/writer/snapshot_writer_test.go
+++ b/contrib/alpacabkfeeder/writer/snapshot_writer_test.go
@@ -25,6 +25,27 @@ var (
 		AskSize:   7,
 		Timestamp: time.Unix(8, 0),
 	}
+	exampleDailyBar = &v2.Bar{
+		Open:      9,
+		High:      10,
+		Low:       11,
+		Close:     12,
+		Volume:    13,
+	}
+	examplePreviousDailyBar = &v2.Bar{
+		Open:      14,
+		High:      15,
+		Low:       16,
+		Close:     17,
+		Volume:    18,
+	}
+	exampleMinuteBar = &v2.Bar{
+		Open:      19,
+		High:      20,
+		Low:       21,
+		Close:     22,
+		Volume:    23,
+	}
 )
 
 func TestSnapshotWriterImpl_Write(t *testing.T) {
@@ -53,6 +74,9 @@ func TestSnapshotWriterImpl_Write(t *testing.T) {
 				"AAPL": {
 					LatestTrade: exampleTrade,
 					LatestQuote: exampleQuote,
+					DailyBar: exampleDailyBar,
+					MinuteBar: exampleMinuteBar,
+					PrevDailyBar: examplePreviousDailyBar,
 				},
 				"AMZN": nil, // nil snapshot must be ignored
 				"FB": {
@@ -68,10 +92,32 @@ func TestSnapshotWriterImpl_Write(t *testing.T) {
 			wantTBKs: []io.TimeBucketKey{*io.NewTimeBucketKey("AAPL/1Sec/TICK")},
 			wantCSMDataShapes: []io.DataShape{
 				{Name: "Epoch", Type: io.INT64},
+				{Name: "QuoteTimestamp", Type: io.INT64},
 				{Name: "Ask", Type: io.FLOAT64},
 				{Name: "AskSize", Type: io.UINT32},
 				{Name: "Bid", Type: io.FLOAT64},
 				{Name: "BidSize", Type: io.UINT32},
+				{Name: "TradeTimestamp", Type: io.INT64},
+				{Name: "Price", Type: io.FLOAT64},
+				{Name: "Size", Type: io.UINT32},
+				{Name: "DailyTimestamp", Type: io.INT64},
+				{Name: "Open", Type: io.FLOAT64},
+				{Name: "High", Type: io.FLOAT64},
+				{Name: "Low", Type: io.FLOAT64},
+				{Name: "Close", Type: io.FLOAT64},
+				{Name: "Volume", Type: io.UINT64},
+				{Name: "MinuteTimestamp", Type: io.INT64},
+				{Name: "MinuteOpen", Type: io.FLOAT64},
+				{Name: "MinuteHigh", Type: io.FLOAT64},
+				{Name: "MinuteLow", Type: io.FLOAT64},
+				{Name: "MinuteClose", Type: io.FLOAT64},
+				{Name: "MinuteVolume", Type: io.UINT64},
+				{Name: "PreviousTimestamp", Type: io.INT64},
+				{Name: "PreviousOpen", Type: io.FLOAT64},
+				{Name: "PreviousHigh", Type: io.FLOAT64},
+				{Name: "PreviousLow", Type: io.FLOAT64},
+				{Name: "PreviousClose", Type: io.FLOAT64},
+				{Name: "PreviousVolume", Type: io.UINT64},
 			},
 			wantCSMLen: 1,
 		},


### PR DESCRIPTION
## WHAT
- Alpaca Broker Feeder plugin: add `Trade`, `DailyBar`, `MinuteBar`, and `PreviousBar` data to `{symbol}/1Sec/TICK` buckets

## WHY
- to store all the data in the response of `GetSnapshot` Alpaca API endpoint