### PR TITLE
refactor: add default config

### DIFF
--- a/cmd/start/main.go
+++ b/cmd/start/main.go
@@ -83,10 +83,11 @@ func executeStart(cmd *cobra.Command, _ []string) error {
 	log.Info("using %v for configuration", configFilePath)
 
 	// Attempt to set configuration.
-	config, err := utils.InstanceConfig.Parse(data)
+	config, err := utils.ParseConfig(data)
 	if err != nil {
 		return fmt.Errorf("failed to parse configuration file error: %w", err)
 	}
+	utils.InstanceConfig = *config // TODO: remove the singleton instance
 
 	// New gRPC stream server for replication.
 	opts := []grpc.ServerOption{

--- a/contrib/polygon/backfill/backfiller/backfiller.go
+++ b/contrib/polygon/backfill/backfiller/backfiller.go
@@ -284,11 +284,12 @@ func initConfig() (rootDir string, triggers []*utils.TriggerSetting, walRotateIn
 		os.Exit(1)
 	}
 
-	config, err := utils.InstanceConfig.Parse(data)
+	config, err := utils.ParseConfig(data)
 	if err != nil {
 		log.Error("failed to parse configuration file error: %v", err.Error())
 		os.Exit(1)
 	}
+	utils.InstanceConfig = *config // TODO: remove the singleton instance
 
 	return config.RootDirectory, config.Triggers, config.WALRotateInterval
 }

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -263,7 +263,7 @@ func (q *Query) Parse() (pr *ParseResult, err error) {
 		}
 	}
 
-	// Parse the query in the first pass by finding qualified files
+	// ParseConfig the query in the first pass by finding qualified files
 	pr = NewParseResult()
 	pr.RootDir = q.DataDir.GetPath()
 	/*


### PR DESCRIPTION
## WHAT
- add `NewDefaultConfig` function
- minor refactors

## WHY
- it is necessary to add a function to initialize the config without using the singleton instance (= `utils.InstanceConfig` ) for Dependency Injection