### PR TITLE
feat(alpacabkfeeder): extended_hours config

### DIFF
--- a/contrib/alpacabkfeeder/README.md
+++ b/contrib/alpacabkfeeder/README.md
@@ -76,7 +76,8 @@ bgworkers:
       open_time_NY: "9:25:00"
       close_time_NY: "16:10:00"
       # When extended_hours is false, TICK data during the off-hours 
-      # (= time < openTime and time > closeTime) are dropped and not stored in DB.
+      # (= time < openTime and time > closeTime) are dropped and not stored in DB, 
+      # even when off_hours_schedule is set.
       extended_hours: false
       # Alpaca Broker API Feeder doesn't run on the following days of the week
       closedDaysOfTheWeek:

--- a/contrib/alpacabkfeeder/README.md
+++ b/contrib/alpacabkfeeder/README.md
@@ -68,14 +68,21 @@ bgworkers:
       # Numbers separated by commas are allowed.  Example: "0,15,30,45" -> execute every 15 minutes.
       # Whitespaces are ignored.
       off_hours_schedule: "0,15,30,45"
-      # Alpaca Broker API Feeder runs from openTime ~ closeTime (UTC)
-      openTime: "14:30:00" # 14:30(UTC) = 09:30 (EST)
-      closeTime: "21:00:00" # 21:00(UTC) = 16:00 (EST)
+      # (Deprecated) Alpaca Broker API Feeder runs from openTime ~ closeTime (UTC)
+      # openTime: "14:30:00" # 14:30(UTC) = 09:30 (EST)
+      # closeTime: "14:29:00"
+      # Alpaca Broker API Feeder runs between open_time_NY and close_time_NY
+      # (in "America/New_York" Location)
+      open_time_NY: "9:25:00"
+      close_time_NY: "16:10:00"
+      # When extended_hours is false, TICK data during the off-hours 
+      # (= time < openTime and time > closeTime) are dropped and not stored in DB.
+      extended_hours: false
       # Alpaca Broker API Feeder doesn't run on the following days of the week
       closedDaysOfTheWeek:
         - "Saturday"
         - "Sunday"
-      # Alpaca Broker API Feeder doesn't run on the closed dates (in JST)
+      # Alpaca Broker API Feeder doesn't run on the closed dates (in "America/New_York" location)
       # (cf. https://www.jpx.co.jp/corporate/about-jpx/calendar/ )
       closedDays:
         - "2021-12-24"

--- a/contrib/alpacabkfeeder/feed/time_checker_test.go
+++ b/contrib/alpacabkfeeder/feed/time_checker_test.go
@@ -1,72 +1,104 @@
-package feed
+package feed_test
 
 import (
 	"testing"
 	"time"
+
+	"github.com/alpacahq/marketstore/v4/contrib/alpacabkfeeder/feed"
 )
 
 var (
 	ClosedDaysOfTheWeek = []time.Weekday{time.Saturday, time.Sunday}
 	ClosedDays          = []time.Time{
-		// Marine day in Japan
-		time.Date(2019, 7, 15, 0, 0, 0, 0, time.UTC),
-		// Health and Sports day in Japan
-		time.Date(2019, 10, 14, 0, 0, 0, 0, time.UTC),
+		// Independence day
+		time.Date(2019, 7, 4, 0, 0, 0, 0, time.UTC),
 	}
+	ny, _ = time.LoadLocation("America/New_York")
+	jst   = time.FixedZone("Asia/Tokyo", 9*60*60)
 )
 
