### PR TITLE
fix(xignitefeeder): validate API token length

### DIFF
--- a/contrib/xignitefeeder/configs/config.go
+++ b/contrib/xignitefeeder/configs/config.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -69,13 +70,25 @@ func NewConfig(config map[string]interface{}) (*DefaultConfig, error) {
 		return nil, err2
 	}
 
-	if len(ret.Exchanges) < 1 && len(ret.IndexGroups) < 1 {
-		return nil, errors.New("must have 1 or more stock exchanges or index group in the config file")
-	}
-
 	ret, err = envOverride(ret)
 
+	if err := validate(ret); err != nil {
+		return nil, fmt.Errorf("config validation error: %w", err)
+	}
+
 	return ret, nil
+}
+
+func validate(cfg *DefaultConfig) error {
+	if len(cfg.Exchanges) < 1 && len(cfg.IndexGroups) < 1 {
+		return errors.New("must have 1 or more stock exchanges or index group in the config file")
+	}
+
+	if len(cfg.APIToken) != 32 {
+		return fmt.Errorf("xignite API Token length must be 32 bytes. got=%d", len(cfg.APIToken))
+	}
+
+	return nil
 }
 
 // CustomTime is a date time object in the ctLayout format.

--- a/contrib/xignitefeeder/configs/config_test.go
+++ b/contrib/xignitefeeder/configs/config_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var testConfig = map[string]interface{}{
-	"token":        "hello",
+	"token":        "hellohellohellohellohellohello12",
 	"update_time":  "12:34:56",
 	"exchanges":    []string{"foo"},
 	"index_groups": []string{"bar"},
@@ -28,7 +28,7 @@ func TestNewConfig(t *testing.T) {
 		"ok/ API token and UpdateTime can be overridden by env vars": {
 			config: testConfig,
 			envVars: map[string]string{
-				"XIGNITE_FEEDER_API_TOKEN":   "yo",
+				"XIGNITE_FEEDER_API_TOKEN":   "ABCDEFGHIJKLMNOPQRSTUVWXYZ789012",
 				"XIGNITE_FEEDER_UPDATE_TIME": "20:00:00",
 			},
 			want: &configs.DefaultConfig{
@@ -37,11 +37,19 @@ func TestNewConfig(t *testing.T) {
 				ClosedDaysOfTheWeek: []time.Weekday{time.Sunday},
 				ClosedDays:          []time.Time{time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)},
 				UpdateTime:          time.Date(0, 1, 1, 20, 0, 0, 0, time.UTC),
-				APIToken:            "yo",
+				APIToken:            "ABCDEFGHIJKLMNOPQRSTUVWXYZ789012",
 			},
 			wantErr: false,
 		},
 		"ok/ nothing is overidden when env vars are empty": {
+			config: testConfig,
+			envVars: map[string]string{
+				"XIGNITE_FEEDER_API_TOKEN": "ABCDE", // 5 bytes
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		"ng/ Token length must be 32 bytes": {
 			config:  testConfig,
 			envVars: map[string]string{},
 			want: &configs.DefaultConfig{
@@ -50,7 +58,7 @@ func TestNewConfig(t *testing.T) {
 				ClosedDaysOfTheWeek: []time.Weekday{time.Sunday},
 				ClosedDays:          []time.Time{time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)},
 				UpdateTime:          time.Date(0, 1, 1, 12, 34, 56, 0, time.UTC),
-				APIToken:            "hello",
+				APIToken:            "hellohellohellohellohellohello12",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
## WHAT
- add validation for the Xignite Token

## WHY
- to avoid accidental DOS to Xignite API