### PR TITLE
bugfix(archivejob): parse extended_hours config

### DIFF
--- a/contrib/alpacabkfeeder/configs/config.go
+++ b/contrib/alpacabkfeeder/configs/config.go
@@ -34,7 +34,7 @@ type DefaultConfig struct {
 	APISecretKey               string     `json:"api_secret_key"`
 	OpenHourNY, OpenMinuteNY   int
 	CloseHourNY, CloseMinuteNY int
-	ExtendedHours              bool
+	ExtendedHours              bool `json:"extended_hours"`
 	ClosedDaysOfTheWeek        []time.Weekday
 	ClosedDays                 []time.Time
 	Interval                   int `json:"interval"`


### PR DESCRIPTION
## WHAT
- bugfix: add json parse for `extended_hours` config of Alpaca broker feeder