### PR TITLE
fix: remove replace from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,3 @@ require (
 	google.golang.org/genproto v0.0.0-20220527130721-00d5c0f3be58 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-// to avoid "invalid pseudo-version: major version without preceding tag must be v0, not v1" error
-replace github.com/go-check/check v1.0.0-20180628173108-788fd7840127 => github.com/go-check/check v0.0.0-20180628173108-788fd7840127


### PR DESCRIPTION
## WHAT
- remove ununsed replace directive from go.mod

## WHAT
- it causes an error when `go install`