### PR TITLE
refactor(adjust): rename test package to adjust_test

### DIFF
--- a/uda/adjust/adjust.go
+++ b/uda/adjust/adjust.go
@@ -25,7 +25,7 @@ var (
 
 	initArgs []io.DataShape
 
-	rounderNum = math.Pow(decimal, roundToDecimals)
+	RounderNum = math.Pow(decimal, roundToDecimals)
 )
 
 type Adjust struct {
@@ -143,7 +143,7 @@ func (adj *Adjust) Accum(tbk io.TimeBucketKey, _ *functions.ArgumentMap, cols io
 		for _, col := range adj.output {
 			switch c := col.(type) {
 			case []float64:
-				c[i] = math.Round((c[i]/rate)*rounderNum) / rounderNum
+				c[i] = math.Round((c[i]/rate)*RounderNum) / RounderNum
 			case []int64:
 				c[i] = int64(float64(c[i]) * rate)
 			}

--- a/uda/adjust/adjust_test.go
+++ b/uda/adjust/adjust_test.go
@@ -1,9 +1,11 @@
-package adjust
+package adjust_test
 
 import (
 	"math"
 	"testing"
 	"time"
+
+	"github.com/alpacahq/marketstore/v4/uda/adjust"
 
 	"github.com/stretchr/testify/assert"
 
@@ -15,8 +17,6 @@ import (
 
 func setup(t *testing.T) (metadata *executor.InstanceMetadata) {
 	t.Helper()
-
-	rounderNum = math.Pow(10, 3)
 
 	metadata, _, err := executor.NewInstanceSetup(t.TempDir(), nil, nil, 5,
 		executor.BackgroundSync(false), executor.WALBypass(true))
@@ -32,7 +32,7 @@ type price struct {
 
 type AdjustTestCase struct {
 	description string
-	rateChanges []RateChange
+	rateChanges []adjust.RateChange
 	input       []price
 	expected    []price
 }
@@ -56,10 +56,11 @@ func evalCase(t *testing.T, testCase *AdjustTestCase) {
 	symbol := "AAPL"
 	tbkStr := symbol + "/1Min/OHLCV"
 	tbk := io.NewTimeBucketKeyFromString(tbkStr)
-	adj := Adjust{}
+	adj := adjust.Adjust{}
+	adjust.RounderNum = math.Pow(10, 3)
 	am := functions.NewArgumentMap(adj.GetRequiredArgs(), adj.GetOptionalArgs()...)
 
-	rateChangeCache[CacheKey{symbol, true, true}] = RateChangeCache{
+	adjust.RateChangeCacheMap[adjust.CacheKey{symbol, true, true}] = adjust.RateChangeCache{
 		Changes:   testCase.rateChanges,
 		Access:    0,
 		CreatedAt: time.Now(),
@@ -90,7 +91,7 @@ func evalCase(t *testing.T, testCase *AdjustTestCase) {
 var testDifferentEvents = []AdjustTestCase{
 	{
 		description: `Price should be adjusted prior to the StockSplit event. Assertion error at %s`,
-		rateChanges: []RateChange{
+		rateChanges: []adjust.RateChange{
 			{1, unixDate(2020, time.January, 4), enum.StockSplit, 2},
 		},
 		input: []price{
@@ -112,7 +113,7 @@ var testDifferentEvents = []AdjustTestCase{
 	},
 	{
 		description: `Price should be adjusted prior to a ReverseStockSplit event. Assertion error at %s`,
-		rateChanges: []RateChange{
+		rateChanges: []adjust.RateChange{
 			{1, unixDate(2020, time.January, 4), enum.ReverseStockSplit, 0.5},
 		},
 		input: []price{
@@ -134,7 +135,7 @@ var testDifferentEvents = []AdjustTestCase{
 	},
 	{
 		description: `Price should be adjusted prior to a ReverseStockSplit event. Assertion error at %s`,
-		rateChanges: []RateChange{
+		rateChanges: []adjust.RateChange{
 			{1, unixDate(2020, time.January, 4), enum.StockDividend, 1.1},
 		},
 		input: []price{
@@ -169,7 +170,7 @@ var testDifferentDates = []AdjustTestCase{
 	{
 		description: `When an event occurs after the requested price range, every price should be adjusted. ` +
 			`Assertion error at %s`,
-		rateChanges: []RateChange{
+		rateChanges: []adjust.RateChange{
 			{1, unixDate(2020, time.January, 20), enum.StockSplit, 2},
 		},
 		input: []price{
@@ -192,7 +193,7 @@ var testDifferentDates = []AdjustTestCase{
 
 	{
 		description: `When an event occurs before the price range, no price should be adjusted. Assertion error at %s`,
-		rateChanges: []RateChange{
+		rateChanges: []adjust.RateChange{
 			{1, unixDate(2019, time.December, 20), enum.StockSplit, 2},
 		},
 		input: []price{
@@ -226,7 +227,7 @@ func TestCase2(t *testing.T) {
 var testMultipleEventsOnDifferentDates = []AdjustTestCase{
 	{
 		description: `Multiple events, one happened after the price range. Assertion error at %s`,
-		rateChanges: []RateChange{
+		rateChanges: []adjust.RateChange{
 			{1, unixDate(2020, time.January, 3), enum.StockSplit, 2},
 			{1, unixDate(2020, time.January, 6), enum.StockSplit, 2},
 			{1, unixDate(2020, time.January, 20), enum.StockSplit, 2},
@@ -256,7 +257,7 @@ var testMultipleEventsOnDifferentDates = []AdjustTestCase{
 
 	{
 		description: `Multiple events, two happen after the price range. Assertion error at %s`,
-		rateChanges: []RateChange{
+		rateChanges: []adjust.RateChange{
 			{1, unixDate(2020, time.January, 3), enum.StockSplit, 2},
 			{1, unixDate(2020, time.January, 6), enum.StockSplit, 2},
 			{1, unixDate(2020, time.January, 20), enum.StockSplit, 2},
@@ -288,7 +289,7 @@ var testMultipleEventsOnDifferentDates = []AdjustTestCase{
 	{
 		description: `Multiple events, one happens after, one before and one in the duration of the price range. ` +
 			`Assertion error at %s`,
-		rateChanges: []RateChange{
+		rateChanges: []adjust.RateChange{
 			{1, unixDate(2019, time.December, 30), enum.StockSplit, 2},
 			{1, unixDate(2020, time.January, 6), enum.StockSplit, 2},
 			{1, unixDate(2020, time.January, 20), enum.StockSplit, 2},
@@ -318,7 +319,7 @@ var testMultipleEventsOnDifferentDates = []AdjustTestCase{
 
 	{
 		description: `Multiple events, split and reverse split testing. Assertion error at %s`,
-		rateChanges: []RateChange{
+		rateChanges: []adjust.RateChange{
 			{1, unixDate(2020, time.January, 3), enum.StockSplit, 2},
 			{1, unixDate(2020, time.January, 6), enum.ReverseStockSplit, 0.2},
 		},

--- a/uda/uda.go
+++ b/uda/uda.go
@@ -2,6 +2,7 @@ package uda
 
 import (
 	"fmt"
+
 	"github.com/alpacahq/marketstore/v4/utils/io"
 )
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -64,7 +64,7 @@ type MktsConfig struct {
 	BgWorkers                  []*BgWorkerSetting
 }
 
-// 2^20 = 1048576
+// 2^20 = 1048576.
 const megabyteToByte = 1 << 20
 
 func NewDefaultConfig() *MktsConfig {


### PR DESCRIPTION
## WHAT
rename the package name of ***_test.go files under /adjust to `adjust_test`

## WHY
- refactor.
- It can cause an import cycle at later PRs