### PR TITLE
refactor: remove io.Epoch element type

### DIFF
--- a/utils/io/coercecolumn_test.go
+++ b/utils/io/coercecolumn_test.go
@@ -153,7 +153,7 @@ func assertType(t *testing.T, cs *io.ColumnSeries, typ io.EnumElementType) {
 		_, ok = cs.GetColumn(columnName).([]uint32)
 	case io.UINT64:
 		_, ok = cs.GetColumn(columnName).([]uint64)
-	case io.BOOL, io.EPOCH, io.NONE, io.STRING, io.STRING16:
+	case io.BOOL, io.NONE, io.STRING, io.STRING16:
 		t.Fatal("not tested yet")
 	}
 	if !ok {

--- a/utils/io/datashape_test.go
+++ b/utils/io/datashape_test.go
@@ -27,7 +27,7 @@ func TestDSVSerialize(t *testing.T) {
 		{
 			name:        "success/single column",
 			columnNames: []string{"column"},
-			elemTypes:   []io.EnumElementType{io.EPOCH},
+			elemTypes:   []io.EnumElementType{io.INT64},
 		},
 	}
 	for _, tt := range tests {

--- a/utils/io/datatypes.go
+++ b/utils/io/datatypes.go
@@ -43,7 +43,6 @@ const (
 	INT32
 	FLOAT64
 	INT64
-	EPOCH
 	BYTE
 	BOOL
 	NONE
@@ -66,7 +65,6 @@ var attributeMap = map[EnumElementType]struct {
 	INT32:    {reflect.Int32, "int32", 4, reflect.TypeOf(int32(0))},
 	FLOAT64:  {reflect.Float64, "float64", 8, reflect.TypeOf(float64(0))},
 	INT64:    {reflect.Int64, "int64", 8, reflect.TypeOf(int64(0))},
-	EPOCH:    {reflect.Int64, "epoch", 8, reflect.TypeOf(int64(0))},
 	BYTE:     {reflect.Int8, "byte", 1, reflect.TypeOf(byte(0))},
 	BOOL:     {reflect.Bool, "bool", 1, reflect.TypeOf(false)},
 	NONE:     {reflect.Invalid, "none", 0, reflect.TypeOf(byte(0))},
@@ -135,7 +133,7 @@ func (e EnumElementType) ConvertByteSliceInto(data []byte) (interface{}, error) 
 				return slc, nil
 			}
 		}
-	case INT64, EPOCH:
+	case INT64:
 		if val, err := SwapSliceByte(data, int64(0)); err == nil {
 			if slc, ok := val.([]int64); ok {
 				return slc, nil

--- a/utils/io/enumelementtype_string.go
+++ b/utils/io/enumelementtype_string.go
@@ -12,22 +12,21 @@ func _() {
 	_ = x[INT32-1]
 	_ = x[FLOAT64-2]
 	_ = x[INT64-3]
-	_ = x[EPOCH-4]
-	_ = x[BYTE-5]
-	_ = x[BOOL-6]
-	_ = x[NONE-7]
-	_ = x[STRING-8]
-	_ = x[INT16-9]
-	_ = x[UINT8-10]
-	_ = x[UINT16-11]
-	_ = x[UINT32-12]
-	_ = x[UINT64-13]
-	_ = x[STRING16-14]
+	_ = x[BYTE-4]
+	_ = x[BOOL-5]
+	_ = x[NONE-6]
+	_ = x[STRING-7]
+	_ = x[INT16-8]
+	_ = x[UINT8-9]
+	_ = x[UINT16-10]
+	_ = x[UINT32-11]
+	_ = x[UINT64-12]
+	_ = x[STRING16-13]
 }
 
-const _EnumElementType_name = "FLOAT32INT32FLOAT64INT64EPOCHBYTEBOOLNONESTRINGINT16UINT8UINT16UINT32UINT64STRING16"
+const _EnumElementType_name = "FLOAT32INT32FLOAT64INT64BYTEBOOLNONESTRINGINT16UINT8UINT16UINT32UINT64STRING16"
 
-var _EnumElementType_index = [...]uint8{0, 7, 12, 19, 24, 29, 33, 37, 41, 47, 52, 57, 63, 69, 75, 83}
+var _EnumElementType_index = [...]uint8{0, 7, 12, 19, 24, 28, 32, 36, 42, 47, 52, 58, 64, 70, 78}
 
 func (i EnumElementType) String() string {
 	if i >= EnumElementType(len(_EnumElementType_index)-1) {

--- a/utils/io/rowseries.go
+++ b/utils/io/rowseries.go
@@ -45,7 +45,7 @@ func (rows *Rows) GetColumn(colname string) (col interface{}) {
 				return getInt16Column(offset, rows.GetRowLen(), rows.GetNumRows(), rows.GetData())
 			case INT32:
 				return getInt32Column(offset, rows.GetRowLen(), rows.GetNumRows(), rows.GetData())
-			case EPOCH, INT64:
+			case INT64:
 				return getInt64Column(offset, rows.GetRowLen(), rows.GetNumRows(), rows.GetData())
 			case UINT8:
 				return getUInt8Column(offset, rows.GetRowLen(), rows.GetNumRows(), rows.GetData())


### PR DESCRIPTION
## WHAT
remove `io.EPOCH` from Element Type enum

## WHY
every bucket has `epoch` column but its element type is `INT64`. `EPOCH` should not be an element type.