### PR TITLE
fix(timeframe): handle an error due to an invalid timeframe string

### DIFF
--- a/contrib/candler/candler.go
+++ b/contrib/candler/candler.go
@@ -124,13 +124,13 @@ func (ca *Candler) init(argMap *functions.ArgumentMap, args ...interface{}) erro
 		}
 		tfstring = val[0]
 	}
-	cd := utils.CandleDurationFromString(tfstring)
+	cd, err := utils.CandleDurationFromString(tfstring)
 
 	if ca == nil {
 		return fmt.Errorf("init called without calling New()")
 	}
-	if cd == nil {
-		return fmt.Errorf("no suitable timeframe provided")
+	if err != nil {
+		return fmt.Errorf("no suitable timeframe provided: %w", err)
 	}
 	if unmapped := argMap.Validate(); unmapped != nil {
 		return fmt.Errorf("unmapped columns: %s", unmapped)

--- a/contrib/ondiskagg/aggtrigger/aggtrigger.go
+++ b/contrib/ondiskagg/aggtrigger/aggtrigger.go
@@ -218,7 +218,7 @@ func (s *OnDiskAggTrigger) writeAggregates(
 
 	window, err := utils.CandleDurationFromString(dest.String)
 	if err != nil {
-		return fmt.Errorf("timeframe not found from %s: %w", dest.String, err)
+		return fmt.Errorf("timeframe not found in %s: %w", dest.String, err)
 	}
 	start := window.Truncate(head).Unix()
 	end := window.Ceil(tail).Add(-time.Second).Unix()

--- a/contrib/stream/streamtrigger/streamtrigger.go
+++ b/contrib/stream/streamtrigger/streamtrigger.go
@@ -114,7 +114,11 @@ func (s *StreamTrigger) Fire(keyPath string, records []trigger.Record) {
 	if tf.Duration > time.Minute {
 		// push aggregates to shelf and let them get handled
 		// asynchronously when they are completed or expire
-		timeWindow := utils.CandleDurationFromString(tf.String)
+		timeWindow, err2 := utils.CandleDurationFromString(tf.String)
+		if err2 != nil {
+			log.Error("[streamtrigger] timeframe extraction failure (tf=%s) (err=%v)", tf.String, err2)
+			return
+		}
 
 		var deadline *time.Time
 

--- a/frontend/query.go
+++ b/frontend/query.go
@@ -305,7 +305,7 @@ func (qs *QueryService) ExecuteQuery(tbk *io.TimeBucketKey, start, end time.Time
 	tf := tbk.GetItemInCategory("Timeframe")
 	cd, err := utils.CandleDurationFromString(tf)
 	if err != nil {
-		return nil, fmt.Errorf("timeframe not found from tf=%s: %w", tf, err)
+		return nil, fmt.Errorf("timeframe not found in TimeBucketKey=%s", tbk.String())
 	}
 	queryableTimeframe := cd.QueryableTimeframe()
 	tbk.SetItemInCategory("Timeframe", queryableTimeframe)

--- a/frontend/query.go
+++ b/frontend/query.go
@@ -305,7 +305,7 @@ func (qs *QueryService) ExecuteQuery(tbk *io.TimeBucketKey, start, end time.Time
 	tf := tbk.GetItemInCategory("Timeframe")
 	cd, err := utils.CandleDurationFromString(tf)
 	if err != nil {
-		return nil, fmt.Errorf("timeframe not found in TimeBucketKey=%s", tbk.String())
+		return nil, fmt.Errorf("timeframe not found in TimeBucketKey=%s: %w", tbk.String(), err)
 	}
 	queryableTimeframe := cd.QueryableTimeframe()
 	tbk.SetItemInCategory("Timeframe", queryableTimeframe)

--- a/frontend/query.go
+++ b/frontend/query.go
@@ -303,7 +303,10 @@ func (qs *QueryService) ExecuteQuery(tbk *io.TimeBucketKey, start, end time.Time
 	*/
 
 	tf := tbk.GetItemInCategory("Timeframe")
-	cd := utils.CandleDurationFromString(tf)
+	cd, err := utils.CandleDurationFromString(tf)
+	if err != nil {
+		return nil, fmt.Errorf("timeframe not found from tf=%s: %w", tf, err)
+	}
 	queryableTimeframe := cd.QueryableTimeframe()
 	tbk.SetItemInCategory("Timeframe", queryableTimeframe)
 	query.AddTargetKey(tbk)

--- a/uda/adjust/caloader.go
+++ b/uda/adjust/caloader.go
@@ -123,7 +123,10 @@ func (act *Actions) Load(catalogDir *catalog.Directory) error {
 	query := planner.NewQuery(catalogDir)
 	tbk := io.NewTimeBucketKeyFromString(act.Symbol + enum.BucketkeySuffix)
 	tf := tbk.GetItemInCategory("Timeframe")
-	cd := utils.CandleDurationFromString(tf)
+	cd, err := utils.CandleDurationFromString(tf)
+	if err != nil {
+		return fmt.Errorf("timeframe is not found in %s: %w", tf, err)
+	}
 	queryableTimeframe := cd.QueryableTimeframe()
 	tbk.SetItemInCategory("Timeframe", queryableTimeframe)
 

--- a/uda/gap/gap.go
+++ b/uda/gap/gap.go
@@ -136,8 +136,8 @@ func (g Gap) New(_ *functions.ArgumentMap, args ...interface{}) (out uda.AggInte
 			}
 			tfstring = val[0]
 		}
-		cd := utils.CandleDurationFromString(tfstring)
-		if cd != nil {
+		cd, err2 := utils.CandleDurationFromString(tfstring)
+		if err2 == nil {
 			// fmt.Printf("Duration %v, args[0] %v, time.SEcond %v\n", cd.Duration(), args[0], time.Second)
 			gx.avgGapIntervalSeconds = int64(cd.Duration() / time.Second)
 		}

--- a/utils/timeframe.go
+++ b/utils/timeframe.go
@@ -212,11 +212,12 @@ func (cd *CandleDuration) Duration() time.Duration {
 	return cd.duration
 }
 
-func CandleDurationFromString(tf string) (cd *CandleDuration) {
-	re := regexp.MustCompile(`(\d+)(Sec|Min|H|D|W|M|Y)`)
-	groups := re.FindStringSubmatch(tf)
+var timeFrameRegex = regexp.MustCompile(`(\d+)(Sec|Min|H|D|W|M|Y)`)
+
+func CandleDurationFromString(tf string) (cd *CandleDuration, err error) {
+	groups := timeFrameRegex.FindStringSubmatch(tf)
 	if len(groups) == 0 {
-		return nil
+		return nil, fmt.Errorf("timeframe not found in \"%s\"", tf)
 	}
 	prefix := groups[1]
 	mult, _ := strconv.Atoi(prefix)
@@ -226,7 +227,7 @@ func CandleDurationFromString(tf string) (cd *CandleDuration) {
 		multiplier: mult,
 		suffix:     suffix,
 		duration:   time.Duration(mult) * suffixDefs[suffix],
-	}
+	}, nil
 }
 
 var suffixDefs = map[string]time.Duration{

--- a/utils/timeframe_test.go
+++ b/utils/timeframe_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +44,8 @@ func TestCandleDuration(t *testing.T) {
 	var cd *CandleDuration
 	var val, start time.Time
 	var within bool
-	cd = CandleDurationFromString("5Min")
+	cd, err := CandleDurationFromString("5Min")
+	require.Nil(t, err)
 	val = time.Date(2017, 9, 10, 13, 47, 0, 0, time.UTC)
 	assert.Equal(t, cd.Truncate(val), time.Date(2017, 9, 10, 13, 45, 0, 0, time.UTC))
 	assert.Equal(t, cd.Ceil(val), time.Date(2017, 9, 10, 13, 50, 0, 0, time.UTC))
@@ -52,7 +55,8 @@ func TestCandleDuration(t *testing.T) {
 	within = cd.IsWithin(time.Date(2017, 9, 10, 13, 51, 0, 0, time.UTC), start)
 	assert.Equal(t, within, false)
 
-	cd = CandleDurationFromString("1M")
+	cd, err = CandleDurationFromString("1M")
+	require.Nil(t, err)
 	val = time.Date(2017, 9, 10, 13, 47, 0, 0, time.UTC)
 	assert.Equal(t, cd.Truncate(val), time.Date(2017, 9, 1, 0, 0, 0, 0, time.UTC))
 	assert.Equal(t, cd.Ceil(val), time.Date(2017, 10, 1, 0, 0, 0, 0, time.UTC))
@@ -73,7 +77,8 @@ func TestCandleDuration(t *testing.T) {
 	within = cd.IsWithin(time.Date(2016, 12, 10, 0, 0, 0, 0, time.UTC), start)
 	assert.Equal(t, within, false)
 
-	cd = CandleDurationFromString("1W")
+	cd, err = CandleDurationFromString("1W")
+	require.Nil(t, err)
 	val = time.Date(2017, 1, 8, 0, 0, 0, 0, time.UTC)
 	start = time.Date(2018, 1, 7, 0, 0, 0, 0, time.UTC)
 	within = cd.IsWithin(val, start)
@@ -84,7 +89,8 @@ func TestCandleDuration(t *testing.T) {
 	assert.Equal(t, within, true)
 
 	loc, _ := time.LoadLocation("America/New_York")
-	cd = CandleDurationFromString("1D")
+	cd, err = CandleDurationFromString("1D")
+	require.Nil(t, err)
 	val = time.Date(2018, 1, 8, 0, 0, 0, 0, loc)
 	start = cd.Truncate(val)
 	assert.Equal(t, start.Hour(), 0)
@@ -98,6 +104,6 @@ func TestCandleDuration(t *testing.T) {
 	assert.Equal(t, cd.IsWithin(val, time.Date(2018, 1, 8, 0, 0, 0, 0, time.UTC)), false)
 	assert.Equal(t, cd.IsWithin(val, time.Date(2018, 1, 8, 23, 59, 0, 0, time.UTC)), true)
 
-	cd = CandleDurationFromString("abc")
-	assert.Nil(t, cd)
+	cd, err = CandleDurationFromString("abc")
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
## WHAT
- fix a possible panic that occurs when invalid timeframe string is specified in the query/write request
(e.g. when queried `FOO/BAR/1Min/OHLCV` , marketstore was panicking)

## WHY
- bugfix