### PR TITLE
fix(alpacabkfeeder): tweak on isOpenTime check

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -39,7 +39,15 @@ marketstore connect --url localhost:5993
 ```
 
 ### Source
-MarketStoreはGoを用いて実装されているので、ソースコードからビルドすることも簡単です。Go `1.11` 以上のバージョンを使用し、また依存管理には`go mod` を使用しています。
+MarketStoreはGoを用いて実装されているので、`go install`コマンドでインストールすることができます。
+```sh
+go install github.com/alpacahq/marketstore/v4@latest
+# export GOROOT=$HOME/go
+# export PATH=$PATH:$GOROOT/bin
+marketstore --version
+```
+
+ソースコードからビルドすることも簡単です。Go `1.11` 以上のバージョンを使用し、また依存管理には`go mod` を使用しています。
 ``` sh
 go get -u github.com/alpacahq/marketstore
 ```

--- a/README.md
+++ b/README.md
@@ -69,8 +69,16 @@ marketstore connect --url localhost:5993
 ```
 
 ### Source
-MarketStore is implemented in Go, so you can build it from
-source pretty easily. You need Go 1.11+ as it uses `go mod` to manage dependencies.
+MarketStore is implemented in Go, so you can install it by `go install`.
+```sh
+go install github.com/alpacahq/marketstore/v4@latest
+# export GOROOT=$HOME/go
+# export PATH=$PATH:$GOROOT/bin
+marketstore --version
+```
+
+You can build it from source easily too. 
+You need Go 1.11+ as it uses `go mod` to manage dependencies.
 ``` sh
 go get -u github.com/alpacahq/marketstore
 ```

--- a/contrib/alpacabkfeeder/feed/time_checker.go
+++ b/contrib/alpacabkfeeder/feed/time_checker.go
@@ -1,12 +1,9 @@
 package feed
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
-
-	"github.com/alpacahq/marketstore/v4/utils/log"
 )
 
 var ny, _ = time.LoadLocation("America/New_York")
@@ -51,7 +48,7 @@ func NewDefaultMarketTimeChecker(
 // if closedDates are defined, return false on those days.
 func (m *DefaultMarketTimeChecker) IsOpen(t time.Time) bool {
 	tNY := t.In(ny)
-	return m.isOpenDate(tNY) && m.isOpenWeekDay(tNY) && m.isOpenTime(tNY)
+	return m.isOpenTime(tNY) && m.isOpenWeekDay(tNY) && m.isOpenDate(tNY)
 }
 
 // isOpenTime returns true if the specified time is between the OpenTime and the CloseTime.
@@ -61,9 +58,9 @@ func (m *DefaultMarketTimeChecker) isOpenTime(nyT time.Time) bool {
 	closeTimeNY := time.Date(nyTYear, nyTMonth, nyTDay, m.CloseHourNY, m.CloseMinuteNY, 0, 0, ny)
 
 	if nyT.Before(openTimeNY) || nyT.After(closeTimeNY) {
-		log.Debug(fmt.Sprintf("[Alpaca Broker Feeder] market is not open. "+
-			"openTime(NewYork)=%02d:%02d, closeTime(NewYork)=%02d:%02d, now=%v",
-			openTimeNY.Hour(), openTimeNY.Minute(), closeTimeNY.Hour(), closeTimeNY.Minute(), nyT))
+		//log.Debug(fmt.Sprintf("[Alpaca Broker Feeder] market is not open. "+
+		//	"openTime(NewYork)=%02d:%02d, closeTime(NewYork)=%02d:%02d, now=%v",
+		//	openTimeNY.Hour(), openTimeNY.Minute(), closeTimeNY.Hour(), closeTimeNY.Minute(), nyT))
 		return false
 	}
 	return true


### PR DESCRIPTION
## WHAT
- check isOpenTime before isOpenDate and isOpenWeekDay check
- remove debug logging on the time check

## WHY
- the isOpen function is called more frequently than before (~100/sec?), so the logging can be too much load
- isOpenTime returns false more frequently than isOpenWeekDay and isOpenDate, it could return early if it's checked first