### PR TITLE
fix(alpacabkfeeder): override stocks_json URL by env var

### DIFF
--- a/contrib/alpacabkfeeder/configs/config_test.go
+++ b/contrib/alpacabkfeeder/configs/config_test.go
@@ -14,6 +14,7 @@ var testConfig = map[string]interface{}{
 	"api_secret_key":         "world",
 	"symbols_update_time":    "01:23:45",
 	"update_time":            "12:34:56",
+	"stocks_json_url":        "https://example.com/tradable_stocks.json",
 	"stocks_json_basic_auth": "foo:bar",
 	"exchanges":              []string{"AMEX", "ARCA", "BATS", "NYSE", "NASDAQ", "NYSEARCA", "OTC"},
 	"index_groups":           []string{"bar"},
@@ -32,13 +33,14 @@ func TestNewConfig(t *testing.T) {
 		want    *configs.DefaultConfig
 		wantErr bool
 	}{
-		"ok/ API key ID, API secret key, UpdateTime, basicAuth can be overridden by env vars": {
+		"ok/ API key ID, API secret key, UpdateTime, stocksJson can be overridden by env vars": {
 			config: testConfig,
 			envVars: map[string]string{
 				"ALPACA_BROKER_FEEDER_API_KEY_ID":             "yo",
 				"ALPACA_BROKER_FEEDER_API_SECRET_KEY":         "yoyo",
 				"ALPACA_BROKER_FEEDER_SYMBOLS_UPDATE_TIME":    "10:00:00",
 				"ALPACA_BROKER_FEEDER_UPDATE_TIME":            "20:00:00",
+				"ALPACA_BROKER_FEEDER_STOCKS_JSON_URL":        "https://example.com/overriden.json",
 				"ALPACA_BROKER_FEEDER_STOCKS_JSON_BASIC_AUTH": "akkie:mypassword",
 			},
 			want: &configs.DefaultConfig{
@@ -52,6 +54,7 @@ func TestNewConfig(t *testing.T) {
 				UpdateTime:          time.Date(0, 1, 1, 20, 0, 0, 0, time.UTC),
 				APIKeyID:            "yo",
 				APISecretKey:        "yoyo",
+				StocksJSONURL:       "https://example.com/overriden.json",
 				StocksJSONBasicAuth: "akkie:mypassword",
 			},
 			wantErr: false,
@@ -70,6 +73,7 @@ func TestNewConfig(t *testing.T) {
 				UpdateTime:          time.Date(0, 1, 1, 12, 34, 56, 0, time.UTC),
 				APIKeyID:            "hello",
 				APISecretKey:        "world",
+				StocksJSONURL:       "https://example.com/tradable_stocks.json",
 				StocksJSONBasicAuth: "foo:bar",
 			},
 			wantErr: false,

--- a/contrib/alpacabkfeeder/configs/envconfig.go
+++ b/contrib/alpacabkfeeder/configs/envconfig.go
@@ -42,7 +42,12 @@ func envOverride(config *DefaultConfig) (*DefaultConfig, error) {
 		config.APISecretKey = apiSecretKey
 	}
 
+	// override the basic Auth of Stocks Json URL and basic auth
 	// override the basic Auth of Stocks Json URL
+	stocksJSONURL := os.Getenv("ALPACA_BROKER_FEEDER_STOCKS_JSON_URL")
+	if stocksJSONURL != "" {
+		config.StocksJSONURL = stocksJSONURL
+	}
 	stocksJSONBasicAuth := os.Getenv("ALPACA_BROKER_FEEDER_STOCKS_JSON_BASIC_AUTH")
 	if stocksJSONBasicAuth != "" {
 		config.StocksJSONBasicAuth = stocksJSONBasicAuth

--- a/contrib/alpacabkfeeder/feed/backfill.go
+++ b/contrib/alpacabkfeeder/feed/backfill.go
@@ -3,7 +3,6 @@ package feed
 import (
 	"time"
 
-
 	"github.com/alpacahq/marketstore/v4/contrib/alpacabkfeeder/api"
 	"github.com/alpacahq/marketstore/v4/contrib/alpacabkfeeder/symbols"
 	"github.com/alpacahq/marketstore/v4/contrib/alpacabkfeeder/writer"


### PR DESCRIPTION
## WHAT
- `ALPACA_BROKER_FEEDER_STOCKS_JSON_URL` overrides the config in mkts.yml

## WHY
- to use different URLs depending on env