### PR TITLE
feat(query): query multiple symbols of different data format

### DIFF
--- a/frontend/grpc.go
+++ b/frontend/grpc.go
@@ -177,7 +177,9 @@ func (s GRPCService) Query(_ context.Context, reqs *proto.MultiQueryRequest) (*p
 				} else {
 					err := nmds.Append(cs, tbk)
 					if err != nil {
-						return nil, fmt.Errorf("add tbk=%s to NumpyMultiDataSet: %w", tbk, err)
+						return nil, fmt.Errorf("symbols in a query must have the same data type "+
+							"or be filtered by common columns. symbols=%v", csm.GetMetadataKeys(),
+						)
 					}
 				}
 			}

--- a/frontend/query.go
+++ b/frontend/query.go
@@ -231,9 +231,9 @@ func (s *DataService) executeQuery(req *QueryRequest) (*QueryResponse, error) {
 	*/
 	var nmds *io.NumpyMultiDataset
 	for tbk, cs := range csm {
-		nds, err := io.NewNumpyDataset(cs)
+		nds, err2 := io.NewNumpyDataset(cs)
 		if err != nil {
-			return nil, err
+			return nil, err2
 		}
 		if nmds == nil {
 			nmds, err = io.NewNumpyMultiDataset(nds, tbk)
@@ -241,7 +241,12 @@ func (s *DataService) executeQuery(req *QueryRequest) (*QueryResponse, error) {
 				return nil, err
 			}
 		} else {
-			nmds.Append(cs, tbk)
+			err3 := nmds.Append(cs, tbk)
+			if err3 != nil {
+				return nil, fmt.Errorf("symbols in a query must have the same data type "+
+					"or be filtered by common columns. symbols=%v", csm.GetMetadataKeys(),
+				)
+			}
 		}
 	}
 

--- a/tests/integ/dockerfiles/pyclient/requirements.txt
+++ b/tests/integ/dockerfiles/pyclient/requirements.txt
@@ -1,2 +1,2 @@
 pytest==3.6.1
-git+https://github.com/alpacahq/pymarketstore.git@a5ec99fe53b550b624bf6a0a51148d7ca604f62b#egg=pymarketstore
+git+https://github.com/alpacahq/pymarketstore.git@591f515cc7b8f83bd3e22be653445fbf6d9f09b6#egg=pymarketstore

--- a/tests/integ/dockerfiles/pyclient/requirements.txt
+++ b/tests/integ/dockerfiles/pyclient/requirements.txt
@@ -1,2 +1,2 @@
 pytest==3.6.1
-git+https://github.com/alpacahq/pymarketstore.git@591f515cc7b8f83bd3e22be653445fbf6d9f09b6#egg=pymarketstore
+git+https://github.com/alpacahq/pymarketstore.git@9e0504c966a8c10168f7a73469726cbe2bc17af3#egg=pymarketstore

--- a/tests/integ/tests/test_query_multi_symbols.py
+++ b/tests/integ/tests/test_query_multi_symbols.py
@@ -1,0 +1,83 @@
+"""
+Integration Test for querying multiple symbols
+"""
+import os
+
+import numpy as np
+import pandas as pd
+import pymarketstore as pymkts
+import pytest
+
+client = pymkts.Client(f"http://127.0.0.1:{os.getenv('MARKETSTORE_PORT', 5993)}/rpc",
+                       grpc=(os.getenv("USE_GRPC", "false") == "true"))
+
+
+@pytest.mark.parametrize('write_data, query_columns, want_err, want_data', [
+    # even if the data format of 2 symbols are different,
+    # querying succeeds if the common columns are specified
+    ({
+         'TEST1': {'data': [(pd.Timestamp('2017-01-01 00:00').value / 10 ** 9, 10.0)],
+                   'dtype': [('Epoch', 'i8'), ('Ask', 'f4')],
+                   'is_variable_length': False
+                   },
+         'TEST2': {'data': [(pd.Timestamp('2017-01-01 00:00').value / 10 ** 9, 20.0, 30.0)],
+                   'dtype': [('Epoch', 'i8'), ('Ask', 'f4'), ('Bid', 'f4')],
+                   'is_variable_length': False
+                   },
+     },
+     # query_columns
+     ['Ask'],
+     # want_err
+     False,
+     # want_data
+     {'TEST1': pd.DataFrame(data={'Ask': np.array([10.0], dtype='float32')},
+                            index=pd.Series(['2017-01-01T00:00:00+00:00'],
+                                            dtype='datetime64[ns, UTC]', name="Epoch")),
+      'TEST2': pd.DataFrame(data={'Ask': np.array([20.0], dtype='float32')},
+                            index=pd.Series(['2017-01-01T00:00:00+00:00'],
+                                            dtype='datetime64[ns, UTC]', name="Epoch"))
+      }
+    ),
+    # if common columns are not specified, query returns an error.
+    ({
+         'TEST1': {'data': [(pd.Timestamp('2017-01-01 00:00').value / 10 ** 9, 10.0)],
+                   'dtype': [('Epoch', 'i8'), ('Ask', 'f4')],
+                   'is_variable_length': False
+                   },
+         'TEST2': {'data': [(pd.Timestamp('2017-01-01 00:00').value / 10 ** 9, 20.0, 30.0)],
+                   'dtype': [('Epoch', 'i8'), ('Ask', 'f4'), ('Bid', 'f4')],
+                   'is_variable_length': False
+                   },
+     },
+     # query_columns
+     None,  # no columns specified
+     # want_err
+     True,
+     # want_data
+     None,
+    ),
+])
+def test_query_multi_symbols(write_data, query_columns, want_err, want_data):
+    # ---- given ----
+    for symbol in write_data:
+        tbk = "{}/1Sec/TICK".format(symbol)
+        client.destroy(tbk)  # setup
+        client.write(np.array(write_data[symbol]['data'], dtype=write_data[symbol]['dtype']), tbk,
+                     isvariablelength=write_data[symbol]['is_variable_length'])
+
+    # ---- when ----
+    symbols = list(write_data.keys())
+    if want_err:
+        with pytest.raises(Exception) as excinfo:
+            client.query(pymkts.Params(symbols, '1Sec', 'TICK', columns=query_columns))
+        assert "symbols in a query must have the same data type or be filtered" in str(excinfo.value)
+        return
+
+    reply = client.query(pymkts.Params(symbols, '1Sec', 'TICK', columns=query_columns))
+
+    # ---- then ----
+    tbks = ["{}/1Sec/TICK".format(symbol) for symbol in symbols]
+    for i in range(len(tbks)):
+        want = want_data[symbols[i]]
+        got = reply.all()[tbks[i]].df()
+        assert got.equals(want)

--- a/utils/io/columnseries.go
+++ b/utils/io/columnseries.go
@@ -182,14 +182,15 @@ func (cs *ColumnSeries) Remove(targetName string) error {
 func (cs *ColumnSeries) Project(keepList []string) error {
 	newCols := make(map[string]interface{})
 
-	newNames := make([]string, len(keepList))
-	for i, name := range keepList {
+	var newNames []string
+	for _, name := range keepList {
 		col := cs.GetByName(name)
 		if col == nil {
-			return fmt.Errorf("column named: %s not found", name)
+			log.Debug(fmt.Sprintf("%s column doesn't exist in the column series. ignored.", name))
+			continue
 		}
 		newCols[name] = col
-		newNames[i] = name
+		newNames = append(newNames, name)
 	}
 	cs.columns = newCols
 	cs.orderedNames = newNames


### PR DESCRIPTION
## WHAT
- return multiple symbols data if common columns are specified on a query.

## WHY
- some OHLCV symbols have columns other than Open/High/Low/Close/Volume, but sometimes we want to query just OHLCV columns for those different symbols in one query.