-// 5 minutes before the market opens in Japan (UTC).
-var OpenTime = time.Date(0, 0, 0, 23, 55, 0, 0, time.UTC)
-
-// 10 minutes after the market closes in Japan (UTC).
-var CloseTime = time.Date(0, 0, 0, 6, 10, 0, 0, time.UTC)
-
 type testCase struct {
-	name   string
-	arg    time.Time
-	isOpen bool
+	name                   string
+	arg                    time.Time
+	openHour, openMinute   int
+	closeHour, closeMinute int
+	wantIsOpen             bool
 }
 
 func TestDefaultMarketTimeChecker_isOpen(t *testing.T) {
 	t.Parallel()
-	// --- given ---
-	SUT := &DefaultMarketTimeChecker{
-		ClosedDaysOfTheWeek,
-		ClosedDays,
-		OpenTime,
-		CloseTime,
-	}
+
 	// test cases
 	tests := []testCase{
+		// Sunday, 13 March 2022, 02:00:00 clocks were turned forward 1 hour to
+		// Sunday, 13 March 2022, 03:00:00 local daylight time instead.
+		// Sunday, 6 November 2022, 02:00:00 clocks are turned backward 1 hour to
+		// Sunday, 6 November 2022, 01:00:00 local standard time instead.
+		// 2019-07-14 = Sunday, EDT(UTC-0400)
+		// 2019-07-16 = Tuesday, EDT(UTC-0400)
+		// 2019-07-20 = Saturday, EDT(UTC-0400)
 		{
-			"open", // 09:00, Tuesday in JST
-			time.Date(2019, 7, 16, 23, 55, 0, 0, time.UTC), true,
+			name:     "open(2019-03-19(Tuesday) 20:00UTC = 2019-03-19 16:00EDT)",
+			arg:      time.Date(2019, 3, 19, 20, 0o0, 0, 0, time.UTC),
+			openHour: 9, openMinute: 30,
+			closeHour: 16, closeMinute: 0,
+			wantIsOpen: true,
 		},
 		{
-			"open", // 12:00, Tuesday in JST
-			time.Date(2019, 7, 16, 3, 0, 0, 0, time.UTC), true,
+			name:     "open(2019-03-19(Tuesday) 13:30UTC = 2019-03-19 9:30EDT)",
+			arg:      time.Date(2019, 3, 19, 13, 30, 0, 0, time.UTC),
+			openHour: 9, openMinute: 30,
+			closeHour: 16, closeMinute: 0,
+			wantIsOpen: true,
 		},
 		{
-			"close", // 19:00 in JST
-			time.Date(2019, 7, 16, 6, 10, 0, 0, time.UTC), false,
-		},
-
-		{
-			"weekend", // Sunday
-			time.Date(2019, 7, 7, 0, 0, 0, 0, time.UTC), false,
+			name:     "close(2019-03-19(Tuesday) 13:29UTC = 2019-03-19 9:29EDT)",
+			arg:      time.Date(2019, 3, 19, 13, 29, 0, 0, time.UTC),
+			openHour: 9, openMinute: 30,
+			closeHour: 16, closeMinute: 0,
+			wantIsOpen: false,
 		},
 		{
-			"not weekend in JST",
-			time.Date(2019, 7, 7, 23, 56, 0, 0, time.UTC), true,
-		},
-
-		{
-			"holiday",
-			time.Date(2019, 7, 15, 0, 0, 0, 0, time.UTC), false,
+			name:     "close(2019-01-15(Tuesday) 06:00JST = 2019-03-18 16:01EST)",
+			arg:      time.Date(2019, 1, 15, 0o6, 0o1, 0, 0, jst),
+			openHour: 9, openMinute: 30,
+			closeHour: 16, closeMinute: 0,
+			wantIsOpen: false,
 		},
 		{
-			"not holiday in JST",
-			time.Date(2019, 7, 15, 23, 56, 0, 0, time.UTC), true,
+			name:     "open(2019-01-15(Tuesday) 14:30UTC = 2019-03-19 09:30EST)",
+			arg:      time.Date(2019, 1, 15, 14, 30, 0, 0, time.UTC),
+			openHour: 9, openMinute: 30,
+			closeHour: 16, closeMinute: 0,
+			wantIsOpen: true,
+		},
+		{
+			name:     "open(2019-07-20 06:00 is Saturday in JST but 2019-07-19 16:00 is Friday in EDT",
+			arg:      time.Date(2019, 7, 20, 5, 0, 0, 0, jst),
+			openHour: 9, openMinute: 30,
+			closeHour: 16, closeMinute: 0,
+			wantIsOpen: true,
+		},
+		{
+			name:     "close(weekend. 2019-07-07 is Sunday)",
+			arg:      time.Date(2019, 7, 7, 0, 0, 0, 0, time.UTC),
+			openHour: 9, openMinute: 30,
+			closeHour: 16, closeMinute: 0,
+			wantIsOpen: false,
+		},
+		{
+			name:     "close(holiday. 2019-07-04 is Monday but Independence day)",
+			arg:      time.Date(2019, 7, 4, 12, 0, 0, 0, ny),
+			openHour: 9, openMinute: 30,
+			closeHour: 16, closeMinute: 0,
+			wantIsOpen: false,
+		},
+		{
+			name:     "close(holiday. 2019-07-05 is not a national holiday in JST but Independence day in US)",
+			arg:      time.Date(2019, 7, 5, 2, 0, 0, 0, jst),
+			openHour: 9, openMinute: 30,
+			closeHour: 16, closeMinute: 0,
+			wantIsOpen: false,
 		},
 	}
 
@@ -74,82 +106,20 @@ func TestDefaultMarketTimeChecker_isOpen(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			// --- given ---
+			SUT := &feed.DefaultMarketTimeChecker{
+				ClosedDaysOfTheWeek: ClosedDaysOfTheWeek,
+				ClosedDays:          ClosedDays,
+				OpenHourNY:          tt.openHour, OpenMinuteNY: tt.openMinute,
+				CloseHourNY: tt.closeHour, CloseMinuteNY: tt.closeMinute,
+			}
+
 			// --- when ---
 			got := SUT.IsOpen(tt.arg)
 
 			// --- then ---
-			if got != tt.isOpen {
-				t.Errorf("DefaultMarketTimeChecker.IsOpen() = %v, want %v", got, tt.isOpen)
-			}
-		})
-	}
-}
-
-type subTestCase struct {
-	name         string
-	currentTime  time.Time
-	businessDays int
-	expected     time.Time
-	isErr        bool
-}
-
-func TestDefaultMarketTimeChecker_Sub(t *testing.T) {
-	t.Parallel()
-	// --- given ---
-	SUT := &DefaultMarketTimeChecker{
-		ClosedDaysOfTheWeek,
-		ClosedDays,
-		OpenTime,
-		CloseTime,
-	}
-	// test cases
-	tests := []subTestCase{
-		{
-			"3 business days", // 2019-10-18 = Friday
-			time.Date(2019, 10, 18, 0, 0, 0, 0, time.UTC), 3,
-			time.Date(2019, 10, 15, 0, 0, 0, 0, time.UTC), false,
-		},
-		{
-			"Sunday and Saturday are not business days", // 2019-10-21 = Monday
-			time.Date(2019, 10, 21, 0, 0, 0, 0, time.UTC), 3,
-			time.Date(2019, 10, 16, 0, 0, 0, 0, time.UTC), false,
-		},
-		{
-			"10/14(Mon) is a national holiday",
-			time.Date(2019, 10, 15, 0, 0, 0, 0, time.UTC), 3,
-			time.Date(2019, 10, 9, 0, 0, 0, 0, time.UTC), false,
-		},
-		{
-			"We consider Friday is one business-day before Sunday", // 2019-10-18 = Friday
-			time.Date(2019, 10, 21, 0, 0, 0, 0, time.UTC), 1,
-			time.Date(2019, 10, 18, 0, 0, 0, 0, time.UTC), false,
-		},
-		{
-			"businessDays argument should be a positive integer",
-			time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC), -1,
-			time.Time{},
-			true,
-		},
-		{
-			"Current date is returned when businessDays = 0",
-			time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC), 0,
-			time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC), false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			// --- when ---
-			got, err := SUT.Sub(tt.currentTime, tt.businessDays)
-
-			// --- then ---
-			if got != tt.expected {
-				t.Errorf("DefaultMarketTimeChecker.Sub() = %v, want %v", got, tt.expected)
-			}
-			if (err != nil) != tt.isErr {
-				t.Errorf("DefaultMarketTimeChecker.Sub() returned %v error", err)
+			if got != tt.wantIsOpen {
+				t.Errorf("DefaultMarketTimeChecker.IsOpen() = %v, want %v", got, tt.wantIsOpen)
 			}
 		})
 	}


### PR DESCRIPTION
## WHAT
- add `extended_hours` config in the AlpacaBrokerAPIFeeder plugin.
  - when `extended_hours: false`, TICK data during the off-hours (= time < openTime and time > closeTime) are dropped and not stored in DB, even when `off_hours_schedule` is set.
- see `contrib/alpacabkfeeder/README.md` for the details.